### PR TITLE
Handle nil letters on AD letter export

### DIFF
--- a/app/presenters/ad_renewal_letters_export_presenter.rb
+++ b/app/presenters/ad_renewal_letters_export_presenter.rb
@@ -4,7 +4,7 @@ class AdRenewalLettersExportPresenter < BasePresenter
   include ActionView::Helpers::TextHelper
 
   def downloadable?
-    succeded? && number_of_letters.positive?
+    succeded? && number_of_letters&.positive?
   end
 
   def expire_date


### PR DESCRIPTION
The assisted digital letter export page was failing because the presenter file was not accounting for number_of_letters not being defined for a particular day. I've verified that this fixes the issue locally.

Cinti has proposed this change, which returns nil if number_of_letters has not been defined rather than throwing an error.