### PR TITLE
Housekeeping on the env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,13 @@
 # Environment variables for the waste-exemptions-front-office.
 #
-# Many of these variables have suitable defaults built-in to the application,
-# but we list them here for completeness and ease-of-editing.
-
-# Addressbase config
-ADDRESSBASE_URL='https://my-addressbase-instance.com'
+# Most environment variables have suitable defaults built-in, but those listed
+# here require values to be provided.
 
 # Errbit config
 AIRBRAKE_HOST='https://my-errbit-instance.com'
 AIRBRAKE_BO_PROJECT_KEY=longvaluefullofnumbersandlettersinlowercase
 
 # Companies House config
-COMPANIES_HOUSE_URL='https://api.companieshouse.gov.uk/company/'
 COMPANIES_HOUSE_API_KEY=longvaluefullofnumbersandlettersinlowercase
 
 # Email settings
@@ -22,56 +18,19 @@ EMAIL_PASSWORD=""
 EMAIL_TEST_ADDRESS=""
 EMAIL_SERVICE_EMAIL=""
 
-# Renewal emails config
-SECOND_RENEWAL_EMAIL_BEFORE_DAYS=14
-FIRST_RENEWAL_EMAIL_REMINDER_DAILY_RUN_TIME="1:05"
-SECOND_RENEWAL_EMAIL_REMINDER_DAILY_RUN_TIME="04:05"
-
-# Renewal window values for before and after a registration expires
-RENEWAL_WINDOW_BEFORE_EXPIRY_IN_DAYS=28
-RENEWAL_WINDOW_AFTER_EXPIRY_IN_DAYS=30
-
-# Expire registration scheduler configs
-EXPIRE_REGISTRATION_EXEMPTION_RUN_TIME="00:05"
-
-# Exporter config
-EXPORT_SERVICE_BATCH_SIZE=10
-EXPORT_SERVICE_EPR_EXPORT_TIME="1:05"
-EXPORT_SERVICE_AD_RENEWAL_LETTERS_TIME="1:05"
-EXPORT_SERVICE_BULK_EXPORT_TIME="20:05"
-EXPORT_SERVICE_BOXI_EXPORT_TIME="03:05"
-AREA_LOOKUP="01:05"
-EXPORT_SERVICE_CRON_LOG_OUTPUT_PATH='/home/rails/waste-exemptions-back-office/shared/log/'
-
-# AWS config
+# AWS S3 config
+AWS_BULK_EXPORT_BUCKET=<bucket_name>
 AWS_BULK_EXPORT_ACCESS_KEY_ID=<key_id>
 AWS_BULK_EXPORT_SECRET_ACCESS_KEY=<secret_key>
-AWS_BULK_EXPORT_BUCKET=<bucket_name>
 
+AWS_DAILY_EXPORT_BUCKET=<bucket_name>
 AWS_DAILY_EXPORT_ACCESS_KEY_ID=<key_id>
 AWS_DAILY_EXPORT_SECRET_ACCESS_KEY=<secret_key>
-AWS_DAILY_EXPORT_BUCKET=<bucket_name>
 
 AWS_BOXI_EXPORT_BUCKET=<bucket_name>
 AWS_BOXI_EXPORT_ACCESS_KEY_ID=<key_id>
 AWS_BOXI_EXPORT_SECRET_ACCESS_KEY=<secret_key>
 
+AWS_LETTERS_EXPORT_BUCKET=<bucket_name>
 AWS_LETTERS_EXPORT_ACCESS_KEY_ID=<key_id>
 AWS_LETTERS_EXPORT_SECRET_ACCESS_KEY=<secret_key>
-AWS_LETTERS_EXPORT_BUCKET=<bucket_name>
-
-# Database cleanup config
-MAX_TRANSIENT_REGISTRATION_AGE_DAYS=30
-CLEANUP_TRANSIENT_REGISTRATIONS_RUN_TIME="00:35"
-
-# Should we use XVFB when rendering PDFs? The reason for asking this is local
-# development environments. If you're working in an environment without a GUI
-# then you want this set to true. However if you are working locally directly
-# on a linux box then you'll want to disable it
-USE_XVFB_FOR_WICKEDPDF=true
-
-# Feature toggles
-# Some features in WEX can be 'toggled' using an env var to change the default
-# behaviour
-FEATURE_TOGGLE_SEND_FIRST_EMAIL_REMINDER=false
-FEATURE_TOGGLE_SEND_SECOND_EMAIL_REMINDER=false

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,8 +41,8 @@ module WasteExemptionsBackOffice
     }
 
     # Paths
