### PR TITLE
Add ability to custom-parse attribute on Boxi serializer

### DIFF
--- a/app/models/reports/boxi/addresses_serializer.rb
+++ b/app/models/reports/boxi/addresses_serializer.rb
@@ -12,6 +12,10 @@ module Reports
       def records_scope
         WasteExemptionsEngine::Address.all
       end
+
+      def parse_description(description)
+        description.gsub(/\r\n|\r|\n/, " ")
+      end
     end
   end
 end

--- a/app/models/reports/boxi/addresses_serializer.rb
+++ b/app/models/reports/boxi/addresses_serializer.rb
@@ -14,7 +14,7 @@ module Reports
       end
 
       def parse_description(description)
-        description.gsub(/\r\n|\r|\n/, " ")
+        description&.gsub(/\r\n|\r|\n/, " ")
       end
     end
   end

--- a/app/models/reports/boxi/base_serializer.rb
+++ b/app/models/reports/boxi/base_serializer.rb
@@ -36,7 +36,7 @@ module Reports
         self.class::ATTRIBUTES.map do |attribute|
           content = record.public_send(attribute)
 
-          if self.respond_to?("parse_#{attribute}")
+          if respond_to?("parse_#{attribute}")
             public_send("parse_#{attribute}", content)
           else
             content

--- a/app/models/reports/boxi/base_serializer.rb
+++ b/app/models/reports/boxi/base_serializer.rb
@@ -34,7 +34,13 @@ module Reports
 
       def serialize_record(record)
         self.class::ATTRIBUTES.map do |attribute|
-          record.public_send(attribute)
+          content = record.public_send(attribute)
+
+          if self.respond_to?("parse_#{attribute}")
+            public_send("parse_#{attribute}", content)
+          else
+            content
+          end
         end
       end
 

--- a/app/models/reports/boxi/registration_exemptions_serializer.rb
+++ b/app/models/reports/boxi/registration_exemptions_serializer.rb
@@ -12,6 +12,10 @@ module Reports
       def records_scope
         WasteExemptionsEngine::RegistrationExemption.all
       end
+
+      def parse_deregistration_message(message)
+        message&.gsub(/\r\n|\r|\n/, " ")
+      end
     end
   end
 end

--- a/spec/models/reports/boxi/addresses_serializer_spec.rb
+++ b/spec/models/reports/boxi/addresses_serializer_spec.rb
@@ -19,6 +19,15 @@ module Reports
           expect(result_lines.first.split(",")).to include(*WasteExemptionsEngine::Address.column_names)
           expect(result_lines.count).to eq(2)
         end
+
+        context "when the address description contains new lines" do
+          it "generates a csv file without new lines" do
+            create(:address, :site, description: "sadfsa\r\nfafdafaf\r\nfdfdaf")
+
+            expect(addresses_serializer.to_csv).to_not include("\r\n")
+            expect(addresses_serializer.to_csv).to include("sadfsa fafdafaf fdfdaf")
+          end
+        end
       end
     end
   end

--- a/spec/models/reports/boxi/registration_exemptions_serializer_spec.rb
+++ b/spec/models/reports/boxi/registration_exemptions_serializer_spec.rb
@@ -19,6 +19,15 @@ module Reports
           expect(result_lines.first.split(",")).to include(*WasteExemptionsEngine::RegistrationExemption.column_names)
           expect(result_lines.count).to eq(2)
         end
+
+        context "when the address description contains new lines" do
+          it "generates a csv file without new lines" do
+            create(:registration_exemption, deregistration_message: "sadfsa\r\nfafdafaf\r\nfdfdaf")
+
+            expect(registration_exemptions_serializer.to_csv).to_not include("\r\n")
+            expect(registration_exemptions_serializer.to_csv).to include("sadfsa fafdafaf fdfdaf")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-556

We had the need to strip out newlines on multiline params such as `description` in the `addresses` table.
To do so, I have used some methaprogramming to create parse methods for an attribute so that we can easely twick those value in the future.