### PR TITLE
Switch source of defra_ruby_aws to rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,9 +61,7 @@ gem "waste_exemptions_engine",
     branch: "master"
 
 # Use the Defra Ruby Aws gem for loading files to AWS buckets
-gem "defra_ruby_aws",
-    git: "https://github.com/DEFRA/defra-ruby-aws",
-    branch: "master"
+gem "defra_ruby_aws", "~> 0.2.0"
 
 # bundle exec rake doc:rails generates the API under doc/api.
 gem "sdoc", "~> 0.4.0", group: :doc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/DEFRA/defra-ruby-aws
-  revision: ce82b4214709b0cc437545958b1b7db8a2472a71
-  branch: master
-  specs:
-    defra_ruby_aws (0.2.0)
-      aws-sdk-s3
-
-GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
   revision: 371066eadf92ec450880adc03f77e5734e0d5d9c
   branch: master
@@ -73,7 +65,7 @@ GEM
     arel (6.0.4)
     ast (2.4.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.213.0)
+    aws-partitions (1.215.0)
     aws-sdk-core (3.68.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
@@ -105,6 +97,8 @@ GEM
     crass (1.0.4)
     database_cleaner (1.7.0)
     debug_inspector (0.0.3)
+    defra_ruby_aws (0.2.0)
+      aws-sdk-s3
     defra_ruby_style (0.1.2)
       rubocop
     defra_ruby_validators (2.1.2)
@@ -380,7 +374,7 @@ DEPENDENCIES
   bullet (~> 5.9)
   cancancan (~> 2.0)
   database_cleaner
-  defra_ruby_aws!
+  defra_ruby_aws (~> 0.2.0)
   defra_ruby_style
   devise (>= 4.4.3)
   devise_invitable (~> 1.7.0)


### PR DESCRIPTION
Prior to this change the source for the [defra_ruby_aws](https://github.com/DEFRA/defra-ruby-aws) gem was GitHub. Essentially any push to master would cause [dependabot](https://dependabot.com/) to raise a PR.

That's fine whilst we're under active development and WEX is the only service using the gem, but we're now about to start a period of focusing on WCR and are likely to introduce the gem there as well.

This might mean further changes are made, but we'll want to have a bit more control over when these get applied back in WEX.

Plus it breaks our currently unwritten convention; our engines are sourced from GitHub, but our gems are sourced from Rubygems.

So this change switches the source for the `defra_ruby_aws` gem to [rubygems](https://rubygems.org/), and uses pessimistic versioning to lock the accepted updates to those that should not break the current app (assuming we stick to using semantic versioning!)