### PR TITLE
Revert "Update defra-ruby-alert"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
     debug_inspector (0.0.3)
     defra_ruby_address (0.1.0)
       rest-client (~> 2.0)
-    defra_ruby_alert (2.1.1)
+    defra_ruby_alert (2.1.0)
       airbrake
     defra_ruby_area (2.0.0)
       nokogiri (~> 1.10.4)


### PR DESCRIPTION
Reverts DEFRA/waste-exemptions-back-office#580

'defra-ruby-alert' is actually a dependency specified and handled in the waste-exemptions-engine. So it's there we need to update the gem, not here.