### PR TITLE
Add renew link in back office dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ EMAIL_TEST_ADDRESS=""
 EMAIL_SERVICE_EMAIL=""
 
 # Renewal emails config
-FIRST_RENEWAL_EMAIL_REMINDER_DAYS=28
+RENEWAL_WINDOW_OPEN_BEFORE_DAYS=28
 FIRST_RENEWAL_EMAIL_REMINDER_DAILY_RUN_TIME="1:05"
 
 # Grace window value in days from when a registration expires

--- a/app/controllers/ad_privacy_policy_controller.rb
+++ b/app/controllers/ad_privacy_policy_controller.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
 class AdPrivacyPolicyController < ApplicationController
+  before_action :set_registration
+
   def show; end
+
+  private
+
+  def set_registration
+    @registration = WasteExemptionsEngine::Registration.find_by(reference: params[:renew_registration])
+  end
 end

--- a/app/controllers/renews_controller.rb
+++ b/app/controllers/renews_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class RenewsController < ApplicationController
+  include WasteExemptionsEngine::CanRedirectFormToCorrectPath
+
+  def new
+    authorize
+
+    @transient_registration = WasteExemptionsEngine::RenewalStartService.run(registration: registration)
+
+    redirect_to_correct_form
+  end
+
+  private
+
+  def registration
+    @_registration ||= WasteExemptionsEngine::Registration.find_by(reference: params[:reference])
+  end
+
+  def authorize
+    authorize! :renew, registration
+  end
+
+  def form_path
+    @transient_registration.save unless @transient_registration.token.present?
+
+    WasteExemptionsEngine::Engine.routes.url_helpers.send("new_#{@transient_registration.workflow_state}_path".to_sym, @transient_registration.token)
+  end
+end

--- a/app/controllers/renews_controller.rb
+++ b/app/controllers/renews_controller.rb
@@ -24,6 +24,9 @@ class RenewsController < ApplicationController
   def form_path
     @transient_registration.save unless @transient_registration.token.present?
 
-    WasteExemptionsEngine::Engine.routes.url_helpers.send("new_#{@transient_registration.workflow_state}_path".to_sym, @transient_registration.token)
+    WasteExemptionsEngine::Engine.routes.url_helpers.send(
+      "new_#{@transient_registration.workflow_state}_path".to_sym,
+      @transient_registration.token
+    )
   end
 end

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -42,4 +42,16 @@ module ActionLinksHelper
   def display_confirmation_letter_link_for?(resource)
     resource.is_a?(WasteExemptionsEngine::Registration)
   end
+
+  def display_renew_link_for?(resource)
+    resource.is_a?(WasteExemptionsEngine::Registration) &&
+      resource.in_renewal_window? &&
+      can?(:renew, resource)
+  end
+
+  def display_renew_window_closed_text_for?(resource)
+    resource.is_a?(WasteExemptionsEngine::Registration) &&
+      resource.past_renewal_window? &&
+      can?(:renew, resource)
+  end
 end

--- a/app/helpers/ad_privacy_policy_helper.rb
+++ b/app/helpers/ad_privacy_policy_helper.rb
@@ -4,4 +4,12 @@ module AdPrivacyPolicyHelper
   def link_to_privacy_policy
     link_to(t(".privacy_policy"), page_path("privacy"), target: "_blank")
   end
+
+  def destination_path
+    if @registration.present?
+      renew_path(reference: @registration.reference)
+    else
+      WasteExemptionsEngine::Engine.routes.url_helpers.new_start_form_path(:new)
+    end
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -36,6 +36,7 @@ class Ability
   end
 
   def permissions_for_admin_agent
+    can :renew, WasteExemptionsEngine::Registration
     can :create, WasteExemptionsEngine::Registration
     can :create, WasteExemptionsEngine::NewRegistration
     can :update, WasteExemptionsEngine::NewRegistration

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -27,5 +27,28 @@ module WasteExemptionsEngine
 
       "ceased"
     end
+
+    def in_renewal_window?
+      (expires_on - renewal_window_open_before_days.days) < Time.now &&
+        !past_renewal_window?
+    end
+
+    def past_renewal_window?
+      (expires_on + registration_renewal_grace_window.days) < Time.now
+    end
+
+    private
+
+    def renewal_window_open_before_days
+      WasteExemptionsBackOffice::Application.config.renewal_window_open_before_days.to_i
+    end
+
+    def registration_renewal_grace_window
+      WasteExemptionsBackOffice::Application.config.registration_renewal_grace_window.to_i
+    end
+
+    def expires_on
+      @_expires_on ||= registration_exemptions.pluck(:expires_on).presence&.sort.first
+    end
   end
 end

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -48,7 +48,7 @@ module WasteExemptionsEngine
     end
 
     def expires_on
