### PR TITLE
Add developer role to back-office

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -16,6 +16,7 @@ class Ability
     permissions_for_super_agent if user.role_is?(:super_agent)
     permissions_for_admin_agent if user.role_is?(:admin_agent)
     permissions_for_data_agent if user.role_is?(:data_agent)
+    permissions_for_developer if user.role_is?(:developer)
   end
 
   def permissions_for_system_user
@@ -51,5 +52,13 @@ class Ability
     can :read, WasteExemptionsEngine::Registration
     can :read, WasteExemptionsEngine::NewRegistration
     can :read, Reports::GeneratedReport
+  end
+
+  # Developer users should just be those on the current delivery team and/or
+  # those providing system support. We allow the same permissions as an admin
+  # agent as they will often need to interact with the service including
+  # creating exemptions in order to test and debug.
+  def permissions_for_developer
+    permissions_for_admin_agent
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,8 @@ class User < ::WasteExemptionsEngine::ApplicationRecord
   ROLES = %w[system
              super_agent
              admin_agent
-             data_agent].freeze
+             data_agent
+             developer].freeze
 
   def role_is?(target_role)
     role == target_role.to_s

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,3 +17,4 @@ en:
           super_agent: "Super agent"
           admin_agent: "Admin agent"
           data_agent: "Data agent"
+          developer: "Developer"

--- a/config/locales/user_roles.en.yml
+++ b/config/locales/user_roles.en.yml
@@ -8,4 +8,5 @@ en:
         super_agent: "%{email} is currently a super agent."
         admin_agent: "%{email} is currently an admin agent."
         data_agent: "%{email} is currently a data agent."
+        developer: "%{email} is currently a developer."
       submit_button: "Change role"

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -15,6 +15,7 @@ en:
           super_agent: "super agent"
           admin_agent: "admin agent"
           data_agent: "data agent"
+          developer: "developer"
         statuses:
           active: "active"
           deactivated: "deactivated"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_19_114115) do
+ActiveRecord::Schema.define(version: 2020_06_29_141525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,13 @@ ActiveRecord::Schema.define(version: 2020_05_19_114115) do
     t.string "summary"
     t.text "description"
     t.text "guidance"
+  end
+
+  create_table "feature_toggles", force: :cascade do |t|
+    t.string "key"
+    t.boolean "active"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "people", id: :serial, force: :cascade do |t|

--- a/db/seeds/users.json
+++ b/db/seeds/users.json
@@ -15,6 +15,10 @@
     {
       "email" : "data_agent@wex.gov.uk",
       "role" : "data_agent"
+    },
+    {
+      "email" : "developer@wex.gov.uk",
+      "role" : "developer"
     }
   ]
 }

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -25,6 +25,10 @@ FactoryBot.define do
       role { "data_agent" }
     end
 
+    trait :developer do
+      role { "developer" }
+    end
+
     trait :inactive do
       active { false }
     end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -49,6 +49,16 @@ RSpec.describe Ability, type: :model do
     include_examples "data_agent examples"
   end
 
+  context "when the user role is developer" do
+    let(:user) { build(:user, :developer) }
+
+    include_examples "below system examples"
+    include_examples "below super_agent examples"
+
+    include_examples "admin_agent examples"
+    include_examples "data_agent examples"
+  end
+
   context "when the user account is inactive" do
     let(:user) { build(:user, :data_agent, :inactive) }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1177

This is related to [PR #573 integrating feature toggle support](https://github.com/DEFRA/waste-exemptions-back-office/pull/573).

Our feature toggles integration allows a user in the back-office to 'toggle' features on an off. These are useful when introducing new functionality because it allows us to enable, and disable the feature quickly. This avoids the delays we experience using the RfC process just to toggle env vars.

However, these feature toggles are something we only want the delivery team to control. We'll have a better understanding of the implications of what happens when they are switched on and off, so we need to control them. In [waste-carriers](https://github.com/DEFRA/waste-carriers-back-office) we introduced a developer role and then only authorised it to access the feature toggles page.

We intend to do the same for WEX. So this change covers adding a new 'developer' role to the service.