### PR TITLE
Clean old AD renewal letters files

### DIFF
--- a/app/controllers/ad_renewal_letters_exports_controller.rb
+++ b/app/controllers/ad_renewal_letters_exports_controller.rb
@@ -22,7 +22,7 @@ class AdRenewalLettersExportsController < ApplicationController
   end
 
   def ad_renewal_letters_exports_presenters
-    WasteExemptionsEngine::AdRenewalLettersExport.all.map do |ad_renewal_letters_export|
+    WasteExemptionsEngine::AdRenewalLettersExport.not_deleted.map do |ad_renewal_letters_export|
       AdRenewalLettersExportPresenter.new(ad_renewal_letters_export)
     end
   end

--- a/app/models/waste_exemptions_engine/ad_renewal_letters_export.rb
+++ b/app/models/waste_exemptions_engine/ad_renewal_letters_export.rb
@@ -6,18 +6,26 @@ module WasteExemptionsEngine
 
     validates :expires_on, uniqueness: true
 
-    enum status: { succeded: 0, failed: 1 }
+    enum status: { succeded: 0, failed: 1, deleted: 2 }
+
+    scope :not_deleted, -> { where.not(status: 2) }
 
     def export!
       AdRenewalLettersExportService.run(self)
     end
 
     def printed?
-      printed_on.presence && printed_by.presence
+      printed_on.present? && printed_by.present?
     end
 
     def presigned_aws_url
       bucket.presigned_url(file_name)
+    end
+
+    def deleted!
+      bucket.delete(file_name)
+
+      super
     end
 
     private

--- a/app/services/ad_renewal_letters_export_cleaner_service.rb
+++ b/app/services/ad_renewal_letters_export_cleaner_service.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AdRenewalLettersExportCleanerService < ::WasteExemptionsEngine::BaseService
+  def run(older_than)
+    WasteExemptionsEngine::AdRenewalLettersExport
+      .not_deleted
+      .where("created_at < ?", older_than)
+      .map(&:deleted!)
+  rescue StandardError => e
+    Airbrake.notify e, older_than: older_than
+    Rails.logger.error "Failed to delete AdRenewalLettersExport older_than #{older_than}:\n#{e}"
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,7 +60,8 @@ module WasteExemptionsBackOffice
     config.export_batch_size = ENV["EXPORT_SERVICE_BATCH_SIZE"] || 1000
 
     config.years_before_expiry = ENV["YEARS_BEFORE_EXPIRY"] || 3
-    config.ad_letters_exports_expires_in = ENV["AD_LETTERS_EXPORT_EXPIRES_IN"] || 35
+    config.ad_letters_exports_expires_in = ENV["AD_LETTERS_EXPORT_EXPIRES_IN"] || 35 # Days
+    config.ad_letters_delete_records_in = ENV["AD_LETTERS_DELETE_RECORDS_IN"] || 3 # Weeks
 
     # Emails
     config.email_test_address = ENV["EMAIL_TEST_ADDRESS"]

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,8 +60,8 @@ module WasteExemptionsBackOffice
     config.export_batch_size = ENV["EXPORT_SERVICE_BATCH_SIZE"] || 1000
 
     config.years_before_expiry = ENV["YEARS_BEFORE_EXPIRY"] || 3
-    config.ad_letters_exports_expires_in = ENV["AD_LETTERS_EXPORT_EXPIRES_IN"] || 35 # Days
-    config.ad_letters_delete_records_in = ENV["AD_LETTERS_DELETE_RECORDS_IN"] || 3 # Weeks
+    config.ad_letters_exports_expires_in = ENV["AD_LETTERS_EXPORT_EXPIRES_IN"] || 35
+    config.ad_letters_delete_records_in = ENV["AD_LETTERS_DELETE_RECORDS_IN"] || 21
 
     # Emails
     config.email_test_address = ENV["EMAIL_TEST_ADDRESS"]

