### PR TITLE
Fix Notify rake tasks

### DIFF
--- a/lib/tasks/notify.rake
+++ b/lib/tasks/notify.rake
@@ -5,17 +5,15 @@ namespace :notify do
     desc "Send a test first renewal reminder email to the newest registration in the DB"
     task first_renewal_reminder: :environment do
       registration = WasteExemptionsEngine::Registration.last
-      recipient = registration.contact_email
 
-      FirstRenewalReminderEmailService.run(registration: registration, recipient: recipient)
+      FirstRenewalReminderEmailService.run(registration: registration)
     end
 
     desc "Send a test second renewal reminder email to the newest registration in the DB"
     task second_renewal_reminder: :environment do
       registration = WasteExemptionsEngine::Registration.last
-      recipient = registration.contact_email
 
-      SecondRenewalReminderEmailService.run(registration: registration, recipient: recipient)
+      SecondRenewalReminderEmailService.run(registration: registration)
     end
   end
 end


### PR DESCRIPTION
These were still passing in a recipient argument, which is no longer required or expected, so it threw an error instead.