### PR TITLE
Integrate defra-ruby-features engine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,10 @@ gem "waste_exemptions_engine",
     git: "https://github.com/DEFRA/waste-exemptions-engine",
     branch: "main"
 
+# Use the Defra Ruby Features gem to allow users with the correct permissions to
+# manage feature toggle (create / update / delete) from the back-office.
+gem "defra_ruby_features", "~> 0.1"
+
 # Use the Defra Ruby Aws gem for loading files to AWS buckets
 gem "defra_ruby_aws", "~> 0.3.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,10 @@ GEM
     defra_ruby_email (1.0.0)
       rails (~> 6.0.3.1)
       sprockets (~> 3.7.2)
+    defra_ruby_features (0.1.1)
+      cancancan (>= 1.10)
+      devise (>= 4.4.3)
+      rails (~> 6.0.3, >= 6.0.3.2)
     defra_ruby_style (0.2.2)
       rubocop (~> 0.82)
     defra_ruby_validators (2.4.1)
@@ -433,6 +437,7 @@ DEPENDENCIES
   cancancan (~> 2.0)
   database_cleaner
   defra_ruby_aws (~> 0.3.0)
+  defra_ruby_features (~> 0.1)
   defra_ruby_style
   devise
   devise_invitable

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -60,5 +60,7 @@ class Ability
   # creating exemptions in order to test and debug.
   def permissions_for_developer
     permissions_for_admin_agent
+
+    can :manage, WasteExemptionsEngine::FeatureToggle
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,6 +37,12 @@
                             main_app.bulk_exports_path %>
               </li>
             <% end %>
+            <% if can?(:manage, WasteExemptionsEngine::FeatureToggle, current_user) %>
+              <li>
+                <%= link_to t("layouts.application.menu.feature_toggles"),
+                            features_engine.feature_toggles_path %>
+              </li>
+            <% end %>
           </ul>
         </nav>
       <% else %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,8 @@ require "rails/all"
 require "active_record/connection_adapters/postgresql_adapter"
 # require "rails/test_unit/railtie"
 
+require "defra_ruby_features"
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/config/initializers/defra_ruby_features.rb
+++ b/config/initializers/defra_ruby_features.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "defra_ruby_features"
+
+DefraRubyFeatures.configure do |configuration|
+  # Tell the engine where to find a model to use in order to persist feature toggles data
+  configuration.feature_toggle_model_name = "::WasteExemptionsEngine::FeatureToggle"
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
         letters: "Download letters"
         users: "Manage users"
         exports: "Data exports"
+        feature_toggles: "Toggle features"
   shared:
     select_role:
       roles:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,5 +60,8 @@ Rails.application.routes.draw do
 
   # Engine
   mount WasteExemptionsEngine::Engine => "/"
+
+  # Defra ruby features engine
+  mount DefraRubyFeatures::Engine => "/features"
 end
 # rubocop:enable Metrics/BlockLength

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,6 @@ Rails.application.routes.draw do
   mount WasteExemptionsEngine::Engine => "/"
 
   # Defra ruby features engine
-  mount DefraRubyFeatures::Engine => "/features"
+  mount DefraRubyFeatures::Engine => "/features", as: "features_engine"
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe Ability, type: :model do
     include_examples "below super_agent examples"
 
     include_examples "admin_agent examples"
+    include_examples "developer examples"
     include_examples "data_agent examples"
   end
 

--- a/spec/support/shared_examples/abilities/developer_examples.rb
+++ b/spec/support/shared_examples/abilities/developer_examples.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "developer examples" do
+  it "should be able to toggle features" do
+    should be_able_to(:manage, WasteExemptionsEngine::FeatureToggle)
+  end
+end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-1139

This integrate the defra-ruby-features engine in the back office app.

Note: There is currently no user with permission to use the feature, due to the fact that there is no existing developer level role, hence it will need to be discussed with the team first