### PR TITLE
Don't include ceased/revoked exemptions in 'unlisted exemptions' count

### DIFF
--- a/app/presenters/renewal_letter_presenter.rb
+++ b/app/presenters/renewal_letter_presenter.rb
@@ -21,7 +21,7 @@ class RenewalLetterPresenter < BaseLetterPresenter
   end
 
   def listable_exemptions
-    @_listable_exemptions ||= (active_exemptions + expired_exemptions).first(18)
+    @_listable_exemptions ||= relevant_exemptions.first(18)
     @_listable_exemptions
   end
 
@@ -49,8 +49,12 @@ class RenewalLetterPresenter < BaseLetterPresenter
 
   private
 
+  def relevant_exemptions
+    @_relevant_exemptions ||= (active_exemptions + expired_exemptions)
+  end
+
   def calculate_number_of_unlisted_exemptions
-    total_exemption_count = exemptions.count
+    total_exemption_count = relevant_exemptions.count
     listable_exemptions_count = listable_exemptions.count
 
     if listable_exemptions_count < total_exemption_count

--- a/spec/presenters/renewal_letter_presenter_spec.rb
+++ b/spec/presenters/renewal_letter_presenter_spec.rb
@@ -126,6 +126,17 @@ RSpec.describe RenewalLetterPresenter do
         expect(subject.unlisted_exemption_count).to eq(1)
       end
     end
+
+    context "when there are exemptions in unrenewable states" do
+      before do
+        registration.exemptions = build_list(:exemption, 21)
+        registration.registration_exemptions.last(2).each { |re| re.update_attributes(state: :ceased) }
+      end
+
+      it "returns the count minus 18 minus the unrenewable exemptions" do
+        expect(subject.unlisted_exemption_count).to eq(1)
+      end
+    end
   end
 
   describe "#partners_list" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-578

While we stopped including ceased and revoked exemptions in the renewal letter, we forgot to remove them from the count of unlisted exemptions that we get if there are more than 18 (too many to fit on the page).

For accuracy, the count should only include renewable exemptions.