### PR TITLE
Add support for rake integration tests

### DIFF
--- a/lib/close_airbrake.rb
+++ b/lib/close_airbrake.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# To ensure errors are reported by Airbrake when a rake task fails we need
+# to tell Airbrake to close before the exit the task. This is because
+# Airbrake operates asynchronously, queuing up the notifications to send rather
+# than forcing the app to wait.
+#
+# However there is an issue when calling `Airbrake.close` in the test
+# environment. The test suite will complain about airbrake being closed already
+# when running. Since there is no way in version 5.8 to ask Airbrake if it is
+# already closed or to reopen it before every test, this check prevents the test
+# suite from complaining.
+#
+# We could have just put the line `Airbrake.close unless Rails.env.test?` in
+# each rake task, but we wanted to record these notes but just in one place.
+class CloseAirbrake
+  def self.now
+    Airbrake.close unless Rails.env.test?
+  end
+end

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
+require_relative "../close_airbrake"
+
 namespace :cleanup do
   desc "Remove old transient_registrations from the database"
   task transient_registrations: :environment do
     TransientRegistrationCleanupService.run
 
-    # The test suite will complain about airbrake being closed already when running this
-    # Since there is no way in version 5.8 to ask Airbrake if it is already closed or to
-    # reopen it before every tets, this check will allow the test suite to not complain
-    Airbrake.close unless Rails.env.test?
+    CloseAirbrake.now
   end
 end

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -5,6 +5,9 @@ namespace :cleanup do
   task transient_registrations: :environment do
     TransientRegistrationCleanupService.run
 
-    Airbrake.close
+    # The test suite will complain about airbrake being closed already when running this
+    # Since there is no way in version 5.8 to ask Airbrake if it is already closed or to
+    # reopen it before every tets, this check will allow the test suite to not complain
+    Airbrake.close unless Rails.env.test?
   end
 end

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../close_airbrake"
+
 # rubocop:disable Metrics/BlockLength
 namespace :email do
   desc "Send a test email to confirm setup is correct"
@@ -24,10 +26,7 @@ namespace :email do
 
         FirstRenewalReminderService.run
 
-        # The test suite will complain about airbrake being closed already when running this
-        # Since there is no way in version 5.8 to ask Airbrake if it is already closed or to
-        # reopen it before every tets, this check will allow the test suite to not complain
-        Airbrake.close unless Rails.env.test?
+        CloseAirbrake.now
       end
     end
 
@@ -38,10 +37,7 @@ namespace :email do
 
         SecondRenewalReminderService.run
 
-        # The test suite will complain about airbrake being closed already when running this
-        # Since there is no way in version 5.8 to ask Airbrake if it is already closed or to
-        # reopen it before every tets, this check will allow the test suite to not complain
-        Airbrake.close unless Rails.env.test?
+        CloseAirbrake.now
       end
     end
   end

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -24,7 +24,10 @@ namespace :email do
 
         FirstRenewalReminderService.run
 
-        Airbrake.close
+        # The test suite will complain about airbrake being closed already when running this
+        # Since there is no way in version 5.8 to ask Airbrake if it is already closed or to
+        # reopen it before every tets, this check will allow the test suite to not complain
+        Airbrake.close unless Rails.env.test?
       end
     end
 
@@ -35,7 +38,10 @@ namespace :email do
 
         SecondRenewalReminderService.run
 
-        Airbrake.close
+        # The test suite will complain about airbrake being closed already when running this
+        # Since there is no way in version 5.8 to ask Airbrake if it is already closed or to
+        # reopen it before every tets, this check will allow the test suite to not complain
+        Airbrake.close unless Rails.env.test?
       end
     end
   end

--- a/lib/tasks/expire_registration.rake
+++ b/lib/tasks/expire_registration.rake
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
+require_relative "../close_airbrake"
+
 namespace :expire_registration do
   desc "Set the status of expired registations to expired"
   task run: :environment do
     ExpiredRegistrationsService.run
 
-    # The test suite will complain about airbrake being closed already when running this
-    # Since there is no way in version 5.8 to ask Airbrake if it is already closed or to
-    # reopen it before every tets, this check will allow the test suite to not complain
-    Airbrake.close unless Rails.env.test?
+    CloseAirbrake.now
   end
 end

