### PR TITLE
Fix SonarCloud code coverage reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,7 @@ group :test do
   gem "faker"
   # Generates a test coverage report on every `bundle exec rspec` call. We use
   # the output to feed CodeClimate's stats and analysis
-  gem "simplecov", require: false
+  gem "simplecov", "~> 0.17.1", require: false
   # A gem providing "time travel" and "time freezing" capabilities, making it
   # dead simple to test time-dependent code.
   gem "timecop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,6 +185,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.3.0)
     kaminari (1.2.0)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.0)
@@ -327,10 +328,11 @@ GEM
       rdoc (>= 5.0)
     secure_headers (5.2.0)
       useragent (>= 0.15.0)
-    simplecov (0.18.5)
+    simplecov (0.17.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     spring (2.1.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -408,7 +410,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   sdoc (~> 1.1.0)
   secure_headers (~> 5.0)
-  simplecov
+  simplecov (~> 0.17.1)
   spring
   timecop
   turbolinks


### PR DESCRIPTION
We have started seeing an error from SonarCloud when it tries to read our SimpleCov output file.

```bash
INFO: Sensor SimpleCov Sensor for Ruby coverage [ruby]
ERROR: Cannot read coverage report file, expecting standard SimpleCov resultset JSON format: 'coverage/.resultset.json'
java.lang.ClassCastException: org.sonarsource.analyzer.commons.internal.json.simple.JSONObject cannot be cast to org.sonarsource.analyzer.commons.internal.json.simple.JSONArray
	at org.sonarsource.ruby.plugin.SimpleCovSensor.mergeFrameworkCoverages(SimpleCovSensor.java:121)
	at org.sonarsource.ruby.plugin.SimpleCovSensor.mergeFileCoverages(SimpleCovSensor.java:114)
...
```

We know this to be because of the recent change to use the latest version of SimpleCov to resolve a security issue with the version of JSON it was using (see PR https://github.com/DEFRA/waste-exemptions-back-office/pull/535). Since that was merged SonarCloud has been reporting 0% test coverage for the project.

This change ensures SonarCloud can read our code coverage again by reverting back to the previous version of [Simplecov](https://rubygems.org/gems/simplecov).

Note. This brings the [JSON](https://rubygems.org/gems/json/) dependency back in again which we were able to drop with our changes in #535. However, with the refresh, it's bringing in the latest version (2.3.0) which includes a fix for the issue Hakiri was previously flagging. So on a security basis, we are still good 😅!