### PR TITLE
Rename :generate namespace to :export

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,14 +19,14 @@ set :job_template, "/bin/bash -l -c 'eval \"$(rbenv init -)\" && :job'"
 # all records and put this into an AWS S3 bucket from which Epimorphics (the
 # company that provides and maintains the EPR) will grab it
 every :day, at: (ENV["EXPORT_SERVICE_EPR_EXPORT_TIME"] || "1:05"), roles: [:db] do
-  rake "reports:generate:epr"
+  rake "reports:export:epr"
 end
 
 # This is the daily bulk export job. When run this will create batched CSV
 # exports of all records and put these files into an AWS S3 bucket.
 bulk_time = (ENV["EXPORT_SERVICE_BULK_EXPORT_TIME"] || "20:05")
 every :day, at: bulk_time, roles: [:db] do
-  rake "reports:generate:bulk"
+  rake "reports:export:bulk"
 end
 
 # This is the daily first renewal reminder mail service.
@@ -47,7 +47,7 @@ end
 # Will run once a day in the early morning hours and generate a zip file containing
 # data required for boxi.
 every :day, at: (ENV["EXPORT_SERVICE_BOXI_EXPORT_TIME"] || "03:05"), roles: [:db] do
-  rake "reports:generate:boxi"
+  rake "reports:export:boxi"
 end
 
 # This is the registration exemptions exiry job which will collect all active

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 namespace :reports do
-  namespace :generate do
+  namespace :export do
     desc "Generate the bulk montly reports and upload them to S3."
     task bulk: :environment do
       Reports::BulkExportService.run

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -17,21 +17,21 @@ RSpec.describe "Whenever schedule" do
     rake_jobs = schedule.jobs[:rake]
     expect(rake_jobs.count).to eq(7)
 
-    epr_jobs = rake_jobs.select { |j| j[:task] == "reports:generate:epr" }
-    bulk_jobs = rake_jobs.select { |j| j[:task] == "reports:generate:bulk" }
+    epr_jobs = rake_jobs.select { |j| j[:task] == "reports:export:epr" }
+    bulk_jobs = rake_jobs.select { |j| j[:task] == "reports:export:bulk" }
     expect(epr_jobs.count).to eq(1)
     expect(bulk_jobs.count).to eq(1)
   end
 
   it "takes the EPR execution time from the appropriate ENV variable" do
-    job_details = schedule.jobs[:rake].find { |h| h[:task] == "reports:generate:epr" }
+    job_details = schedule.jobs[:rake].find { |h| h[:task] == "reports:export:epr" }
 
     expect(job_details[:every][0]).to eq(:day)
     expect(job_details[:every][1][:at]).to eq(ENV["EXPORT_SERVICE_EPR_EXPORT_TIME"])
   end
 
   it "takes the bulk export execution time and frequency from the appropriate ENV variables" do
-    job_details = schedule.jobs[:rake].find { |h| h[:task] == "reports:generate:bulk" }
+    job_details = schedule.jobs[:rake].find { |h| h[:task] == "reports:export:bulk" }
 
     expect(job_details[:every][0]).to eq(:day)
     expect(job_details[:every][1][:at]).to eq(ENV["EXPORT_SERVICE_BULK_EXPORT_TIME"])
@@ -64,7 +64,7 @@ RSpec.describe "Whenever schedule" do
   end
 
   it "takes the boxi export generation execution time from the appropriate ENV variable" do
-    job_details = schedule.jobs[:rake].find { |h| h[:task] == "reports:generate:boxi" }
+    job_details = schedule.jobs[:rake].find { |h| h[:task] == "reports:export:boxi" }
 
     expect(job_details[:every][0]).to eq(:day)
     expect(job_details[:every][1][:at]).to eq(ENV["EXPORT_SERVICE_BOXI_EXPORT_TIME"])


### PR DESCRIPTION
In order to keep consistency with the new `:letters` namespaced exports, and since the main goal of this tasks is exporting data to AWS, we are renaming this task to use `:export` rather than `:generate`