### PR TITLE
Fix various minor issues on AD letters

### DIFF
--- a/app/presenters/ad_renewal_letters_export_presenter.rb
+++ b/app/presenters/ad_renewal_letters_export_presenter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AdRenewalLettersExportPresenter < BasePresenter
+  include ActionView::Helpers::TextHelper
+
   def downloadable?
     succeded? && number_of_letters.positive?
   end
@@ -11,7 +13,7 @@ class AdRenewalLettersExportPresenter < BasePresenter
 
   def letters_label
     if number_of_letters.positive?
-      I18n.t("ad_renewal_letters_exports.index.table.letters_label", number_of_letters: number_of_letters)
+      pluralize(number_of_letters, I18n.t("ad_renewal_letters_exports.index.table.letters_label"))
     else
       I18n.t("ad_renewal_letters_exports.index.labels.no_renewals")
     end
@@ -35,7 +37,7 @@ class AdRenewalLettersExportPresenter < BasePresenter
   end
 
   def printed_by_label
-    printed_by.scan(/(\A.*)\.(.*)@/).flatten.map(&:capitalize).join(" ")
+    printed_by.scan(/(\A.*)[\.|_](.*)@/).flatten.map(&:capitalize).join(" ").presence || printed_by
   end
 
   def none_to_print_label

--- a/app/services/renewal_letters_bulk_pdf_service.rb
+++ b/app/services/renewal_letters_bulk_pdf_service.rb
@@ -19,6 +19,8 @@ class RenewalLettersBulkPdfService < ::WasteExemptionsEngine::BaseService
   rescue StandardError => e
     Airbrake.notify e
     Rails.logger.error "Generate AD renewal letters PDF bulk error:\n#{e}"
+
+    raise e
   end
 
   private

--- a/app/views/renewal_letter/bulk.html.erb
+++ b/app/views/renewal_letter/bulk.html.erb
@@ -8,7 +8,7 @@
 </head>
 
 <body>
-  <% presenters.each do |presenter| %>
+  <% presenters.each_with_index do |presenter, index| %>
     <!-- We don't want the bulk to fail if a single render fails -->
     <%=
       begin
@@ -19,7 +19,9 @@
         ""
       end
     %>
-    <div id="page-break">&nbsp;</div>
+    <% if index < (presenters.size - 1) %>
+      <div id="page-break">&nbsp;</div>
+    <% end %>
   <% end %>
 </body>
 </html>

--- a/config/locales/ad_renewal_letters_exports.en.yml
+++ b/config/locales/ad_renewal_letters_exports.en.yml
@@ -7,7 +7,7 @@ en:
           expiring_date: "Expiry date"
           number_of_letters: "Number of letters"
           printed: "Printed"
-        letters_label: "%{number_of_letters} letters"
+        letters_label: "letter"
       labels:
         submit: "Mark as printed"
         none_to_print: "None to print"

--- a/spec/presenters/ad_renewal_letters_export_presenter_spec.rb
+++ b/spec/presenters/ad_renewal_letters_export_presenter_spec.rb
@@ -116,7 +116,6 @@ RSpec.describe AdRenewalLettersExportPresenter do
           end
         end
 
-
         it "returns a label with the printed status" do
           ad_renewal_letters_export.printed_by = "katherine.johnson@nasa.org.uk"
           ad_renewal_letters_export.printed_on = Date.today

--- a/spec/presenters/ad_renewal_letters_export_presenter_spec.rb
+++ b/spec/presenters/ad_renewal_letters_export_presenter_spec.rb
@@ -89,6 +89,34 @@ RSpec.describe AdRenewalLettersExportPresenter do
       let(:status) { :succeded }
 
       context "when the export has been printed" do
+        context "when the email is in the format name_surname" do
+          it "returns a label with the name of the person that printed it" do
+            ad_renewal_letters_export.printed_by = "katherine_johnson@nasa.org.uk"
+            ad_renewal_letters_export.printed_on = Date.today
+
+            expect(presenter.print_label).to include("Katherine Johnson")
+          end
+        end
+
+        context "when the email is in the format name.surname" do
+          it "returns a label with the name of the person that printed it" do
+            ad_renewal_letters_export.printed_by = "katherine.johnson@nasa.org.uk"
+            ad_renewal_letters_export.printed_on = Date.today
+
+            expect(presenter.print_label).to include("Katherine Johnson")
+          end
+        end
+
+        context "when the email is in any other format" do
+          it "returns a label with the email of the person that printed it" do
+            ad_renewal_letters_export.printed_by = "katherine-johnson@nasa.org.uk"
+            ad_renewal_letters_export.printed_on = Date.today
+
+            expect(presenter.print_label).to include("katherine-johnson@nasa.org.uk")
+          end
+        end
+
+
         it "returns a label with the printed status" do
           ad_renewal_letters_export.printed_by = "katherine.johnson@nasa.org.uk"
           ad_renewal_letters_export.printed_on = Date.today

--- a/spec/services/renewal_letters_bulk_pdf_service_spec.rb
+++ b/spec/services/renewal_letters_bulk_pdf_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RenewalLettersBulkPdfService do
         expect_any_instance_of(ApplicationController).to receive(:render_to_string).and_raise("An error")
         expect(Airbrake).to receive(:notify)
 
-        described_class.run(registrations)
+        expect { described_class.run(registrations) }.to raise_error("An error")
       end
     end
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-580

Fix some issues with ad renewal letters:
 - Pluralize the letters label on the dashboard
 - Pop up error raised from generating a PDF to the main job, so that the record is correctly registered as a failure if there is an issue with overall PDF generation
 - Prevent adding of extra blank page at thee end of the document