### PR TITLE
Don't require active status to display renewal link

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -47,13 +47,19 @@ module ActionLinksHelper
     resource.is_a?(WasteExemptionsEngine::Registration) &&
       resource.in_renewal_window? &&
       can?(:renew, resource) &&
-      resource.active?
+      resource_has_active_or_expired_exemptions?(resource)
   end
 
   def display_renew_window_closed_text_for?(resource)
     resource.is_a?(WasteExemptionsEngine::Registration) &&
       resource.past_renewal_window? &&
       can?(:renew, resource) &&
-      resource.active?
+      resource_has_active_or_expired_exemptions?(resource)
+  end
+
+  private
+
+  def resource_has_active_or_expired_exemptions?(resource)
+    resource.active? || resource.registration_exemptions.select(&:expired?).any?
   end
 end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -202,4 +202,81 @@ RSpec.describe ActionLinksHelper, type: :helper do
       end
     end
   end
+
+  describe "display_renew_links_for?" do
+    context "when the resource is a registration" do
+      let(:resource) { create(:registration) }
+
+      context "when the resource is in the renewal window" do
+        before(:each) { allow(resource).to receive(:in_renewal_window?).and_return(true) }
+
+        context "when the user has permission to renew" do
+          before(:each) { allow_any_instance_of(described_class).to receive(:can?).with(:renew, resource).and_return(true) }
+
+          context "when the resource has active exemptions" do
+            before do
+              resource.registration_exemptions.each do |re|
+                re.state = "active"
+                re.save!
+              end
+            end
+
+            it "returns true" do
+              expect(helper.display_renew_links_for?(resource)).to eq(true)
+            end
+          end
+
+          context "when the resource has expired exemptions" do
+            before do
+              resource.registration_exemptions.each do |re|
+                re.state = "expired"
+                re.save!
+              end
+            end
+
+            it "returns true" do
+              expect(helper.display_renew_links_for?(resource)).to eq(true)
+            end
+          end
+
+          context "when the resource has no active or expired exemptions" do
+            before do
+              resource.registration_exemptions.each do |re|
+                re.state = "ceased"
+                re.save!
+              end
+            end
+
+            it "returns false" do
+              expect(helper.display_renew_links_for?(resource)).to eq(false)
+            end
+          end
+        end
+
+        context "when the user does not have permission to renew" do
+          before(:each) { allow_any_instance_of(described_class).to receive(:can?).with(:renew, resource).and_return(false) }
+
+          it "returns false" do
+            expect(helper.display_renew_links_for?(resource)).to eq(false)
+          end
+        end
+      end
+
+      context "when the resource is not in the renewal window" do
+        before(:each) { allow(resource).to receive(:in_renewal_window?).and_return(false) }
+
+        it "returns false" do
+          expect(helper.display_renew_links_for?(resource)).to eq(false)
+        end
+      end
+    end
+
+    context "when the resource is not a registration" do
+      let(:resource) { nil }
+
+      it "returns false" do
+        expect(helper.display_renew_links_for?(resource)).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
We want to display the renew link when the registration is still in the renewal wndow. But we've spotted that the check to display the links requires the registration to still be active. However, some expired registrations could still be in the renewal window. In this case, the link would no longer display even when it should.

This PR fixes this issue.