### PR TITLE
Add one-off task to fix areas for certain regs

### DIFF
--- a/lib/tasks/one_off/area_fix.rake
+++ b/lib/tasks/one_off/area_fix.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+namespace :one_off do
+  desc "Fix areas for exemptions on same site (see RUBY-1234)"
+  # Run as rake one_off:area_fix["WEX1234 WEX5678 WEXetc"]
+  task :area_fix, [:references] => [:environment] do |_task, args|
+    references = args[:references].split(" ")
+
+    references.each do |reference|
+      print "Updating area for #{reference}..."
+      reg = WasteExemptionsEngine::Registration.where(reference: reference).first
+      puts reg.site_address.update(area: "Staffs Warwickshire and West Midlands")
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1234

These registrations have the same site but have been automatically assigned different areas by mistake.

This PR contains a one-off rake task to assign the correct areas to the registrations.