--- a/lib/tasks/letters.rake
+++ b/lib/tasks/letters.rake
@@ -10,6 +10,10 @@ namespace :letters do
         expires_on: expires_on
       ).export!
 
+      older_than = WasteExemptionsBackOffice::Application.config.ad_letters_delete_records_in.to_i.weeks.from_now
+
+      AdRenewalLettersExportCleanerService.run(older_than)
+
       Airbrake.close
     end
   end

--- a/lib/tasks/letters.rake
+++ b/lib/tasks/letters.rake
@@ -10,7 +10,7 @@ namespace :letters do
         expires_on: expires_on
       ).export!
 
-      older_than = WasteExemptionsBackOffice::Application.config.ad_letters_delete_records_in.to_i.weeks.from_now
+      older_than = WasteExemptionsBackOffice::Application.config.ad_letters_delete_records_in.to_i.days.from_now
 
       AdRenewalLettersExportCleanerService.run(older_than)
 

--- a/spec/models/waste_exemptions_engine/ad_renewal_letters_export_spec.rb
+++ b/spec/models/waste_exemptions_engine/ad_renewal_letters_export_spec.rb
@@ -22,6 +22,19 @@ module WasteExemptionsEngine
       end
     end
 
+    describe "#deleted!" do
+      subject(:ad_renewal_letters_export) { create(:ad_renewal_letters_export, file_name: "foo.pdf") }
+
+      let(:bucket) { double(:bucket) }
+
+      it "deletes the file from AWS" do
+        expect(DefraRuby::Aws).to receive(:get_bucket).and_return(bucket)
+        expect(bucket).to receive(:delete).with("foo.pdf")
+
+        ad_renewal_letters_export.deleted!
+      end
+    end
+
     describe "#presigned_aws_url" do
       subject(:ad_renewal_letters_export) { build(:ad_renewal_letters_export, file_name: "foo.pdf") }
 

--- a/spec/services/ad_renewal_letters_export_cleaner_service_spec.rb
+++ b/spec/services/ad_renewal_letters_export_cleaner_service_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AdRenewalLettersExportCleanerService do
+  describe ".run" do
+    let(:bucket) { double(:bucket) }
+    let(:ad_renewal_letters_export) do
+      create(:ad_renewal_letters_export, created_at: 3.weeks.ago, file_name: "example.txt")
+    end
+
+    it "mark as deleted all records oldert than a specified date and delete their associated files" do
+      # Expect no error
+      expect(Airbrake).to_not receive(:notify)
+
+      expect(DefraRuby::Aws).to receive(:get_bucket).and_return(bucket)
+      expect(bucket).to receive(:delete).with("example.txt")
+      expect { described_class.run(3.weeks.ago) }.to change { ad_renewal_letters_export.reload.status }.to("deleted")
+    end
+
+    context "if an error happens" do
+      it "report the error to Rails and Airbrake" do
+        expect(WasteExemptionsEngine::AdRenewalLettersExport).to receive(:not_deleted).and_raise("An Error!")
+
+        expect(Airbrake).to receive(:notify)
+        expect(Rails.logger).to receive(:error)
+
+        described_class.run(3.weeks.ago)
+      end
+    end
+  end
+end

--- a/spec/services/ad_renewal_letters_export_cleaner_service_spec.rb
+++ b/spec/services/ad_renewal_letters_export_cleaner_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AdRenewalLettersExportCleanerService do
       create(:ad_renewal_letters_export, created_at: 3.weeks.ago, file_name: "example.txt")
     end
 
-    it "mark as deleted all records oldert than a specified date and delete their associated files" do
+    it "marks as deleted all records older than a specified date and deletes their associated files" do
       # Expect no error
       expect(Airbrake).to_not receive(:notify)
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-635

This adds a new `deleted` status to the AD renewal letters export records.
The enum-defined `deleted!` method is then overriden to also delete the AWS file from the bucket before updating the status of the records to `deleted`. The dashboards result have been filtered out to not show records in a `deleted` status.