### PR TITLE
Update defra-ruby-aws to AWS:KMS version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem "waste_exemptions_engine",
     branch: "master"
 
 # Use the Defra Ruby Aws gem for loading files to AWS buckets
-gem "defra_ruby_aws", "~> 0.2.0"
+gem "defra_ruby_aws", "~> 0.3.0"
 
 # bundle exec rake doc:rails generates the API under doc/api.
 gem "sdoc", "~> 1.1.0", group: :doc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,21 +91,21 @@ GEM
       rbtree3 (~> 0.5)
     ast (2.4.1)
     aws-eventstream (1.1.0)
-    aws-partitions (1.324.0)
-    aws-sdk-core (3.97.1)
+    aws-partitions (1.331.0)
+    aws-sdk-core (3.100.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.33.0)
-      aws-sdk-core (~> 3, >= 3.71.0)
+    aws-sdk-kms (1.34.1)
+      aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.67.1)
-      aws-sdk-core (~> 3, >= 3.96.1)
+    aws-sdk-s3 (1.69.0)
+      aws-sdk-core (~> 3, >= 3.99.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.1.4)
-      aws-eventstream (~> 1.0, >= 1.0.2)
+    aws-sigv4 (1.2.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.13)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
@@ -130,7 +130,7 @@ GEM
     defra_ruby_area (2.0.0)
       nokogiri (~> 1.10.4)
       rest-client (~> 2.0)
-    defra_ruby_aws (0.2.0)
+    defra_ruby_aws (0.3.0)
       aws-sdk-s3
     defra_ruby_email (1.0.0)
       rails (~> 6.0.3.1)
@@ -432,7 +432,7 @@ DEPENDENCIES
   bullet
   cancancan (~> 2.0)
   database_cleaner
-  defra_ruby_aws (~> 0.2.0)
+  defra_ruby_aws (~> 0.3.0)
   defra_ruby_style
   devise
   devise_invitable


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1099

web-ops have asked us to set the encryption for everything uploaded going forward to `AWS:KMS`. This updates the project to a version of [defra-ruby-aws](https://github.com/DEFRA/defra-ruby-aws/pull/20) that uses it.