### PR TITLE
Make whenever cron log output configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,7 @@ EMAIL_SERVICE_EMAIL=""
 # Exporter config
 EXPORT_SERVICE_BATCH_SIZE=10
 EXPORT_SERVICE_EPR_EXPORT_TIME="1:05"
+EXPORT_SERVICE_CRON_LOG_OUTPUT_PATH='/home/rails/waste-exemptions-back-office/shared/log/'
 
 # AWS config
 AWS_MANUAL_EXPORT_ACCESS_KEY_ID=<key_id>

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
     - AWS_DAILY_EXPORT_SECRET_ACCESS_KEY=secretkey
     - AWS_DAILY_EXPORT_BUCKET=daily-exports
     - EXPORT_SERVICE_EPR_EXPORT_TIME="2:05"
+    - EXPORT_SERVICE_CRON_LOG_OUTPUT_PATH="/home/rails/waste-exemptions-back-office/shared/log/"
 
 language: ruby
 rvm: 2.4.2

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -7,7 +7,8 @@
 
 # Learn more: http://github.com/javan/whenever
 
-set :output, "/home/rails/waste-exemptions-back-office/shared/log/whenever_cron.log"
+log_output_path = ENV["EXPORT_SERVICE_CRON_LOG_OUTPUT_PATH"] || "/srv/ruby/waste-exemptions-back-office/shared/log/"
+set :output, File.join(log_output_path, "whenever_cron.log")
 set :job_template, "/bin/bash -l -c 'eval \"$(rbenv init -)\" && :job'"
 
 # Only one of the AWS app servers has a role of "db"

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe "Whenever schedule", vcr: true do
     expect(job_details[:every][1][:at]).to eq(ENV["EXPORT_SERVICE_EPR_EXPORT_TIME"])
   end
 
+  it "takes the cron log output path from the appropriate ENV variable" do
+    schedule = Whenever::Test::Schedule.new(file: "config/schedule.rb")
+
+    expected_output_file = File.join(ENV["EXPORT_SERVICE_CRON_LOG_OUTPUT_PATH"], "whenever_cron.log")
+    expect(schedule.sets[:output]).to eq(expected_output_file)
+  end
+
   it "allows the `whenever` command to be called without raising an error" do
     stdin, stdout, stderr, wait_thr = Open3.popen3("bundle", "exec", "whenever")
     expect(stdout.read).to_not be_empty


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-205

Should have spotted in PR #69 that the path set for the cron output is not available when the app is deployed to our AWS environment.

As what we have set in AWS also may not be suitable for local development this change makes the path configurable, though we default to what it would be in our AWS environments to simplify deployment.