--- a/lib/tasks/expire_registration.rake
+++ b/lib/tasks/expire_registration.rake
@@ -5,6 +5,9 @@ namespace :expire_registration do
   task run: :environment do
     ExpiredRegistrationsService.run
 
-    Airbrake.close
+    # The test suite will complain about airbrake being closed already when running this
+    # Since there is no way in version 5.8 to ask Airbrake if it is already closed or to
+    # reopen it before every tets, this check will allow the test suite to not complain
+    Airbrake.close unless Rails.env.test?
   end
 end

--- a/lib/tasks/letters.rake
+++ b/lib/tasks/letters.rake
@@ -14,7 +14,10 @@ namespace :letters do
 
       AdRenewalLettersExportCleanerService.run(older_than)
 
-      Airbrake.close
+      # The test suite will complain about airbrake being closed already when running this
+      # Since there is no way in version 5.8 to ask Airbrake if it is already closed or to
+      # reopen it before every tets, this check will allow the test suite to not complain
+      Airbrake.close unless Rails.env.test?
     end
   end
 end

--- a/lib/tasks/letters.rake
+++ b/lib/tasks/letters.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../close_airbrake"
+
 namespace :letters do
   namespace :export do
     desc "Generate a bulk export PDF file of AD renewal letters expiring soon"
@@ -14,10 +16,7 @@ namespace :letters do
 
       AdRenewalLettersExportCleanerService.run(older_than)
 
-      # The test suite will complain about airbrake being closed already when running this
-      # Since there is no way in version 5.8 to ask Airbrake if it is already closed or to
-      # reopen it before every tets, this check will allow the test suite to not complain
-      Airbrake.close unless Rails.env.test?
+      CloseAirbrake.now
     end
   end
 end

--- a/lib/tasks/lookups.rake
+++ b/lib/tasks/lookups.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../close_airbrake"
+
 namespace :lookups do
   namespace :update do
     desc "Update all sites with a missing area (x & y must be populated)"
@@ -14,7 +16,7 @@ namespace :lookups do
         UpdateAreaService.run(address)
       end
 
-      Airbrake.close
+      CloseAirbrake.now
     end
   end
 end

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -1,35 +1,28 @@
 # frozen_string_literal: true
 
+require_relative "../close_airbrake"
+
 namespace :reports do
   namespace :export do
     desc "Generate the bulk montly reports and upload them to S3."
     task bulk: :environment do
       Reports::BulkExportService.run
 
-      # The test suite will complain about airbrake being closed already when running this
-      # Since there is no way in version 5.8 to ask Airbrake if it is already closed or to
-      # reopen it before every tets, this check will allow the test suite to not complain
-      Airbrake.close unless Rails.env.test?
+      CloseAirbrake.now
     end
 
     desc "Generate the EPR report and upload it to S3."
     task epr: :environment do
       Reports::EprExportService.run
 
-      # The test suite will complain about airbrake being closed already when running this
-      # Since there is no way in version 5.8 to ask Airbrake if it is already closed or to
-      # reopen it before every tets, this check will allow the test suite to not complain
-      Airbrake.close unless Rails.env.test?
+      CloseAirbrake.now
     end
 
     desc "Generate the BOXI report (zipped) and upload it to S3."
     task boxi: :environment do
       Reports::BoxiExportService.run if WasteExemptionsEngine::FeatureToggle.active?(:generate_boxi_report)
 
-      # The test suite will complain about airbrake being closed already when running this
-      # Since there is no way in version 5.8 to ask Airbrake if it is already closed or to
-      # reopen it before every tets, this check will allow the test suite to not complain
-      Airbrake.close unless Rails.env.test?
+      CloseAirbrake.now
     end
   end
 end

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -6,21 +6,30 @@ namespace :reports do
     task bulk: :environment do
       Reports::BulkExportService.run
 
-      Airbrake.close
+      # The test suite will complain about airbrake being closed already when running this
+      # Since there is no way in version 5.8 to ask Airbrake if it is already closed or to
+      # reopen it before every tets, this check will allow the test suite to not complain
+      Airbrake.close unless Rails.env.test?
     end
 
     desc "Generate the EPR report and upload it to S3."
     task epr: :environment do
       Reports::EprExportService.run
 
