### PR TITLE
Prevent exports to fail if a required address is missing

### DIFF
--- a/app/presenters/reports/exemption_bulk_report_presenter.rb
+++ b/app/presenters/reports/exemption_bulk_report_presenter.rb
@@ -66,21 +66,21 @@ module Reports
     # rubocop:enable Naming/PredicateName
 
     def site_location_address
-      return if site_address.located_by_grid_reference?
+      return if site_address&.located_by_grid_reference?
 
       format_address(site_address)
     end
 
     def site_location_grid_reference
-      site_address.grid_reference
+      site_address&.grid_reference
     end
 
     def site_location_description
-      site_address.description
+      site_address&.description
     end
 
     def site_location_area
-      site_address.area
+      site_address&.area
     end
 
     def exemption_code
@@ -134,11 +134,11 @@ module Reports
 
     def format_address(address)
       [
-        address.premises,
-        address.street_address,
-        address.locality,
-        address.city,
-        address.postcode
+        address&.premises,
+        address&.street_address,
+        address&.locality,
+        address&.city,
+        address&.postcode
       ].join(", ")
     end
 

--- a/app/presenters/reports/exemption_epr_report_presenter.rb
+++ b/app/presenters/reports/exemption_epr_report_presenter.rb
@@ -11,59 +11,59 @@ module Reports
     end
 
     def organisation_premises
-      registration.operator_address.premises
+      registration.operator_address&.premises
     end
 
     def organisation_street_address
-      registration.operator_address.street_address
+      registration.operator_address&.street_address
     end
 
     def organisation_locality
-      registration.operator_address.locality
+      registration.operator_address&.locality
     end
 
     def organisation_city
-      registration.operator_address.city
+      registration.operator_address&.city
     end
 
     def organisation_postcode
-      registration.operator_address.postcode
+      registration.operator_address&.postcode
     end
 
     def site_premises
-      registration.site_address.premises
+      registration.site_address&.premises
     end
 
     def site_street_address
-      registration.site_address.street_address
+      registration.site_address&.street_address
     end
 
     def site_locality
-      registration.site_address.locality
+      registration.site_address&.locality
     end
 
     def site_city
-      registration.site_address.city
+      registration.site_address&.city
     end
 
     def site_postcode
-      registration.site_address.postcode
+      registration.site_address&.postcode
     end
 
     def site_country
-      registration.site_address.country_iso
+      registration.site_address&.country_iso
     end
 
     def site_ngr
-      registration.site_address.grid_reference
+      registration.site_address&.grid_reference
     end
 
     def site_easting
-      registration.site_address.x
+      registration.site_address&.x
     end
 
     def site_northing
-      registration.site_address.y
+      registration.site_address&.y
     end
 
     def exemption_code

--- a/spec/presenters/reports/exemption_bulk_report_presenter_spec.rb
+++ b/spec/presenters/reports/exemption_bulk_report_presenter_spec.rb
@@ -99,6 +99,14 @@ module Reports
       it "returns the organisation address" do
         expect(exemption_bulk_report_presenter.organisation_address).to eq("Westland, 45 way, away, Erabor, HD5 JFS")
       end
+
+      context "if the registration has no organisation address" do
+        let(:registration) { create(:registration, addresses: []) }
+
+        it "returns empty values between delimiting commas" do
+          expect(exemption_bulk_report_presenter.organisation_address).to eq(", , , , ")
+        end
+      end
     end
 
     describe "#correspondance_contact_full_name" do
@@ -134,6 +142,14 @@ module Reports
 
       it "returns the contact's address" do
         expect(exemption_bulk_report_presenter.correspondance_contact_address).to eq("Westland, 45 way, away, Erabor, HD5 JFS")
+      end
+
+      context "if the registration has no correspondance contact address" do
+        let(:registration) { create(:registration, addresses: []) }
+
+        it "returns empty values between delimiting commas" do
+          expect(exemption_bulk_report_presenter.correspondance_contact_address).to eq(", , , , ")
+        end
       end
     end
 
