### PR TITLE
Do not open renewals in new tab

### DIFF
--- a/app/views/shared/_resource_details.html.erb
+++ b/app/views/shared/_resource_details.html.erb
@@ -133,7 +133,7 @@
 
         <% if display_renew_links_for?(resource) %>
           <li>
-            <%= link_to ad_privacy_policy_path(renew_registration: resource.reference), id: "renew_#{resource.reference}", target: "_blank" do %>
+            <%= link_to ad_privacy_policy_path(renew_registration: resource.reference), id: "renew_#{resource.reference}" do %>
               <%= t(".actions.renew.link_text") %>
               <span class="visually-hidden">
                <%= t(".actions.renew.visually_hidden_text",

--- a/app/views/shared/_search_result.html.erb
+++ b/app/views/shared/_search_result.html.erb
@@ -128,7 +128,7 @@
 
           <% if display_renew_links_for?(result) %>
             <li>
-              <%= link_to ad_privacy_policy_path(renew_registration: result.reference), id: "renew_#{result.reference}", target: "_blank" do %>
+              <%= link_to ad_privacy_policy_path(renew_registration: result.reference), id: "renew_#{result.reference}" do %>
                 <%= t(".actions.renew.link_text") %>
                 <span class="visually-hidden">
                  <%= t(".actions.renew.visually_hidden_text",


### PR DESCRIPTION
We missed it on code review, but was found later in QA. The renewal workflow for an NCCC user should follow the same as resuming a new registration, or editing an existing one. It should happen in the existing tab and not open a new one.

Like resuming and editing, we continue to show the main menu in the header. The view confirmation feature opens the confirmation in PDF which does take the user out of the system. Hence we open that in a new tab, but we don't need to open resume, edit or renew in a new tab.