### PR TITLE
Fix wrong letter cleanup service called

### DIFF
--- a/lib/tasks/letters.rake
+++ b/lib/tasks/letters.rake
@@ -21,7 +21,7 @@ namespace :letters do
 
       older_than = WasteExemptionsBackOffice::Application.config.ad_letters_delete_records_in.to_i.days.ago
 
-      AdRenewalLettersExportCleanerService.run(older_than)
+      AdConfirmationLettersExportCleanerService.run(older_than)
     end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-636

Spotted that the wrong letter cleanup service was being called from the rake task.