-      Airbrake.close
+      # The test suite will complain about airbrake being closed already when running this
+      # Since there is no way in version 5.8 to ask Airbrake if it is already closed or to
+      # reopen it before every tets, this check will allow the test suite to not complain
+      Airbrake.close unless Rails.env.test?
     end
 
     desc "Generate the BOXI report (zipped) and upload it to S3."
     task boxi: :environment do
       Reports::BoxiExportService.run if WasteExemptionsEngine::FeatureToggle.active?(:generate_boxi_report)
 
-      Airbrake.close
+      # The test suite will complain about airbrake being closed already when running this
+      # Since there is no way in version 5.8 to ask Airbrake if it is already closed or to
+      # reopen it before every tets, this check will allow the test suite to not complain
+      Airbrake.close unless Rails.env.test?
     end
   end
 end

--- a/spec/lib/tasks/cleanup_spec.rb
+++ b/spec/lib/tasks/cleanup_spec.rb
@@ -6,10 +6,7 @@ RSpec.describe "Cleanup task" do
   include_context "rake"
 
   describe "cleanup:transient_registrations" do
-    let(:task_name) { self.class.description }
-
     it "runs without error" do
-
       expect { subject.invoke }.not_to raise_error
     end
   end

--- a/spec/lib/tasks/cleanup_spec.rb
+++ b/spec/lib/tasks/cleanup_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Cleanup task" do
+RSpec.describe "Cleanup task", type: :rake do
   include_context "rake"
 
   describe "cleanup:transient_registrations" do

--- a/spec/lib/tasks/cleanup_spec.rb
+++ b/spec/lib/tasks/cleanup_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Cleanup task" do
+  include_context "rake"
+
+  describe "cleanup:transient_registrations" do
+    let(:task_name) { self.class.description }
+
+    it "runs without error" do
+
+      expect { subject.invoke }.not_to raise_error
+    end
+  end
+
+end

--- a/spec/lib/tasks/email_spec.rb
+++ b/spec/lib/tasks/email_spec.rb
@@ -5,11 +5,18 @@ require "rails_helper"
 RSpec.describe "Email task" do
   include_context "rake"
 
-  describe "email:test" do
+  # We have this test declared here as a way of recording a decision. The
+  # test requires that the env var EMAIL_TEST_ADDRESS is specified, which
+  # is no big problem but is a slight hindrance. Mainly it's because when run
+  # it just spits out text to the console. This messes up our rspec output
+  # format, and we don't like that!
+  #
+  # If this was a more important function we'd properly cover it, but in this
+  # case we are happy to skip the test coverage.
+  describe "email:test", skip: "We don't want to cover this!" do
     let(:task_name) { self.class.description }
 
     it "runs without error" do
-
       expect { subject.invoke }.not_to raise_error
     end
   end

--- a/spec/lib/tasks/email_spec.rb
+++ b/spec/lib/tasks/email_spec.rb
@@ -14,36 +14,25 @@ RSpec.describe "Email task" do
   # If this was a more important function we'd properly cover it, but in this
   # case we are happy to skip the test coverage.
   describe "email:test", skip: "We don't want to cover this!" do
-    let(:task_name) { self.class.description }
-
     it "runs without error" do
       expect { subject.invoke }.not_to raise_error
     end
   end
 
   describe "email:anonymise" do
-    let(:task_name) { self.class.description }
-
     it "runs without error" do
-
       expect { subject.invoke }.not_to raise_error
     end
   end
 
   describe "email:renew_reminder:first:send" do
-    let(:task_name) { self.class.description }
-
     it "runs without error" do
-
       expect { subject.invoke }.not_to raise_error
     end
   end
 
   describe "email:renew_reminder:second:send" do
-    let(:task_name) { self.class.description }
-
     it "runs without error" do
-
       expect { subject.invoke }.not_to raise_error
     end
   end

--- a/spec/lib/tasks/email_spec.rb
+++ b/spec/lib/tasks/email_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Email task" do
+RSpec.describe "Email task", type: :rake do
   include_context "rake"
 
   # We have this test declared here as a way of recording a decision. The

