### PR TITLE
Do not show renew links on not active registrations

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -46,12 +46,14 @@ module ActionLinksHelper
   def display_renew_links_for?(resource)
     resource.is_a?(WasteExemptionsEngine::Registration) &&
       resource.in_renewal_window? &&
-      can?(:renew, resource)
+      can?(:renew, resource) &&
+      resource.active?
   end
 
   def display_renew_window_closed_text_for?(resource)
     resource.is_a?(WasteExemptionsEngine::Registration) &&
       resource.past_renewal_window? &&
-      can?(:renew, resource)
+      can?(:renew, resource) &&
+      resource.active?
   end
 end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-466

Do not show the renewals links in the back office if the registration has no exemptions in an active status