-    config.front_office_url = ENV["FRONT_OFFICE_URL"] || "http://localhost:3001"
-    config.back_office_url = ENV["BACK_OFFICE_URL"] || "http://localhost:8001"
+    config.front_office_url = ENV["FRONT_OFFICE_URL"] || "http://localhost:3000"
+    config.back_office_url = ENV["BACK_OFFICE_URL"] || "http://localhost:8000"
 
     # Addressbase facade config
     config.addressbase_url = ENV["ADDRESSBASE_URL"] || "http://localhost:9002"
@@ -59,7 +59,6 @@ module WasteExemptionsBackOffice
     config.epr_export_filename = ENV["EPR_DAILY_REPORT_FILE_NAME"] || "waste_exemptions_epr_daily_full"
     config.export_batch_size = ENV["EXPORT_SERVICE_BATCH_SIZE"] || 1000
 
-    config.years_before_expiry = ENV["YEARS_BEFORE_EXPIRY"] || 3
     config.ad_letters_exports_expires_in = ENV["AD_LETTERS_EXPORT_EXPIRES_IN"] || 35
     config.ad_letters_delete_records_in = ENV["AD_LETTERS_DELETE_RECORDS_IN"] || 21
 

--- a/config/initializers/waste_exemptions_engine.rb
+++ b/config/initializers/waste_exemptions_engine.rb
@@ -11,6 +11,7 @@ WasteExemptionsEngine.configure do |configuration|
 
   # Addressbase facade config
   configuration.addressbase_url = ENV["ADDRESSBASE_URL"] || "http://localhost:9002"
+
   # Email config
   configuration.service_name = ENV["EMAIL_SERVICE_NAME"] || "Waste Exemptions Service"
   configuration.email_service_email = ENV["EMAIL_SERVICE_EMAIL"] || "wex-local@example.com"
@@ -22,6 +23,10 @@ WasteExemptionsEngine.configure do |configuration|
   configuration.edit_enabled = "true"
 
   # PDF config
+  # Should we use XVFB when rendering PDFs? The reason for asking this is local
+  # development environments. If you're working in an environment without a GUI
+  # then you want this set to true. However if you are working locally then
+  # you'll want to disable it
   configuration.use_xvfb_for_wickedpdf = ENV["USE_XVFB_FOR_WICKEDPDF"] || "true"
 
   # Last email cache config

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -18,48 +18,8 @@ set :job_template, "/bin/bash -l -c 'eval \"$(rbenv init -)\" && :job'"
 # This is the daily EPR export job. When run this will create a CSV export of
 # all records and put this into an AWS S3 bucket from which Epimorphics (the
 # company that provides and maintains the EPR) will grab it
-every :day, at: (ENV["EXPORT_SERVICE_EPR_EXPORT_TIME"] || "1:05"), roles: [:db] do
+every :day, at: (ENV["EXPORT_SERVICE_EPR_EXPORT_TIME"] || "22:05"), roles: [:db] do
   rake "reports:export:epr"
-end
-
-# This will run daily and update EA areas for addresses with x and y but without Area.
-every :day, at: (ENV["AREA_LOOKUP"] || "1:05"), roles: [:db] do
-  rake "lookups:update:missing_area"
-end
-
-# This is the daily bulk export job. When run this will create batched CSV
-# exports of all records and put these files into an AWS S3 bucket.
-bulk_time = (ENV["EXPORT_SERVICE_BULK_EXPORT_TIME"] || "20:05")
-every :day, at: bulk_time, roles: [:db] do
-  rake "reports:export:bulk"
-end
-
-# This is the daily first renewal reminder mail service.
-# Will run once a day in the early morning hours and send email reminders about
-# registrations that will expire in X time.
-every :day, at: (ENV["FIRST_RENEWAL_EMAIL_REMINDER_DAILY_RUN_TIME"] || "1:05"), roles: [:db] do
-  rake "email:renew_reminder:first:send"
-end
-
-# This is the daily second renewal reminder mail service.
-# Will run once a day in the early morning hours and send email reminders about
-# registrations that will expire in X time.
-every :day, at: (ENV["SECOND_RENEWAL_EMAIL_REMINDER_DAILY_RUN_TIME"] || "04:05"), roles: [:db] do
-  rake "email:renew_reminder:second:send"
-end
-
-# This is the daily boxi export generation service.
-# Will run once a day in the early morning hours and generate a zip file containing
-# data required for boxi.
-every :day, at: (ENV["EXPORT_SERVICE_BOXI_EXPORT_TIME"] || "03:05"), roles: [:db] do
-  rake "reports:export:boxi"
-end
-
-# This is the daily AD renewal letters export service.
-# Will run once a day in the early morning hours and generate a PDF file containing
-# all AD renewal letters expiring in X days.
-every :day, at: (ENV["EXPORT_SERVICE_AD_RENEWAL_LETTERS_TIME"] || "01:05"), roles: [:db] do
-  rake "letters:export:ad_renewals"
 end
 
 # This is the registration exemptions exiry job which will collect all active
