### PR TITLE
Change AD confirm. letters job start time

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -51,7 +51,7 @@ end
 
 # This is the AD confirmation letters export job. When run it will generate a single
 # PDF containing confirmation letters for all AD registrations created today
-every :day, at: (ENV["EXPORT_SERVICE_AD_CONFIRMATION_LETTERS_TIME"] || "00:55"), roles: [:db] do
+every :day, at: (ENV["EXPORT_SERVICE_AD_CONFIRMATION_LETTERS_TIME"] || "22:35"), roles: [:db] do
   rake "letters:export:ad_confirmations"
 end
 

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Whenever schedule" do
     job_details = schedule.jobs[:rake].find { |h| h[:task] == "letters:export:ad_confirmations" }
 
     expect(job_details[:every][0]).to eq(:day)
-    expect(job_details[:every][1][:at]).to eq("00:55")
+    expect(job_details[:every][1][:at]).to eq("22:35")
   end
 
   it "picks up the boxi export generation run frequency and time" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1161

The logic of the job is that it looks for AD registrations created that day. Any it finds it creates a PDF containing a copy of the confirmation letter for each one.

Because of this it needs to run at the end of the day to pick up registrations created. The previous default start time of 00:55 means it was running at a time when there would never have been anything created.

22:35 seems to fit amongst the other jobs, and be towards the end of the day. It doesn't have to be at 23:59 because AD registrations have to be created by NCCC and they will have long finished for the day.