### PR TITLE
Add visually hidden text for button

### DIFF
--- a/app/assets/stylesheets/partials/_links.scss
+++ b/app/assets/stylesheets/partials/_links.scss
@@ -1,5 +1,6 @@
 // A button which looks like a link
-input.button-link {
+input.button-link, button.button-link {
+  @extend input;
   border: none;
   color: $link-colour;
   padding: 0;

--- a/app/views/ad_renewal_letters_exports/index.html.erb
+++ b/app/views/ad_renewal_letters_exports/index.html.erb
@@ -42,7 +42,7 @@
                   <%= f.hidden_field :printed_by, value: current_user.email %>
                   <%= f.hidden_field :printed_on, value: Date.today %>
 
-                  <%= button_tag(type: 'submit', class: "button-link", id: 'validForm') do %>
+                  <%= button_tag(type: 'submit', class: "button-link") do %>
                     <%= t(".labels.submit") %>
                     <span class="visually-hidden">
                       <%= t(".labels.expire_date_for", expire_date: presenter.expire_date) %>

--- a/app/views/ad_renewal_letters_exports/index.html.erb
+++ b/app/views/ad_renewal_letters_exports/index.html.erb
@@ -42,7 +42,12 @@
                   <%= f.hidden_field :printed_by, value: current_user.email %>
                   <%= f.hidden_field :printed_on, value: Date.today %>
 
-                  <%= f.submit t(".labels.submit"), class: "button-link" %>
+                  <%= button_tag(type: 'submit', class: "button-link", id: 'validForm') do %>
+                    <%= t(".labels.submit") %>
+                    <span class="visually-hidden">
+                      <%= t(".labels.expire_date_for", expire_date: presenter.expire_date) %>
+                    </span>
+                  <% end %>
                 <% end %>
               <% end %>
             </td>

--- a/config/locales/ad_renewal_letters_exports.en.yml
+++ b/config/locales/ad_renewal_letters_exports.en.yml
@@ -14,3 +14,4 @@ en:
         no_renewals: "No registrations"
         failed: "Letter generation failed - contact support"
         printed: "%{printed_by}, %{printed_on}"
+        expire_date_for: "for %{expire_date}"


### PR DESCRIPTION
Part of: https://eaflood.atlassian.net/browse/RUBY-580

Add visually hidden text on the "Mark as printed" button in the AD renewal letters export dashboard
<img width="1143" alt="Screenshot 2019-09-20 at 09 46 38" src="https://user-images.githubusercontent.com/1385397/65313184-da3eda00-db8b-11e9-8c0d-f87e756f3d86.png">
