### PR TITLE
Fix :month_year date formatting

### DIFF
--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 Time::DATE_FORMATS[:time_on_day_month_year] = "%-l:%M%P on %-d %B %Y"
-Time::DATE_FORMATS[:month_year] = "%B %Y"
+Date::DATE_FORMATS[:month_year] = "%B %Y"


### PR DESCRIPTION
When a date format is going to be applied to a DateTime, it has to be set on `Time`. If it is going to be applied to a `Date`, the format has to be set on `Date`.