### PR TITLE
Show an already renewed message when relevant

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -57,6 +57,12 @@ module ActionLinksHelper
       resource_has_active_or_expired_exemptions?(resource)
   end
 
+  def display_already_renewed_text_for?(resource)
+    can?(:renew, resource) &&
+      resource.in_renewal_window? &&
+      resource.already_renewed?
+  end
+
   private
 
   def resource_has_active_or_expired_exemptions?(resource)

--- a/app/views/shared/_resource_details.html.erb
+++ b/app/views/shared/_resource_details.html.erb
@@ -131,7 +131,9 @@
           </li>
         <% end %>
 
-        <% if display_renew_links_for?(resource) %>
+        <% if display_already_renewed_text_for?(resource) %>
+          <li><%= t(".actions.renew.already_renewed") %></li>
+        <% elsif display_renew_links_for?(resource) %>
           <li>
             <%= link_to ad_privacy_policy_path(renew_registration: resource.reference), id: "renew_#{resource.reference}" do %>
               <%= t(".actions.renew.link_text") %>

--- a/app/views/shared/_search_result.html.erb
+++ b/app/views/shared/_search_result.html.erb
@@ -126,7 +126,9 @@
             </li>
           <% end %>
 
-          <% if display_renew_links_for?(result) %>
+          <% if display_already_renewed_text_for?(result) %>
+            <li><%= t(".actions.renew.already_renewed") %></li>
+          <% elsif display_renew_links_for?(result) %>
             <li>
               <%= link_to ad_privacy_policy_path(renew_registration: result.reference), id: "renew_#{result.reference}" do %>
                 <%= t(".actions.renew.link_text") %>

--- a/config/locales/partials/resource_details.en.yml
+++ b/config/locales/partials/resource_details.en.yml
@@ -63,6 +63,7 @@ en:
           link_text: "Start renewal"
           visually_hidden_text: "of %{name}"
           renew_window_closed: "Renewal period closed"
+          already_renewed: "Already renewed"
         resend_renew_email:
           link_text: "Resend renewal email"
           visually_hidden_text: "of %{name}"

--- a/config/locales/partials/search_result.en.yml
+++ b/config/locales/partials/search_result.en.yml
@@ -37,6 +37,7 @@ en:
           link_text: "Start renewal"
           visually_hidden_text: "of %{name}"
           renew_window_closed: "Renewal period closed"
+          already_renewed: "Already renewed"
         resend_renew_email:
           link_text: "Resend renewal email"
           visually_hidden_text: "of %{name}"

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -356,4 +356,70 @@ RSpec.describe ActionLinksHelper, type: :helper do
       end
     end
   end
+
+  describe "display_already_renewed_text_for?" do
+    context "when the resource is a registration" do
+      let(:resource) { create(:registration) }
+
+      before do
+        allow_any_instance_of(described_class).to receive(:can?).with(:renew, resource).and_return(user_can_renew)
+      end
+
+      context "when the user has permission to renew" do
+        let(:user_can_renew) { true }
+
+        before do
+          allow(resource).to receive(:in_renewal_window?).and_return(in_renewal_window)
+        end
+
+        context "when the resource is in the renewal window" do
+          let(:in_renewal_window) { true }
+
+          before do
+            allow(resource).to receive(:already_renewed?).and_return(already_renewed)
+          end
+
+          context "when the resource is already renewed" do
+            let(:already_renewed) { true }
+
+            it "returns true" do
+              expect(helper.display_already_renewed_text_for?(resource)).to eq(true)
+            end
+          end
+
+          context "when the resource is not already renewed" do
+            let(:already_renewed) { false }
+
+            it "returns false" do
+              expect(helper.display_already_renewed_text_for?(resource)).to eq(false)
+            end
+          end
+        end
+
+        context "when the resource is not in the renewal window" do
+          let(:in_renewal_window) { false }
+
+          it "returns false" do
+            expect(helper.display_already_renewed_text_for?(resource)).to eq(false)
+          end
+        end
+      end
+
+      context "when the user has no permission to renew" do
+        let(:user_can_renew) { false }
+
+        it "returns false" do
+          expect(helper.display_already_renewed_text_for?(resource)).to eq(false)
+        end
+      end
+    end
+
+    context "when the resource is not a registration" do
+      let(:resource) { nil }
+
+      it "returns false" do
+        expect(helper.display_renew_window_closed_text_for?(resource)).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-602

Show an already renewed message in the back office instead of the renew links as per business rules.

<img width="1056" alt="Screenshot 2019-08-27 at 10 39 32" src="https://user-images.githubusercontent.com/1385397/63760517-60327280-c8b7-11e9-894f-6b58f7b72167.png">
<img width="1083" alt="Screenshot 2019-08-27 at 10 39 25" src="https://user-images.githubusercontent.com/1385397/63760518-60327280-c8b7-11e9-89f6-ca3721c13123.png">