-      @_expires_on ||= registration_exemptions.pluck(:expires_on).presence&.sort.first
+      @_expires_on ||= registration_exemptions.pluck(:expires_on).presence&.sort&.first
     end
   end
 end

--- a/app/views/ad_privacy_policy/show.html.erb
+++ b/app/views/ad_privacy_policy/show.html.erb
@@ -55,7 +55,9 @@
       </div>
     </details>
 
-    <p><%= link_to "Continue", WasteExemptionsEngine::Engine.routes.url_helpers.new_start_form_path(:new), class: "button" %></p>
+    <p>
+      <%= link_to "Continue", destination_path, class: "button" %>
+    </p>
     <p><%= t(".last_updated") %></p>
   </div>
 </div>

--- a/app/views/shared/_search_result.html.erb
+++ b/app/views/shared/_search_result.html.erb
@@ -44,7 +44,7 @@
         <% end %>
       </ul>
     <% else %>
-      <br />
+      <br>
     <% end %>
   </div>
 

--- a/app/views/shared/_search_result.html.erb
+++ b/app/views/shared/_search_result.html.erb
@@ -6,17 +6,19 @@
         <span><%= t(".labels.status") %></span>
         <span class="<%= "status-tag-#{status_tag_for(result)}" %>"><%= t(".statuses.#{status_tag_for(result)}") %></span>
       </li>
+
       <% if result.operator_name.present? %>
-      <li>
-        <span><%= t(".labels.operator_name") %></span>
-        <%= result.operator_name %>
-      </li>
+        <li>
+          <span><%= t(".labels.operator_name") %></span>
+          <%= result.operator_name %>
+        </li>
       <% end %>
+
       <% if result.reference.present? %>
-      <li>
-        <span><%= t(".labels.reference") %></span>
-        <%= result.reference %>
-      </li>
+        <li>
+          <span><%= t(".labels.reference") %></span>
+          <%= result.reference %>
+        </li>
       <% end %>
     </ul>
   </div>
@@ -24,49 +26,53 @@
     <% if result.site_address.present? %>
       <ul class="registration-details">
         <% if result.site_address.postcode.present? %>
-        <li>
-          <span><%= t(".labels.address") %></span>
-          <ul>
-            <% displayable_address(result.site_address).each do |address_line| %>
-              <li><%= address_line %></li>
-            <% end %>
-          </ul>
-        </li>
+          <li>
+            <span><%= t(".labels.address") %></span>
+            <ul>
+              <% displayable_address(result.site_address).each do |address_line| %>
+                <li><%= address_line %></li>
+              <% end %>
+            </ul>
+          </li>
         <% end %>
+
         <% if result.site_address.grid_reference.present? %>
-        <li>
-          <span><%= t(".labels.grid_reference") %></span>
-          <%= result.site_address.grid_reference %>
-        </li>
+          <li>
+            <span><%= t(".labels.grid_reference") %></span>
+            <%= result.site_address.grid_reference %>
+          </li>
         <% end %>
       </ul>
     <% else %>
-      <br>
+      <br />
     <% end %>
   </div>
+
   <div class="column-one-quarter">
     <ul class="registration-details">
       <% if result.applicant_first_name.present? %>
-      <li>
-        <span><%= t(".labels.applicant") %></span>
-        <%= result.applicant_first_name %> <%= result.applicant_last_name %>
-      </li>
+        <li>
+          <span><%= t(".labels.applicant") %></span>
+          <%= result.applicant_first_name %> <%= result.applicant_last_name %>
+        </li>
       <% end %>
+
       <% if result.contact_first_name.present? %>
       <li>
         <span><%= t(".labels.contact") %></span>
         <%= result.contact_first_name %> <%= result.contact_last_name %>
       </li>
       <% end %>
+
       <% if result.people.present? && result.business_type == "partnership" %>