@@ -217,6 +233,14 @@ module Reports
           expect(exemption_bulk_report_presenter.site_location_address).to be_nil
         end
       end
+
+      context "if the registration has no site address" do
+        let(:registration) { create(:registration, addresses: []) }
+
+        it "returns empty values between delimiting commas" do
+          expect(exemption_bulk_report_presenter.site_location_address).to eq(", , , , ")
+        end
+      end
     end
 
     describe "#site_location_grid_reference" do
@@ -230,8 +254,16 @@ module Reports
 
       let(:registration) { create(:registration, addresses: [site_location_grid_reference]) }
 
-      it "returns the contact's address" do
+      it "returns the site location grid reference" do
         expect(exemption_bulk_report_presenter.site_location_grid_reference).to eq("ST12345678")
+      end
+
+      context "if the registration has no site address" do
+        let(:registration) { create(:registration, addresses: []) }
+
+        it "returns nil" do
+          expect(exemption_bulk_report_presenter.site_location_grid_reference).to be_nil
+        end
       end
     end
 
@@ -246,8 +278,16 @@ module Reports
 
       let(:registration) { create(:registration, addresses: [site_address]) }
 
-      it "returns the contact's address" do
+      it "returns the site location description" do
         expect(exemption_bulk_report_presenter.site_location_description).to eq("Next to the big green tree.")
+      end
+
+      context "if the registration has no site address" do
+        let(:registration) { create(:registration, addresses: []) }
+
+        it "returns nil" do
+          expect(exemption_bulk_report_presenter.site_location_description).to be_nil
+        end
       end
     end
 
@@ -264,6 +304,14 @@ module Reports
 
       it "returns the site address area" do
         expect(exemption_bulk_report_presenter.site_location_area).to eq("Site address area")
+      end
+
+      context "if the registration has no site address" do
+        let(:registration) { create(:registration, addresses: []) }
+
+        it "returns nil" do
+          expect(exemption_bulk_report_presenter.site_location_area).to be_nil
+        end
       end
     end
 

--- a/spec/presenters/reports/exemption_epr_report_presenter_spec.rb
+++ b/spec/presenters/reports/exemption_epr_report_presenter_spec.rb
@@ -39,6 +39,14 @@ module Reports
       it "returns the operator address premises" do
         expect(presenter.organisation_premises).to eq("123 ABC")
       end
+
+      context "if the registration has no organisation address" do
+        let(:registration) { create(:registration, addresses: []) }
+
+        it "returns nil" do
+          expect(presenter.organisation_premises).to be_nil
+        end
+      end
     end
 
     describe "#organisation_street_address" do
@@ -47,6 +55,14 @@ module Reports
 
       it "returns the operator street address" do
         expect(presenter.organisation_street_address).to eq("32 Foo St")
+      end
+
+      context "if the registration has no organisation address" do
+        let(:registration) { create(:registration, addresses: []) }
+
+        it "returns nil" do
+          expect(presenter.organisation_street_address).to be_nil
+        end
       end
     end
 
@@ -57,6 +73,14 @@ module Reports
       it "returns the operator address locality" do
         expect(presenter.organisation_locality).to eq("Avon")
       end
+
+      context "if the registration has no organisation address" do
+        let(:registration) { create(:registration, addresses: []) }
+
+        it "returns nil" do
+          expect(presenter.organisation_street_address).to be_nil
+        end
+      end
     end
 
     describe "#organisation_city" do
@@ -65,6 +89,14 @@ module Reports
 
       it "returns the operator address city" do
         expect(presenter.organisation_city).to eq("Bristol")
+      end
+
+      context "if the registration has no organisation address" do
+        let(:registration) { create(:registration, addresses: []) }
+
+        it "returns nil" do
+          expect(presenter.organisation_city).to be_nil
+        end
       end
     end
 