@@ -74,4 +34,44 @@ end
 # that are too old, as well as their associated addresses, exemptions and people
 every :day, at: (ENV["CLEANUP_TRANSIENT_REGISTRATIONS_RUN_TIME"] || "00:35"), roles: [:db] do
   rake "cleanup:transient_registrations"
+end
+
+# This is the daily AD renewal letters export service.
+# Will run once a day in the early morning hours and generate a PDF file containing
+# all AD renewal letters expiring in X days.
+every :day, at: (ENV["EXPORT_SERVICE_AD_RENEWAL_LETTERS_TIME"] || "00:45"), roles: [:db] do
+  rake "letters:export:ad_renewals"
+end
+
+# This will run daily and update EA areas for addresses with x and y but without Area.
+every :day, at: (ENV["AREA_LOOKUP"] || "01:05"), roles: [:db] do
+  rake "lookups:update:missing_area"
+end
+
+# This is the daily bulk export job. When run this will create batched CSV
+# exports of all records and put these files into an AWS S3 bucket.
+bulk_time = (ENV["EXPORT_SERVICE_BULK_EXPORT_TIME"] || "02:05")
+every :day, at: bulk_time, roles: [:db] do
+  rake "reports:export:bulk"
+end
+
+# This is the daily first renewal reminder mail service.
+# Will run once a day in the early morning hours and send email reminders about
+# registrations that will expire in X time.
+every :day, at: (ENV["FIRST_RENEWAL_EMAIL_REMINDER_DAILY_RUN_TIME"] || "02:05"), roles: [:db] do
+  rake "email:renew_reminder:first:send"
+end
+
+# This is the daily boxi export generation service.
+# Will run once a day in the early morning hours and generate a zip file containing
+# data required for boxi.
+every :day, at: (ENV["EXPORT_SERVICE_BOXI_EXPORT_TIME"] || "03:05"), roles: [:db] do
+  rake "reports:export:boxi"
+end
+
+# This is the daily second renewal reminder mail service.
+# Will run once a day in the early morning hours and send email reminders about
+# registrations that will expire in X time.
+every :day, at: (ENV["SECOND_RENEWAL_EMAIL_REMINDER_DAILY_RUN_TIME"] || "04:05"), roles: [:db] do
+  rake "email:renew_reminder:second:send"
 end

--- a/spec/presenters/reports/exemption_bulk_report_presenter_spec.rb
+++ b/spec/presenters/reports/exemption_bulk_report_presenter_spec.rb
@@ -393,7 +393,7 @@ module Reports
 
     describe "#registration_detail_url" do
       it "returns an url to the registration details backend page" do
-        url = "http://localhost:8001/registrations/#{registration.reference}"
+        url = "http://localhost:8000/registrations/#{registration.reference}"
 
         expect(exemption_bulk_report_presenter.registration_detail_url).to eq(url)
       end


### PR DESCRIPTION
This housekeeping exercise does 2 things

- it updates the default env vars to match what we actually use in our environments
- it updates and orders the items in `schedule.rb` by their actual times
- it updates the `.env.example` file to be accurate

On that last point, the original intention of the `.env.example` file was to list all environment variables that are used by the app.

But clearly we haven't been keeping on top of it, as what's listed is vastly out of sync with all the env vars we use. So to make it 'accurate' it now just lists those env vars that must be set for the app to run.