### PR TITLE
Remove 'change AD level' link from search results

### DIFF
--- a/app/views/shared/_search_result.html.erb
+++ b/app/views/shared/_search_result.html.erb
@@ -111,15 +111,6 @@
             <% end %>
           </li>
           <% end %>
-          <li>
-            <%= link_to "#", id: "change_ad_#{result.reference}" do %>
-              <%= t(".actions.change_ad.link_text") %>
-              <span class="visually-hidden">
-               <%= t(".actions.change_ad.visually_hidden_text",
-                     name: result.operator_name) %>
-             </span>
-            <% end %>
-          </li>
           <% if result.is_a?(WasteExemptionsEngine::Registration) %>
           <li>
             <%= link_to "#", id: "confirmation_letter_#{result.reference}" do %>

--- a/config/locales/partials/search_result.en.yml
+++ b/config/locales/partials/search_result.en.yml
@@ -26,9 +26,6 @@ en:
         resume:
           link_text: "Resume"
           visually_hidden_text: "registering %{name}"
-        change_ad:
-          link_text: "Change AD classification"
-          visually_hidden_text: "for %{name}"
         confirmation_letter:
           link_text: "View confirmation letter"
           visually_hidden_text: "for %{name}"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-154

This fixes an issue flagged in QA of the transient reg search story. We've deprioritised the 'change AD level' feature so this link should be removed.