@@ -84,6 +116,14 @@ module Reports
       it "returns the operator address premises" do
         expect(presenter.site_premises).to eq("Bar 123")
       end
+
+      context "if the registration has no site address" do
+        let(:registration) { create(:registration, addresses: []) }
+
+        it "returns nil" do
+          expect(presenter.site_premises).to be_nil
+        end
+      end
     end
 
     describe "#site_street_address" do
@@ -92,6 +132,14 @@ module Reports
 
       it "returns the operator address street" do
         expect(presenter.site_street_address).to eq("12 Baz road")
+      end
+
+      context "if the registration has no site address" do
+        let(:registration) { create(:registration, addresses: []) }
+
+        it "returns nil" do
+          expect(presenter.site_street_address).to be_nil
+        end
       end
     end
 
@@ -102,6 +150,14 @@ module Reports
       it "returns the operator address locality" do
         expect(presenter.site_locality).to eq("Avon")
       end
+
+      context "if the registration has no site address" do
+        let(:registration) { create(:registration, addresses: []) }
+
+        it "returns nil" do
+          expect(presenter.site_locality).to be_nil
+        end
+      end
     end
 
     describe "#site_city" do
@@ -110,6 +166,14 @@ module Reports
 
       it "returns the operator address locality" do
         expect(presenter.site_city).to eq("Bristol")
+      end
+
+      context "if the registration has no site address" do
+        let(:registration) { create(:registration, addresses: []) }
+
+        it "returns nil" do
+          expect(presenter.site_city).to be_nil
+        end
       end
     end
 
@@ -120,6 +184,14 @@ module Reports
       it "returns the operator address postcode" do
         expect(presenter.site_postcode).to eq("BS2 34G")
       end
+
+      context "if the registration has no site address" do
+        let(:registration) { create(:registration, addresses: []) }
+
+        it "returns nil" do
+          expect(presenter.site_postcode).to be_nil
+        end
+      end
     end
 
     describe "#site_country" do
@@ -128,6 +200,14 @@ module Reports
 
       it "returns the operator address country" do
         expect(presenter.site_country).to eq("GB")
+      end
+
+      context "if the registration has no site address" do
+        let(:registration) { create(:registration, addresses: []) }
+
+        it "returns nil" do
+          expect(presenter.site_country).to be_nil
+        end
       end
     end
 
@@ -138,6 +218,14 @@ module Reports
       it "returns the operator address grid reference" do
         expect(presenter.site_ngr).to eq("SB1234")
       end
+
+      context "if the registration has no site address" do
+        let(:registration) { create(:registration, addresses: []) }
+
+        it "returns nil" do
+          expect(presenter.site_ngr).to be_nil
+        end
+      end
     end
 
     describe "#site_easting" do
@@ -147,6 +235,14 @@ module Reports
       it "returns the operator address x coordinates" do
         expect(presenter.site_easting).to eq(123.45)
       end
+
+      context "if the registration has no site address" do
+        let(:registration) { create(:registration, addresses: []) }
+
+        it "returns nil" do
+          expect(presenter.site_easting).to be_nil
+        end
+      end
     end
 
     describe "#site_northing" do
@@ -155,6 +251,14 @@ module Reports
 
       it "returns the operator address y coordinates" do
         expect(presenter.site_northing).to eq(123.45)
+      end
+
+      context "if the registration has no site address" do
+        let(:registration) { create(:registration, addresses: []) }
+
+        it "returns nil" do
+          expect(presenter.site_northing).to be_nil
+        end
       end
     end
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-523

We are currently facing an issue in regard of completed registrations not having all required addresses.
To prevent the Bulk and EPR exports to fail during our investigations, the code in this PR is a good candidate for an hot-fix release.
In the long term, we do prefer to be notified about the issue by someone flagging the info is missing from the export, rather than from a server error and hence failure to generate reports, hence this code is a good candidate to be merged and kept in the master code.