### PR TITLE
Update .env.example post BOXI changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,11 +32,9 @@ EXPIRE_REGISTRATION_EXEMPTION_RUN_TIME="00:05"
 # Exporter config
 EXPORT_SERVICE_BATCH_SIZE=10
 EXPORT_SERVICE_EPR_EXPORT_TIME="1:05"
-EXPORT_SERVICE_CRON_LOG_OUTPUT_PATH='/home/rails/waste-exemptions-back-office/shared/log/'
 EXPORT_SERVICE_BULK_EXPORT_TIME="20:05"
-
-# Boxi export daily job
-BOXI_EXPORT_GENERATION_DAILY_RUN_TIME=03:05
+EXPORT_SERVICE_BOXI_EXPORT_TIME="03:05"
+EXPORT_SERVICE_CRON_LOG_OUTPUT_PATH='/home/rails/waste-exemptions-back-office/shared/log/'
 
 # AWS config
 AWS_BULK_EXPORT_ACCESS_KEY_ID=<key_id>
@@ -50,7 +48,6 @@ AWS_DAILY_EXPORT_BUCKET=<bucket_name>
 AWS_BOXI_EXPORT_BUCKET=<bucket_name>
 AWS_BOXI_EXPORT_ACCESS_KEY_ID=<key_id>
 AWS_BOXI_EXPORT_SECRET_ACCESS_KEY=<secret_key>
-BOXI_EXPORTS_BATCH_SIZE=100
 
 # Should we use XVFB when rendering PDFs? The reason for asking this is local
 # development environments. If you're working in an environment without a GUI


### PR DESCRIPTION
PR #287 moved the BOXI export into the reports namespace along with making other changes like making the env vars it uses consistent with the existing export config.

However we omitted to update the `.env.example` file. This change updates it to match what is actually expected.