--- a/spec/lib/tasks/email_spec.rb
+++ b/spec/lib/tasks/email_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Email task" do
+  include_context "rake"
+
+  describe "email:test" do
+    let(:task_name) { self.class.description }
+
+    it "runs without error" do
+
+      expect { subject.invoke }.not_to raise_error
+    end
+  end
+
+  describe "email:anonymise" do
+    let(:task_name) { self.class.description }
+
+    it "runs without error" do
+
+      expect { subject.invoke }.not_to raise_error
+    end
+  end
+
+  describe "email:renew_reminder:first:send" do
+    let(:task_name) { self.class.description }
+
+    it "runs without error" do
+
+      expect { subject.invoke }.not_to raise_error
+    end
+  end
+
+  describe "email:renew_reminder:second:send" do
+    let(:task_name) { self.class.description }
+
+    it "runs without error" do
+
+      expect { subject.invoke }.not_to raise_error
+    end
+  end
+
+end

--- a/spec/lib/tasks/expire_registration_spec.rb
+++ b/spec/lib/tasks/expire_registration_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Expire Registration task" do
+  include_context "rake"
+
+  describe "expire_registration:run" do
+    let(:task_name) { self.class.description }
+
+    it "runs without error" do
+
+      expect { subject.invoke }.not_to raise_error
+    end
+  end
+
+end

--- a/spec/lib/tasks/expire_registration_spec.rb
+++ b/spec/lib/tasks/expire_registration_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Expire Registration task" do
+RSpec.describe "Expire Registration task", type: :rake do
   include_context "rake"
 
   describe "expire_registration:run" do

--- a/spec/lib/tasks/expire_registration_spec.rb
+++ b/spec/lib/tasks/expire_registration_spec.rb
@@ -6,10 +6,7 @@ RSpec.describe "Expire Registration task" do
   include_context "rake"
 
   describe "expire_registration:run" do
-    let(:task_name) { self.class.description }
-
     it "runs without error" do
-
       expect { subject.invoke }.not_to raise_error
     end
   end

--- a/spec/lib/tasks/letters_spec.rb
+++ b/spec/lib/tasks/letters_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Letters task" do
+RSpec.describe "Letters task", type: :rake do
   include_context "rake"
 
   describe "letters:export:ad_renewals" do

--- a/spec/lib/tasks/letters_spec.rb
+++ b/spec/lib/tasks/letters_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Letters task" do
+  include_context "rake"
+
+  describe "letters:export:ad_renewals" do
+    let(:task_name) { self.class.description }
+
+    it "runs without error" do
+
+      expect { subject.invoke }.not_to raise_error
+    end
+  end
+
+end

--- a/spec/lib/tasks/letters_spec.rb
+++ b/spec/lib/tasks/letters_spec.rb
@@ -6,10 +6,7 @@ RSpec.describe "Letters task" do
   include_context "rake"
 
   describe "letters:export:ad_renewals" do
-    let(:task_name) { self.class.description }
-
     it "runs without error" do
-
       expect { subject.invoke }.not_to raise_error
     end
   end

--- a/spec/lib/tasks/lookups_spec.rb
+++ b/spec/lib/tasks/lookups_spec.rb
@@ -2,7 +2,9 @@
 
 require "rails_helper"
 
-RSpec.describe "Lookups task" do
+RSpec.describe "Lookups task", type: :rake do
+  include_context "rake"
+
   describe "lookups:update:missing_area" do
     include_context "rake"
 

--- a/spec/lib/tasks/lookups_spec.rb
+++ b/spec/lib/tasks/lookups_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe "Lookups task" do
     end
 
     let(:run_for) { 10 }
-    let(:task_name) { self.class.description }
 
     it "update area info into addresses missing it" do
       site_address = create(:address, address_type: :site, x: 408_602.61, y: 257_535.31)

--- a/spec/lib/tasks/lookups_spec.rb
+++ b/spec/lib/tasks/lookups_spec.rb
@@ -10,10 +10,11 @@ RSpec.describe "Lookups task" do
     after { VCR.eject_cassette }
 
     before do
