### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on: push
+
+jobs:
+  build:
+    # You must use a Linux environment when using service containers or container jobs
+    runs-on: ubuntu-latest
+    env:
+      ENV_VARIABLE_TEST_FEATURE: true
+      NOTIFY_API_KEY: ${{ secrets.ACTIONS_NOTIFY_API_KEY }}
+      PG_HOST: localhost
+      PG_PASSWORD: pinafore
+      PG_PORT: 5432
+      PG_USERNAME: postgres
+      TZ: UTC
+
+    # Service containers to run with `runner-job`
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres:9.6-alpine
+        # Provide the password for postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: pinafore
+          POSTGRES_DB: waste_exemptions_test
+        # Maps tcp port 5432 on service container to the host
+        ports:
+          - 5432:5432
+        # Set health checks to wait until postgres has started. You must have this so the runner knows to wait till
+        # postgres is up and running before proceeding
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      # Downloads a copy of the code in your repository before running CI tests
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
+
+      # We don't have to specify the ruby version, or grab it from .ruby-verion. This action supports reading the
+      # version from .ruby-version itself
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      # Install various other dependencies
+      - name: Install dependencies
+        run: |
+          sudo apt-get install xvfb -y
+          sudo apt-get install wkhtmltopdf -y
+
+      - name: Database migrations
+        run: |
+          RAILS_ENV=test bundle exec rake db:create --trace --trace
+          RAILS_ENV=test bundle exec rake db:schema:load --trace --trace
+      # Run linting first. No point running the tests if there is a linting issue
+      - name: Run lint check
+        run: |
+          bundle exec rubocop --format progress --format json --out rubocop-result.json
+      # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
+      # folder mounted as `/github/workspace`. The problem is when the .resultset.json file is generated it will
+      # reference the code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use
+      # sed to update the references in .resultset.json
+      # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
+      - name: Run unit tests
+        run: |
+          bundle exec rails test
+          bundle exec rspec
+          sed -i 's/\/home\/runner\/work\/waste-exemptions-back-office\/waste-exemptions-back-office\//\/github\/workspace\//g' coverage/.resultset.json
+      - name: Analyze with SonarCloud
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1229

Travis has changed its availability for open source projects so we have decided to switch to GitHub Actions. This PR is a first pass at replacing the config.