### PR TITLE
Include expired exemptions in renewal emails

### DIFF
--- a/app/mailers/renewal_reminder_mailer.rb
+++ b/app/mailers/renewal_reminder_mailer.rb
@@ -75,7 +75,9 @@ class RenewalReminderMailer < ActionMailer::Base
   end
 
   def exemptions(registration)
-    active_exemptions = registration.registration_exemptions.select(&:may_expire?)
-    active_exemptions.map { |ex| "#{ex.exemption.code} #{ex.exemption.summary}" }
+    relevant_exemptions = registration.registration_exemptions.select do |re|
+      re.may_expire? || re.expired?
+    end
+    relevant_exemptions.map { |ex| "#{ex.exemption.code} #{ex.exemption.summary}" }
   end
 end

--- a/spec/mailers/renewal_mailer_spec.rb
+++ b/spec/mailers/renewal_mailer_spec.rb
@@ -67,9 +67,23 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
       expect(mail.body.parts[0].body.encoded).to include(exemption_text)
     end
 
-    it "excludes inactive exemptions" do
-      re = registration.registration_exemptions.last
+    it "includes expired exemptions" do
+      re = registration.registration_exemptions.first
+      re.state = :expired
+      exemption_text = "#{re.exemption.code} #{re.exemption.summary}"
+      expect(mail.body.parts[0].body.encoded).to include(exemption_text)
+    end
+
+    it "excludes ceased exemptions" do
+      re = registration.registration_exemptions.first
       re.state = :ceased
+      exemption_text = "#{re.exemption.code} #{re.exemption.summary}"
+      expect(mail.body.parts[0].body.encoded).to_not include(exemption_text)
+    end
+
+    it "excludes revoked exemptions" do
+      re = registration.registration_exemptions.first
+      re.state = :revoked
       exemption_text = "#{re.exemption.code} #{re.exemption.summary}"
       expect(mail.body.parts[0].body.encoded).to_not include(exemption_text)
     end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-594

Normally emails are sent before any exemptions expire. However, if the reminder is manually re-sent from the back office after they expire, we want to include those expired exemptions in the list.