### PR TITLE
Add link to view renewal letter

### DIFF
--- a/app/views/shared/_resource_details.html.erb
+++ b/app/views/shared/_resource_details.html.erb
@@ -152,6 +152,9 @@
               </span>
             <% end %>
           </li>
+          <li>
+            <%= link_to t(".actions.renewal_letter"), renewal_letter_path(resource), id: "renewal_letter_#{resource.reference}", target: "_blank" %>
+          </li>
         <% elsif display_renew_window_closed_text_for?(resource) %>
           <li><%= t(".actions.renew.renew_window_closed") %></li>
         <% end %>

--- a/app/views/shared/_search_result.html.erb
+++ b/app/views/shared/_search_result.html.erb
@@ -147,6 +147,15 @@
                 </span>
               <% end %>
             </li>
+            <li>
+              <%= link_to renewal_letter_path(result), id: "renewal_letter_#{result.reference}", target: "_blank" do %>
+                <%= t(".actions.renewal_letter.link_text") %>
+                <span class="visually-hidden">
+                 <%= t(".actions.renewal_letter.visually_hidden_text",
+                       name: result_name_for_visually_hidden_text(result)) %>
+                </span>
+              <% end %>
+            </li>
           <% elsif display_renew_window_closed_text_for?(result) %>
             <li><%= t(".actions.renew.renew_window_closed") %></li>
           <% end %>

--- a/config/locales/partials/resource_details.en.yml
+++ b/config/locales/partials/resource_details.en.yml
@@ -68,6 +68,7 @@ en:
         resend_renew_email:
           link_text: "Resend renewal email"
           visually_hidden_text: "of %{name}"
+        renewal_letter: "View renewal letter"
       no_applicant_data: "No applicant details"
       no_contact_data: "No contact details"
       no_exemptions: "No exemptions"

--- a/config/locales/partials/search_result.en.yml
+++ b/config/locales/partials/search_result.en.yml
@@ -41,3 +41,6 @@ en:
         resend_renew_email:
           link_text: "Resend renewal email"
           visually_hidden_text: "of %{name}"
+        renewal_letter:
+          link_text: "View renewal letter"
+          visually_hidden_text: "for %{name}"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-579

This PR adds the links to view the renewal letter to the search results and registration details pages.

The link is visible under the same conditions for "Resend renewal email" and "Start renewal".