### PR TITLE
Close Airbrake to execute async promises

### DIFF
--- a/lib/tasks/boxi_export.rake
+++ b/lib/tasks/boxi_export.rake
@@ -4,5 +4,7 @@ namespace :boxi_export do
   desc "Generates a Zip file containing data for BOXI export and load them to AWS bucket"
   task generate: :environment do
     BoxiExport::GeneratorService.run if WasteExemptionsEngine::FeatureToggle.active?(:generate_boxi_report)
+
+    Airbrake.close
   end
 end

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -13,6 +13,8 @@ namespace :email do
         return unless WasteExemptionsEngine::FeatureToggle.active?(:send_first_email_reminder)
 
         FirstRenewalReminderService.run
+
+        Airbrake.close
       end
     end
   end

--- a/lib/tasks/expire_registration.rake
+++ b/lib/tasks/expire_registration.rake
@@ -4,5 +4,7 @@ namespace :expire_registration do
   desc "Set the status of expired registations to expired"
   task run: :environment do
     ExpiredRegistrationsService.run
+
+    Airbrake.close
   end
 end

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -5,11 +5,15 @@ namespace :reports do
     desc "Generate the bulk montly reports and upload them to S3."
     task bulk: :environment do
       Reports::BulkExportService.run
+
+      Airbrake.close
     end
 
     desc "Generate the EPR report and upload it to S3."
     task epr: :environment do
       Reports::EprExportService.run
+
+      Airbrake.close
     end
   end
 end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-522

Airbrake#notify generates a promise which execute the call in an async way.
Our rake tasks, when an error happens, exit too quickly and don't give Airbrake the time to execute their asyn calls.

Adding a call to `Airbrake#close` at the end of every scheduled rake task makes sure that the process is interrupted only after the Airbrake promises have returned a response.