-      <li>
-        <span><%= t(".labels.partners") %></span>
-        <ul>
-          <% result.people.each do |partner| %>
-            <li><%= partner.first_name %> <%= partner.last_name %></li>
-          <% end %>
-        </ul>
-      </li>
+        <li>
+          <span><%= t(".labels.partners") %></span>
+          <ul>
+            <% result.people.each do |partner| %>
+              <li><%= partner.first_name %> <%= partner.last_name %></li>
+            <% end %>
+          </ul>
+        </li>
       <% end %>
     </ul>
   </div>
@@ -79,43 +85,59 @@
             <%= link_to view_link_for(result), id: "view_#{result.reference}" do %>
               <%= t(".actions.view.link_text") %>
               <span class="visually-hidden">
-               <%= t(".actions.view.visually_hidden_text",
-                     name: result_name_for_visually_hidden_text(result)) %>
-             </span>
-            <% end %>
-          </li>
-          <% if display_edit_link_for?(result) %>
-          <li>
-            <%= link_to edit_link_for(result), id: "edit_#{result.reference}" do %>
-              <%= t(".actions.edit.link_text") %>
-              <span class="visually-hidden">
-               <%= t(".actions.edit.visually_hidden_text",
-                     name: result_name_for_visually_hidden_text(result)) %>
-             </span>
-            <% end %>
-          </li>
-          <% end %>
-          <% if display_resume_link_for?(result) %>
-          <li>
-            <%= link_to resume_link_for(result), id: "resume_#{result.reference}" do %>
-              <%= t(".actions.resume.link_text") %>
-              <span class="visually-hidden">
-               <%= t(".actions.resume.visually_hidden_text",
-                     name: result_name_for_visually_hidden_text(result)) %>
-             </span>
-            <% end %>
-          </li>
-          <% end %>
-          <% if display_confirmation_letter_link_for?(result) %>
-          <li>
-            <%= link_to confirmation_letter_path(result), id: "confirmation_letter_#{result.reference}", target: "_blank" do %>
-              <%= t(".actions.confirmation_letter.link_text") %>
-              <span class="visually-hidden">
-               <%= t(".actions.confirmation_letter.visually_hidden_text",
-                     name: result_name_for_visually_hidden_text(result)) %>
+                <%= t(".actions.view.visually_hidden_text",
+                      name: result_name_for_visually_hidden_text(result)) %>
               </span>
             <% end %>
           </li>
+          <% if display_edit_link_for?(result) %>
+            <li>
+              <%= link_to edit_link_for(result), id: "edit_#{result.reference}" do %>
+                <%= t(".actions.edit.link_text") %>
+                <span class="visually-hidden">
+                 <%= t(".actions.edit.visually_hidden_text",
+                       name: result_name_for_visually_hidden_text(result)) %>
+               </span>
+              <% end %>
+            </li>
+          <% end %>
+
+          <% if display_resume_link_for?(result) %>
+            <li>
+              <%= link_to resume_link_for(result), id: "resume_#{result.reference}" do %>
+                <%= t(".actions.resume.link_text") %>
+                <span class="visually-hidden">
+                 <%= t(".actions.resume.visually_hidden_text",
+                       name: result_name_for_visually_hidden_text(result)) %>
+               </span>
+              <% end %>
+            </li>
+          <% end %>
+
+          <% if display_confirmation_letter_link_for?(result) %>
+            <li>
+              <%= link_to confirmation_letter_path(result), id: "confirmation_letter_#{result.reference}", target: "_blank" do %>
+                <%= t(".actions.confirmation_letter.link_text") %>
+                <span class="visually-hidden">
+                 <%= t(".actions.confirmation_letter.visually_hidden_text",
+                       name: result_name_for_visually_hidden_text(result)) %>
+                </span>
+              <% end %>
+            </li>
+          <% end %>
+
+          <% if display_renew_link_for?(result) %>
+            <li>
+              <%= link_to ad_privacy_policy_path(renew_registration: result.reference), id: "renew_#{result.reference}", target: "_blank" do %>
+                <%= t(".actions.renew.link_text") %>
+                <span class="visually-hidden">
+                 <%= t(".actions.renew.visually_hidden_text",
+                       name: result_name_for_visually_hidden_text(result)) %>
+                </span>
+              <% end %>
+            </li>
+          <% elsif display_renew_window_closed_text_for?(result) %>
+            <li><%= t(".actions.renew.renew_window_closed") %></li>
           <% end %>
         </ul>
       </li>

