### PR TITLE
Make use of airbrake configurable in initializer

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -17,8 +17,7 @@
 # In production when we run rake tasks it's in an environment where environment
 # variables have not been  set. As such we need a way to disable using airbrake
 # unless we actually need it.
-use_airbrake = ENV["USE_AIRBRAKE"] == "true" ? true : false
-if use_airbrake
+if ENV["USE_AIRBRAKE"] == "true"
   Airbrake.configure do |c|
     # By default, it is set to airbrake.io As we use our own hosted instance of
     # Errbit we need to set this value


### PR DESCRIPTION
Unfortunately the airbrake initializer errors if project_key is not set. The problem is that the initializer is fired in scenarios where we are not actually using the app, for example when running a rake task.

In production when we run rake tasks it's in an environment where environment variables have not been set. As such we need a way to disable using airbrake unless we actually need it.