### PR TITLE
Add rake task to remove old transient_registrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,9 @@ AWS_BOXI_EXPORT_BUCKET=<bucket_name>
 AWS_BOXI_EXPORT_ACCESS_KEY_ID=<key_id>
 AWS_BOXI_EXPORT_SECRET_ACCESS_KEY=<secret_key>
 
+# Database cleanup config
+MAX_TRANSIENT_REGISTRATION_AGE_DAYS=30
+
 # Should we use XVFB when rendering PDFs? The reason for asking this is local
 # development environments. If you're working in an environment without a GUI
 # then you want this set to true. However if you are working locally directly

--- a/app/services/transient_registration_cleanup_service.rb
+++ b/app/services/transient_registration_cleanup_service.rb
@@ -2,7 +2,7 @@
 
 class TransientRegistrationCleanupService < ::WasteExemptionsEngine::BaseService
   def run
-    transient_registrations_to_remove.each(&:destroy)
+    transient_registrations_to_remove.destroy_all
   end
 
   private

--- a/app/services/transient_registration_cleanup_service.rb
+++ b/app/services/transient_registration_cleanup_service.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class TransientRegistrationCleanupService < ::WasteExemptionsEngine::BaseService
+  def run
+    transient_registrations_to_remove.each(&:destroy)
+  end
+
+  private
+
+  def transient_registrations_to_remove
+    WasteExemptionsEngine::TransientRegistration.where("created_at < ?", oldest_possible_date)
+  end
+
+  def oldest_possible_date
+    30.days.ago
+  end
+end

--- a/app/services/transient_registration_cleanup_service.rb
+++ b/app/services/transient_registration_cleanup_service.rb
@@ -12,6 +12,7 @@ class TransientRegistrationCleanupService < ::WasteExemptionsEngine::BaseService
   end
 
   def oldest_possible_date
-    30.days.ago
+    max = Rails.configuration.max_transient_registration_age_days
+    max.days.ago
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -64,6 +64,9 @@ module WasteExemptionsBackOffice
     config.email_test_address = ENV["EMAIL_TEST_ADDRESS"]
     config.second_renewal_email_reminder_days = ENV["SECOND_RENEWAL_EMAIL_BEFORE_DAYS"] || 14
 
+    # Database cleanup
+    config.max_transient_registration_age_days = ENV["MAX_TRANSIENT_REGISTRATION_AGE_DAYS"] || 30
+
     # Version info
     config.application_name = "waste-exemptions-back-office-ta"
     config.git_repository_url = "https://github.com/DEFRA/#{config.application_name}"

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :cleanup do
+  desc "Remove old transient_registrations from the database"
+  task test: :transient_registrations do
+    TransientRegistrationCleanupService.run
+
+    Airbrake.close
+  end
+end

--- a/spec/services/transient_registration_cleanup_service_spec.rb
+++ b/spec/services/transient_registration_cleanup_service_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TransientRegistrationCleanupService do
+  describe ".run" do
+    let(:transient_registration) { create(:new_registration) }
+    let(:id) { transient_registration.id }
+
+    context "when a transient_registration is older than 30 days" do
+      before do
+        transient_registration.update_attributes!(created_at: Time.now - 31.days)
+      end
+
+      it "deletes it" do
+        expect { described_class.run }.to change { WasteExemptionsEngine::TransientRegistration.where(id: id).count }.from(1).to(0)
+      end
+
+      it "deletes its transient_addresses" do
+        address_count = transient_registration.addresses.count
+
+        expect { described_class.run }.to change { WasteExemptionsEngine::TransientAddress.where(transient_registration_id: id).count }.from(address_count).to(0)
+      end
+
+      it "deletes its transient_people" do
+        people_count = transient_registration.people.count
+
+        expect { described_class.run }.to change { WasteExemptionsEngine::TransientPerson.where(transient_registration_id: id).count }.from(people_count).to(0)
+      end
+
+      it "deletes its transient_registration_exemptions" do
+        re_count = transient_registration.registration_exemptions.count
+
+        expect { described_class.run }.to change { WasteExemptionsEngine::TransientRegistrationExemption.where(transient_registration_id: id).count }.from(re_count).to(0)
+      end
+    end
+
+    context "when a transient_registration is newer than 30 days" do
+      it "does not delete it" do
+        expect { described_class.run }.to_not change { WasteExemptionsEngine::TransientRegistration.where(id: id).count }.from(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-326

We've agreed that we shouldn't store transient_registrations for more than 30 days. So we need a way of clearing out the old ones.

This rake task will find and remove transient_registrations that are older than 30 days. It should also remove all related objects (eg transient_addresses).