### PR TITLE
Make sure boxi export always have a value for person_type

### DIFF
--- a/app/models/reports/boxi/people_serializer.rb
+++ b/app/models/reports/boxi/people_serializer.rb
@@ -12,6 +12,10 @@ module Reports
       def records_scope
         WasteExemptionsEngine::Person.all
       end
+
+      def parse_person_type
+        person_type.presence || 0
+      end
     end
   end
 end

--- a/app/models/reports/boxi/people_serializer.rb
+++ b/app/models/reports/boxi/people_serializer.rb
@@ -13,7 +13,7 @@ module Reports
         WasteExemptionsEngine::Person.all
       end
 
-      def parse_person_type
+      def parse_person_type(person_type)
         person_type.presence || 0
       end
     end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-798

This make sure we always populate the `person_type` field for Boxi export. Ideally, since the column have been removed on our system, it should be removed from Boxi as well.