### PR TITLE
Set the config timezone to be London rather than UTC

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ module WasteExemptionsBackOffice
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    config.time_zone = "UTC"
+    config.time_zone = "London"
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-62 
Addresses point 2 of https://docs.google.com/document/d/1rkl7J7az9Z8yv__8N4hHUW9a6zE7I40Z0i5cUZFP_7g/edit 

As part of the Edit functionality QA we discovered that times were not local but set and rendered in UTC. Rather than us having to remember to call ".localtime" every time we show time info to the user, I find it more useful to have the application timezone config set to the London area (it does apply to all UK doesn't it?)

We should apply this change to the front office as well 