-      expect(WasteExemptionsBackOffice::Application.config).to receive(:area_lookup_run_for).and_return(run_for)
+      allow(WasteExemptionsBackOffice::Application.config).to receive(:area_lookup_run_for).and_return(run_for)
     end
 
     let(:run_for) { 10 }
+    let(:task_name) { self.class.description }
 
     it "update area info into addresses missing it" do
       site_address = create(:address, address_type: :site, x: 408_602.61, y: 257_535.31)

--- a/spec/lib/tasks/one_off/reminders_spec.rb
+++ b/spec/lib/tasks/one_off/reminders_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Reminder task" do
+  include_context "rake"
+
+  before(:all) { create(:registration, :with_active_exemptions) }
+
+  describe "reminder:first" do
+    let(:task_name) { self.class.description }
+
+    it "runs without error" do
+      expect { subject.invoke }.not_to raise_error
+    end
+  end
+
+  describe "reminder:second" do
+    let(:task_name) { self.class.description }
+
+    it "runs without error" do
+
+      expect { subject.invoke }.not_to raise_error
+    end
+  end
+
+end

--- a/spec/lib/tasks/one_off/reminders_spec.rb
+++ b/spec/lib/tasks/one_off/reminders_spec.rb
@@ -2,10 +2,10 @@
 
 require "rails_helper"
 
-RSpec.describe "Reminder task" do
+RSpec.describe "Reminder task", type: :rake do
   include_context "rake"
 
-  before(:all) { create(:registration, :with_active_exemptions) }
+  before(:each) { create(:registration, :with_active_exemptions) }
 
   describe "reminder:first" do
     it "runs without error" do

--- a/spec/lib/tasks/one_off/reminders_spec.rb
+++ b/spec/lib/tasks/one_off/reminders_spec.rb
@@ -8,18 +8,13 @@ RSpec.describe "Reminder task" do
   before(:all) { create(:registration, :with_active_exemptions) }
 
   describe "reminder:first" do
-    let(:task_name) { self.class.description }
-
     it "runs without error" do
       expect { subject.invoke }.not_to raise_error
     end
   end
 
   describe "reminder:second" do
-    let(:task_name) { self.class.description }
-
     it "runs without error" do
-
       expect { subject.invoke }.not_to raise_error
     end
   end

--- a/spec/lib/tasks/reports_spec.rb
+++ b/spec/lib/tasks/reports_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Reports task" do
+  include_context "rake"
+
+  describe "reports:export:bulk" do
+    let(:task_name) { self.class.description }
+
+    it "runs without error" do
+
+      expect { subject.invoke }.not_to raise_error
+    end
+  end
+
+  describe "reports:export:epr" do
+    let(:task_name) { self.class.description }
+
+    it "runs without error" do
+
+      expect { subject.invoke }.not_to raise_error
+    end
+  end
+
+  describe "reports:export:boxi" do
+    let(:task_name) { self.class.description }
+
+    it "runs without error" do
+
+      expect { subject.invoke }.not_to raise_error
+    end
+  end
+
+end

--- a/spec/lib/tasks/reports_spec.rb
+++ b/spec/lib/tasks/reports_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Reports task" do
+RSpec.describe "Reports task", type: :rake do
   include_context "rake"
 
   describe "reports:export:bulk" do

--- a/spec/lib/tasks/reports_spec.rb
+++ b/spec/lib/tasks/reports_spec.rb
@@ -6,28 +6,19 @@ RSpec.describe "Reports task" do
   include_context "rake"
 
   describe "reports:export:bulk" do
-    let(:task_name) { self.class.description }
-
     it "runs without error" do
-
       expect { subject.invoke }.not_to raise_error
     end
   end
 
   describe "reports:export:epr" do
-    let(:task_name) { self.class.description }
-
     it "runs without error" do
-
       expect { subject.invoke }.not_to raise_error
     end
   end
 
   describe "reports:export:boxi" do
-    let(:task_name) { self.class.description }
-
     it "runs without error" do
-
       expect { subject.invoke }.not_to raise_error
     end
   end

--- a/spec/support/rake_env.rb
+++ b/spec/support/rake_env.rb
@@ -38,4 +38,12 @@ RSpec.configure do |config|
 
     Rake::Task.define_task(:environment)
   end
