### PR TITLE
Replace mailer with Notify services in RenewalReminderServices

### DIFF
--- a/app/services/first_renewal_reminder_service.rb
+++ b/app/services/first_renewal_reminder_service.rb
@@ -4,7 +4,7 @@ class FirstRenewalReminderService < RenewalReminderServiceBase
   private
 
   def send_email(registration)
-    RenewalReminderMailer.first_reminder_email(registration).deliver_now
+    FirstRenewalReminderEmailService.run(registration: registration)
   end
 
   def expires_in_days

--- a/app/services/renewal_reminder_email_service.rb
+++ b/app/services/renewal_reminder_email_service.rb
@@ -6,13 +6,12 @@ class RenewalReminderEmailService < ::WasteExemptionsEngine::BaseService
   # So we can use displayable_address()
   include ::WasteExemptionsEngine::ApplicationHelper
 
-  def run(registration:, recipient:)
+  def run(registration:)
     @registration = registration
-    @recipient = recipient
 
     client = Notifications::Client.new(WasteExemptionsEngine.configuration.notify_api_key)
 
-    client.send_email(email_address: recipient,
+    client.send_email(email_address: @registration.contact_email,
                       template_id: template,
                       personalisation: personalisation)
   end

--- a/app/services/second_renewal_reminder_service.rb
+++ b/app/services/second_renewal_reminder_service.rb
@@ -4,7 +4,7 @@ class SecondRenewalReminderService < RenewalReminderServiceBase
   private
 
   def send_email(registration)
-    RenewalReminderMailer.second_reminder_email(registration).deliver_now
+    SecondRenewalReminderEmailService.run(registration: registration)
   end
 
   def expires_in_days

--- a/spec/services/first_renewal_reminder_email_service_spec.rb
+++ b/spec/services/first_renewal_reminder_email_service_spec.rb
@@ -5,10 +5,8 @@ require "rails_helper"
 RSpec.describe FirstRenewalReminderEmailService do
   describe "run" do
     let(:registration) { create(:registration) }
-    let(:recipient) { registration.contact_email }
     let(:service) do
-      FirstRenewalReminderEmailService.run(registration: registration,
-                                           recipient: recipient)
+      FirstRenewalReminderEmailService.run(registration: registration)
     end
 
     it "sends an email" do

--- a/spec/services/first_renewal_reminder_service_spec.rb
+++ b/spec/services/first_renewal_reminder_service_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe FirstRenewalReminderService do
           ]
         )
 
-        expect(RenewalReminderMailer).to receive(:first_reminder_email).and_raise("An error")
+        expect(FirstRenewalReminderEmailService).to receive(:run).and_raise("An error")
         expect(Airbrake).to receive(:notify)
         expect(Rails.logger).to receive(:error)
 
@@ -35,7 +35,7 @@ RSpec.describe FirstRenewalReminderService do
       )
 
       # Create an expiring registration in a non-active status. Make sure we don't pick it up and send an email.
-      create(
+      expiring_non_active_registration = create(
         :registration,
         registration_exemptions: [
           build(:registration_exemption, :revoked, expires_on: 4.weeks.from_now.to_date)
@@ -43,15 +43,18 @@ RSpec.describe FirstRenewalReminderService do
       )
 
       # Create a non-expiring registration in a non-active status. Make sure we don't pick it up and send an email.
-      create(
+      non_expiring_non_active_registration = create(
         :registration,
         registration_exemptions: [
           build(:registration_exemption, :active, expires_on: 5.weeks.from_now.to_date)
         ]
       )
 
-      expect { described_class.run }.to change { ActionMailer::Base.deliveries.count }.by(1)
-      expect(ActionMailer::Base.deliveries.last.to).to eq([active_expiring_registration.contact_email])
+      expect(FirstRenewalReminderEmailService).to receive(:run).with(registration: active_expiring_registration)
+      expect(FirstRenewalReminderEmailService).to_not receive(:run).with(registration: expiring_non_active_registration)
+      expect(FirstRenewalReminderEmailService).to_not receive(:run).with(registration: non_expiring_non_active_registration)
+
+      described_class.run
     end
 
     it "does not send emails to AD NCCC email addresses" do
@@ -63,7 +66,10 @@ RSpec.describe FirstRenewalReminderService do
           build(:registration_exemption, :revoked, expires_on: 4.weeks.from_now.to_date)
         ]
       )
-      expect { described_class.run }.to_not change { ActionMailer::Base.deliveries.count }
+
+      expect(FirstRenewalReminderEmailService).to_not receive(:run)
+
+      described_class.run
     end
 
     it "does not send emails to registrations with the NCCC postcode" do
@@ -76,7 +82,9 @@ RSpec.describe FirstRenewalReminderService do
       )
       registration.site_address.update(postcode: "S9 4WF")
 
-      expect { described_class.run }.to_not change { ActionMailer::Base.deliveries.count }
+      expect(FirstRenewalReminderEmailService).to_not receive(:run)
+
+      described_class.run
     end
   end
 end

--- a/spec/services/second_renewal_reminder_email_service_spec.rb
+++ b/spec/services/second_renewal_reminder_email_service_spec.rb
@@ -5,10 +5,8 @@ require "rails_helper"
 RSpec.describe SecondRenewalReminderEmailService do
   describe "run" do
     let(:registration) { create(:registration, :site_uses_address) }
-    let(:recipient) { registration.contact_email }
     let(:service) do
-      SecondRenewalReminderEmailService.run(registration: registration,
-                                            recipient: recipient)
+      SecondRenewalReminderEmailService.run(registration: registration)
     end
 
     it "sends an email" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1187
https://eaflood.atlassian.net/browse/RUBY-1188

The FirstRenewalReminderService and the SecondRenewalReminderService collect the registrations which are due to be reminded and then call the class that sends them an email.

This PR changes the called class from the old mailers to the new Notify-based service classes.

It also changes the Notify classes so they don't receive an email argument, since this was always contact email by default.