### PR TITLE
Update defra-ruby-alert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
     debug_inspector (0.0.3)
     defra_ruby_address (0.1.0)
       rest-client (~> 2.0)
-    defra_ruby_alert (2.1.0)
+    defra_ruby_alert (2.1.1)
       airbrake
     defra_ruby_area (2.0.0)
       nokogiri (~> 1.10.4)


### PR DESCRIPTION
https://github.com/DEFRA/defra-ruby-alert/pull/11

The defra-ruby-alert gem was updated to use the latest version of Airbrake at the same time as this project was updated to work with Rails 6 and Ruby 2.7.

What we did not realise is that the Airbrake gem had introduced a performance monitoring feature which is enabled by default. As we log our exceptions to errbit this feature was not supported so our logs are getting spammed with 404 messages from the Airbrake gem.

We've fixed that in defra-ruby-alert and this updates the project to use the latest version.