### PR TITLE
Inherit SCSS from engine

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,7 @@
+/*
+ *= require waste_exemptions_engine/application
+*/
+
 // From GDS's alphagov/govuk_frontend_toolkit
 @import 'colours';
 @import 'grid_layout';


### PR DESCRIPTION
This allows us to add styling to the engine which can be used in the host applications.

In the long run, this should reduce duplication in SCSS across the various apps.