--- a/config/application.rb
+++ b/config/application.rb
@@ -62,7 +62,8 @@ module WasteExemptionsBackOffice
 
     # Emails
     config.email_test_address = ENV["EMAIL_TEST_ADDRESS"]
-    config.first_renewal_email_reminder_days = ENV["FIRST_RENEWAL_EMAIL_REMINDER_DAYS"]
+    config.first_renewal_email_reminder_days = ENV["RENEWAL_WINDOW_OPEN_BEFORE_DAYS"]
+    config.renewal_window_open_before_days = ENV["RENEWAL_WINDOW_OPEN_BEFORE_DAYS"]
 
     # Version info
     config.application_name = "waste-exemptions-back-office-ta"

--- a/config/locales/partials/search_result.en.yml
+++ b/config/locales/partials/search_result.en.yml
@@ -33,3 +33,7 @@ en:
         confirmation_letter:
           link_text: "View confirmation letter"
           visually_hidden_text: "for %{name}"
+        renew:
+          link_text: "Start renewal"
+          visually_hidden_text: "of %{name}"
+          renew_window_closed: "Renewal period closed"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,11 @@ Rails.application.routes.draw do
   get "/registration-exemptions/deregister/:id", to: "deregister_exemptions#new", as: :deregister_exemptions_form
   post "/registration-exemptions/deregister/:id", to: "deregister_exemptions#update", as: :deregister_exemptions
 
-  # Engine
+  # Override renew path
+  get "/renew/:reference",
+      to: "renews#new",
+      as: "renew"
 
+  # Engine
   mount WasteExemptionsEngine::Engine => "/"
 end

--- a/spec/factories/renewing_registration.rb
+++ b/spec/factories/renewing_registration.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :renewing_registration, class: WasteExemptionsEngine::RenewingRegistration do
+    # Create a new registration when initializing so we can copy its data
+    initialize_with do
+      registration = create(:registration)
+
+      new(reference: registration.reference, token: registration.renew_token)
+    end
+  end
+end

--- a/spec/requests/renews_spec.rb
+++ b/spec/requests/renews_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Renews", type: :request do
+  let(:registration) { create(:registration) }
+
+  describe "GET /renews/:reference" do
+    let(:request_path) { "/renew/#{registration.reference}" }
+
+    before(:each) do
+      sign_in(user) if defined?(user)
+    end
+
+    context "when a data agent user is signed in" do
+      let(:user) { create(:user, :data_agent) }
+
+      it "redirects to permission page" do
+        get request_path
+        follow_redirect!
+
+        expect(response).to render_template("pages/permission")
+      end
+    end
+
+    context "when an admin agent user is signed in" do
+      let(:user) { create(:user, :admin_agent) }
+
+      it "return a 303 redirect code" do
+        get request_path
+
+        expect(response.code).to eq("303")
+      end
+
+      it "redirect to the renewal start form" do
+        get request_path
+        follow_redirect!
+
+        expect(response).to render_template("waste_exemptions_engine/renewal_start_forms/new")
+      end
+
+      context "when the renewal was already started" do
+        let(:renewing_registration) { create(:renewing_registration, workflow_state: "contact_name_form") }
+        let(:registration) { renewing_registration.referring_registration }
+
+        it "redirects to the correct template status" do
+          get request_path
+          follow_redirect!
+
+          expect(response).to render_template("waste_exemptions_engine/contact_name_forms/new")
+        end
+      end
+    end
+
+    context "when a valid user is not signed in" do
+      before { sign_out(create(:user)) }
+
+      it "redirects to the sign-in page" do
+        get request_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-499

Add links to renew journey on all registration in the renewal period.
The link will redirect first to the ad_privacy_policy and then to the renewal journey.
Only users with at least admin permissions can see and use the path.

<details> 
<summary>Before renewal period:</summary>

![Screenshot 2019-08-07 at 12 39 13](https://user-images.githubusercontent.com/1385397/62622388-243e6a00-b916-11e9-9841-44d79ba45846.png)

</details>
<details> 
<summary>In renewal period:</summary>

![Screenshot 2019-08-07 at 12 39 02](https://user-images.githubusercontent.com/1385397/62622386-243e6a00-b916-11e9-8dd9-0d84b58c80eb.png)

</details>

<details> 
<summary>Past renewal period:</summary>

![Screenshot 2019-08-07 at 12 38 56](https://user-images.githubusercontent.com/1385397/62622474-5354db80-b916-11e9-96f2-e41640b5421e.png)

</details>






