### PR TITLE
Update address base url details

### DIFF
--- a/config/initializers/waste_exemptions_engine.rb
+++ b/config/initializers/waste_exemptions_engine.rb
@@ -10,7 +10,7 @@ WasteExemptionsEngine.configure do |configuration|
   configuration.companies_house_api_key = ENV["COMPANIES_HOUSE_API_KEY"]
 
   # Addressbase facade config
-  configuration.addressbase_url = ENV["ADDRESSBASE_URL"] || "http://localhost:9002"
+  configuration.addressbase_url = ENV["ADDRESSBASE_URL"] || "http://localhost:3002"
 
   # Email config
   configuration.service_name = ENV["EMAIL_SERVICE_NAME"] || "Waste Exemptions Service"

--- a/spec/cassettes/invalid_postcode_lookup.yml
+++ b/spec/cassettes/invalid_postcode_lookup.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:9002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=AB35EF
+    uri: http://localhost:3002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=AB35EF
     body:
       encoding: US-ASCII
       string: ''
@@ -14,7 +14,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
-      - localhost:9002
+      - localhost:3002
   response:
     status:
       code: 200
@@ -31,6 +31,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"totalMatches":0,"startMatch":null,"endMatch":null,"uri_to_supplier":"https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=AB35EF&maxresults=100&dataset=DPA","uri_from_client":"stub","results":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 25 Sep 2019 09:58:25 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/valid_area_lookup.yml
+++ b/spec/cassettes/valid_area_lookup.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 13 Oct 2019 18:16:21 GMT
+      - Thu, 31 Oct 2019 14:42:04 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -58,5 +58,5 @@ http_interactions:
           </gml:featureMember>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Sun, 13 Oct 2019 18:16:21 GMT
+  recorded_at: Thu, 31 Oct 2019 14:42:02 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/valid_postcode_lookup.yml
+++ b/spec/cassettes/valid_postcode_lookup.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:9002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=BS15AH
+    uri: http://localhost:3002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=BS15AH
     body:
       encoding: US-ASCII
       string: ''
@@ -14,14 +14,14 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
-      - localhost:9002
+      - localhost:3002
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Sun, 13 Oct 2019 18:15:25 GMT
+      - Thu, 31 Oct 2019 14:42:01 GMT
       Content-Type:
       - application/json
       Vary:
@@ -38,7 +38,7 @@ http_interactions:
         PLC","premises":null,"street_address":"DEANERY ROAD","locality":null,"city":"BRISTOL","postcode":"BS1
         5AH","x":"358130.1","y":"172687.87","coordinate_system":null,"state_date":"12/10/2009","blpu_state_code":null,"postal_address_code":null,"logical_status_code":null,"source_data_type":"dpa"}]}'
     http_version: 
-  recorded_at: Sun, 13 Oct 2019 18:15:27 GMT
+  recorded_at: Thu, 31 Oct 2019 14:42:01 GMT
 - request:
     method: get
     uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E358205.03,172708.07%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,area_name,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
@@ -62,7 +62,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 13 Oct 2019 18:15:28 GMT
+      - Thu, 31 Oct 2019 14:42:04 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -97,5 +97,5 @@ http_interactions:
           </gml:featureMember>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Sun, 13 Oct 2019 18:15:27 GMT
+  recorded_at: Thu, 31 Oct 2019 14:42:02 GMT
 recorded_with: VCR 5.0.0


### PR DESCRIPTION
In our local environment we hadn't quite got the configuration of the address base facade correct.

Turns out this was blocking vagrant from using the cassettes when running tests locally, because it could no longer match the requests.

This change fixes the issue.