### PR TITLE
Update token generation in renew email

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: 2fe17a0e4a46966a39ea154f986d95166ef7b36e
+  revision: edfd0704271a225a7b120fbed2631d24f6d7ca2d
   branch: master
   specs:
     waste_exemptions_engine (0.0.1)
@@ -16,7 +16,6 @@ GIT
       defra_ruby_validators
       has_secure_token
       high_voltage (~> 3.1)
-      jwt
       os_map_ref (~> 0.5)
       paper_trail (~> 10.2.0)
       pg (~> 0.18.4)
@@ -175,7 +174,6 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.6)
-    jwt (2.2.1)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)

--- a/app/mailers/renewal_reminder_mailer.rb
+++ b/app/mailers/renewal_reminder_mailer.rb
@@ -34,7 +34,7 @@ class RenewalReminderMailer < ActionMailer::Base
   end
 
   def magic_link_token(registration)
-    WasteExemptionsEngine::GenerateRenewTokenService.run(registration: registration) if registration.renew_token.nil?
+    registration.regenerate_renew_token if registration.renew_token.nil?
     registration.renew_token
   end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-514

Following changes we have made to how we generate the token for the renewal in the engine (see <https://github.com/DEFRA/waste-exemptions-engine/pull/258>) we need to update the code in the renewal reminder that generates a token for registrations where one is missing.