### PR TITLE
Fix bug on Cleaning AD renewal letters

### DIFF
--- a/lib/tasks/letters.rake
+++ b/lib/tasks/letters.rake
@@ -10,7 +10,7 @@ namespace :letters do
         expires_on: expires_on
       ).export!
 
-      older_than = WasteExemptionsBackOffice::Application.config.ad_letters_delete_records_in.to_i.days.from_now
+      older_than = WasteExemptionsBackOffice::Application.config.ad_letters_delete_records_in.to_i.days.ago
 
       AdRenewalLettersExportCleanerService.run(older_than)
 


### PR DESCRIPTION
This fix a bug in the cleaning of AD renewal letters where the date passed to the service was in the future rather than in the past