### PR TITLE
Various fixes to AD letters

### DIFF
--- a/app/helpers/ad_privacy_policy_helper.rb
+++ b/app/helpers/ad_privacy_policy_helper.rb
@@ -9,7 +9,7 @@ module AdPrivacyPolicyHelper
     if @registration.present?
       renew_path(reference: @registration.reference)
     else
-      WasteExemptionsEngine::Engine.routes.url_helpers.new_start_form_path(:new)
+      WasteExemptionsEngine::Engine.routes.url_helpers.new_start_form_path
     end
   end
 end

--- a/app/services/ad_renewal_letters_export_service.rb
+++ b/app/services/ad_renewal_letters_export_service.rb
@@ -62,6 +62,7 @@ class AdRenewalLettersExportService < ::WasteExemptionsEngine::BaseService
     @ad_renewal_letters_export.file_name = file_name
 
     @ad_renewal_letters_export.save!
+    @ad_renewal_letters_export.succeded!
   end
 
   def record_content_errored

--- a/app/views/renewal_letter/_styles.html.erb
+++ b/app/views/renewal_letter/_styles.html.erb
@@ -118,12 +118,6 @@
     page-break-after: always;
   }
 
-  #page-break {
-    display: block;
-    clear: both;
-    page-break-after:always;
-  }
-
   #logo {
     top: 0;
     float: right;

--- a/app/views/renewal_letter/bulk.html.erb
+++ b/app/views/renewal_letter/bulk.html.erb
@@ -19,9 +19,6 @@
         ""
       end
     %>
-    <% if index < (presenters.size - 1) %>
-      <div id="page-break">&nbsp;</div>
-    <% end %>
   <% end %>
 </body>
 </html>


### PR DESCRIPTION
Fixes includes:
 - Remove blank page between letters in the generated PDF
 - Make sure a AD renewal letters export record is marked as succeded when a failed job rerun succesfully
 - Remove extra "new" parameter to the `start` page link from the Privacy Policy document