### PR TITLE
Restrict missing area update job to site addresses

### DIFF
--- a/lib/tasks/lookups.rake
+++ b/lib/tasks/lookups.rake
@@ -2,11 +2,11 @@
 
 namespace :lookups do
   namespace :update do
-    desc "Populate EA Area information in all WasteExemptionsEngine::Address objects missing it."
+    desc "Update all sites with a missing area (x & y must be populated)"
     task missing_area: :environment do
       run_for = WasteExemptionsBackOffice::Application.config.area_lookup_run_for.to_i
       run_until = run_for.minutes.from_now
-      addresses_scope = WasteExemptionsEngine::Address.missing_area.with_easting_and_northing
+      addresses_scope = WasteExemptionsEngine::Address.site.missing_area.with_easting_and_northing
 
       addresses_scope.find_each do |address|
         break if Time.now > run_until

--- a/spec/lib/tasks/lookups_spec.rb
+++ b/spec/lib/tasks/lookups_spec.rb
@@ -16,9 +16,11 @@ RSpec.describe "Lookups task" do
     let(:run_for) { 10 }
 
     it "update area info into addresses missing it" do
-      address = create(:address, x: 408_602.61, y: 257_535.31)
+      site_address = create(:address, address_type: :site, x: 408_602.61, y: 257_535.31)
+      non_site_address = create(:address, x: 408_602.61, y: 257_535.31)
 
-      expect { subject.invoke }.to change { address.reload.area }.from(nil).to("West Midlands")
+      expect { subject.invoke }.to change { site_address.reload.area }.from(nil).to("West Midlands")
+      expect { subject.invoke }.to_not change { non_site_address.reload.area }
     end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-487

The aim is to try and identify the EA area for each registration we have.

The address we use to determine this though is the **site**. Where the site is located is what determines a registration's area. So we don't care if the x & y or area is missing on the other addresses (operator and contact). We only care they are populated for the `:site` address.

So this change amends the query in the lookup to only return site addresses where x & y is populated but area is missing.