### PR TITLE
Don't list revoked and ceased exemptions in renewal letter

### DIFF
--- a/app/presenters/renewal_letter_presenter.rb
+++ b/app/presenters/renewal_letter_presenter.rb
@@ -21,7 +21,7 @@ class RenewalLetterPresenter < BaseLetterPresenter
   end
 
   def listable_exemptions
-    @_listable_exemptions ||= exemptions.first(18)
+    @_listable_exemptions ||= (active_exemptions + expired_exemptions).first(18)
     @_listable_exemptions
   end
 

--- a/spec/presenters/renewal_letter_presenter_spec.rb
+++ b/spec/presenters/renewal_letter_presenter_spec.rb
@@ -84,6 +84,30 @@ RSpec.describe RenewalLetterPresenter do
         expect(subject.listable_exemptions).to eq(registration.exemptions.first(18))
       end
     end
+
+    it "includes the active exemptions from the registration" do
+      registration.registration_exemptions.first.update_attributes(state: :active)
+
+      expect(subject.listable_exemptions).to include(registration.exemptions.first)
+    end
+
+    it "includes the expired exemptions from the registration" do
+      registration.registration_exemptions.first.update_attributes(state: :expired)
+
+      expect(subject.listable_exemptions).to include(registration.exemptions.first)
+    end
+
+    it "does not include revoked exemptions from the registration" do
+      registration.registration_exemptions.first.update_attributes(state: :revoked)
+
+      expect(subject.listable_exemptions).to_not include(registration.exemptions.first)
+    end
+
+    it "does not include ceased exemptions from the registration" do
+      registration.registration_exemptions.first.update_attributes(state: :ceased)
+
+      expect(subject.listable_exemptions).to_not include(registration.exemptions.first)
+    end
   end
 
   describe "#unlisted_exemption_count" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-579

Spotted during QA that we were including all exemptions in the renewal letter, even ones which should not be renewed. This PR fixes that so only active and expired exemptions are listed.