### PR TITLE
Add with_postcode to x & y lookup job scope

### DIFF
--- a/lib/tasks/lookups.rake
+++ b/lib/tasks/lookups.rake
@@ -22,7 +22,7 @@ namespace :lookups do
     desc "Populate EA Area information in all WasteExemptionsEngine::Address objects missing it."
     task missing_easting_and_northing: :environment do
       run_for = WasteExemptionsBackOffice::Application.config.easting_and_northing_lookup_run_for.to_i
-      addresses_scope = WasteExemptionsEngine::Address.site.missing_easting_or_northing
+      addresses_scope = WasteExemptionsEngine::Address.site.with_postcode.missing_easting_or_northing
 
       TimedServiceRunner.run(
         scope: addresses_scope,

--- a/spec/lib/tasks/lookups_spec.rb
+++ b/spec/lib/tasks/lookups_spec.rb
@@ -40,14 +40,23 @@ RSpec.describe "Lookups task", type: :rake do
 
     it "updates x & y for site addresses missing them, as long as the postcode is populated" do
       site_address = create(:address, address_type: :site, x: nil, y: nil, postcode: "BS1 5AH")
+      site_address_no_postcode = create(:address, address_type: :site, x: nil, y: nil, postcode: nil)
       non_site_address = create(:address, x: nil, y: nil, postcode: "BS1 5AH")
 
+      # Expect no error
+      expect(Airbrake).to_not receive(:notify)
+
       subject.invoke
+
       site_address.reload
+      site_address_no_postcode.reload
       non_site_address.reload
 
       expect(site_address.x).to eq(358_205.03)
       expect(site_address.y).to eq(172_708.07)
+
+      expect(site_address_no_postcode.x).to be_nil
+      expect(site_address_no_postcode.y).to be_nil
 
       expect(non_site_address.x).to be_nil
       expect(non_site_address.y).to be_nil


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-486

This fixes an issue encountered in testing with certain addresses. Some of the old data we migrated when launching the new version of the service was missing site addresses. So the migrating created blank site records in these cases as the new code expects there to be 1 site address for every registration.

However these have neither an x & y nor a postcode. We had not coded for this in our solution, so the records were coming up in our query, and we were trying to look up the x & y with OS Places using a null postcode.

We added the `with_postcode` scope to the engine. This change applies it to our x & y lookup job.