+
+  config.before(:each, type: :rake) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.after(type: :rake) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
 end

--- a/spec/support/rake_env.rb
+++ b/spec/support/rake_env.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Adapted from: https://thoughtbot.com/blog/test-rake-tasks-like-a-boss
+# and https://stackoverflow.com/a/42172531
+#
+# Used to resolve an issue with simplecov test reporting of rake tasks. It first
+# arose when we implemented integration tests for a rake tast for the first
+# time. That spec was actually testing 2 tasks in the same task namespace. The
+# problem was whichever was run last would overwrite the coverage data
+# for the other.
+#
+# According to https://stackoverflow.com/a/42172531 the belief is
+#
+#   SimpleCov uses `Coverage#result` module from Ruby standard library to check
+#   what was covered. `Coverage#result` gets reset for the file [..] when you
+#   re-load the file using Kernel load.
+#
+# So everytime we were invoking a task in one test, it would overwite the
+# results captured in the previous.
+#
+# We thought we nailed it by placing the calls below in a `before(:all)` block
+# in `spec/shared_examples/rake.rb`, but then found this caused all our rake
+# tasks to be flagged as missing coverage. Next step was to add some basic
+# unit tests which if run in isolation gave a 100% test coverage. But when the
+# full suite was run the same behaviour happened again. Now the last rake spec
+# to be run would blitz the test coverage for the others.
+#
+# So following the logic in the stackoverflow article to its conclusion, we
+# moved the calls here to ensure they happen before any rake tasks are run.
+# Doing so has resolved the problem with our test coverage, and now it is
+# retaiuned for each rake spec irrespective if one or all are run.
+#
+# See also spec/shared_examples/rake.rb
+RSpec.configure do |config|
+  config.before(:suite) do
+    Rake.application = Rake::Application.new
+    Rails.application.load_tasks
+
+    Rake::Task.define_task(:environment)
+  end
+end

--- a/spec/support/shared_examples/rake.rb
+++ b/spec/support/shared_examples/rake.rb
@@ -15,18 +15,12 @@
 #
 # So we have dropped its use and incorporated the notes from the stackoverflow
 # article to cater for this situation, and ensure our test coverage is accurate.
-
+#
+# See also spec/support/rake_env.rb
 require "rake"
 
 RSpec.shared_context "rake" do
   let(:task_name) { self.class.description }
   let(:subject) { Rake.application[task_name] }
   let(:task_path) { "lib/tasks/#{task_name.split(':').first}" }
-
-  before(:all) do
-    Rake.application = Rake::Application.new
-    Rails.application.load_tasks
-
-    Rake::Task.define_task(:environment)
-  end
 end

--- a/spec/support/shared_examples/rake.rb
+++ b/spec/support/shared_examples/rake.rb
@@ -19,6 +19,7 @@
 require "rake"
 
 RSpec.shared_context "rake" do
+  let(:task_name) { self.class.description }
   let(:subject) { Rake.application[task_name] }
   let(:task_path) { "lib/tasks/#{task_name.split(':').first}" }
 

--- a/spec/support/simplecov.rb
+++ b/spec/support/simplecov.rb
@@ -19,4 +19,5 @@ SimpleCov.start("rails") do
   add_group "Presenters", "app/presenters"
   add_group "Services", "app/services"
   add_group "Validators", "app/validators"
+  add_group "Tasks", "lib/tasks"
 end


### PR DESCRIPTION
This change will allow us to invoke rake tasks within out test suite to ensure that they run as expected.

Supporting rake integration tests comes with 2 primary challenges

- ensuring accurate test coverage
- ensuring any records created are correctly cleaned

Both result from the fact that invoking a rake task is the equivalent of starting a new instance. For simplecov this has the effect of it only capturing the coverage for the last rake task invoked. For DatabaseBase cleaner it is not called because the connection to the DB is new and not the one it is applying its transaction strategy to.

Each has its own solution. For simplecov we need to start an instance of Rake and load all tasks before the suite starts. This means its able to distinguish between which files are being called and collate the test coverage, rather than keep overwriting.

For DatabaseCleaner we need to mark our tests, and then use Rspec's config to alter the cleaning strategy when a rake test is called, plus clean the database after each rake spec.