### PR TITLE
Enable BOXI export job

### DIFF
--- a/config/feature_toggles.yml
+++ b/config/feature_toggles.yml
@@ -2,6 +2,6 @@
 send_first_email_reminder:
   active: true
 generate_boxi_report:
-  active: false
+  active: true
 send_renewal_magic_link:
   active: false


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-460

Even though the BOXI universe is not ready, our export of the data to CSV and then AWS S3 is. It has been decided to have the export running ahead of the other changes, so we can be sure we are ready and working for when they are made.

Hence this change enables the BOXI export job.