### PR TITLE
Update whenever to latest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem "devise_invitable"
 gem "kaminari", "~> 1.1"
 
 # Use Whenever to manage cron tasks
-gem "whenever", "~> 0.10.0"
+gem "whenever", "~> 1.0"
 
 # Used for auditing and version control
 gem "paper_trail", "~> 10.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -417,7 +417,7 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    whenever (0.10.0)
+    whenever (1.0.0)
       chronic (>= 0.6.3)
     whenever-test (1.0.1)
       whenever
@@ -465,7 +465,7 @@ DEPENDENCIES
   waste_exemptions_engine!
   web-console (~> 2.0)
   webmock (~> 3.5)
-  whenever (~> 0.10.0)
+  whenever (~> 1.0)
   whenever-test (~> 1.0)
 
 RUBY VERSION


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1061

It's not actually needed for RUBY-1061. But we spotted that whenever was both out of date with the latest released version and not in sync with the version used in our Capistrano deployment project **rails-deployment** when working on it.

This takes the opportunity to update it to the latest.