### PR TITLE
Make the cutoff for cleaning out old records start of day

### DIFF
--- a/app/services/transient_registration_cleanup_service.rb
+++ b/app/services/transient_registration_cleanup_service.rb
@@ -13,6 +13,6 @@ class TransientRegistrationCleanupService < ::WasteExemptionsEngine::BaseService
 
   def oldest_possible_date
     max = Rails.configuration.max_transient_registration_age_days.to_i
-    max.days.ago
+    max.days.ago.beginning_of_day
   end
 end


### PR DESCRIPTION
`.days.ago` returns a time. However we want all registrations on a particular day to be covered, not just ones before or after when the job is run.