### PR TITLE
Upload EPR exports to EPR folder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,9 @@ gem "waste_exemptions_engine",
 gem "defra_ruby_features", "~> 0.1"
 
 # Use the Defra Ruby Aws gem for loading files to AWS buckets
-gem "defra_ruby_aws", "~> 0.3.0"
+gem "defra_ruby_aws",
+    git: "https://github.com/DEFRA/defra-ruby-aws",
+    branch: "feature/filename"
 
 # bundle exec rake doc:rails generates the API under doc/api.
 gem "sdoc", "~> 1.1.0", group: :doc

--- a/Gemfile
+++ b/Gemfile
@@ -65,9 +65,7 @@ gem "waste_exemptions_engine",
 gem "defra_ruby_features", "~> 0.1"
 
 # Use the Defra Ruby Aws gem for loading files to AWS buckets
-gem "defra_ruby_aws",
-    git: "https://github.com/DEFRA/defra-ruby-aws",
-    branch: "feature/filename"
+gem "defra_ruby_aws", "~> 0.4"
 
 # bundle exec rake doc:rails generates the API under doc/api.
 gem "sdoc", "~> 1.1.0", group: :doc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/DEFRA/defra-ruby-aws
-  revision: 22d88810c6ec4814366a1230aa78ff475ece2376
-  branch: feature/filename
-  specs:
-    defra_ruby_aws (0.3.1)
-      aws-sdk-s3
-
-GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
   revision: 8b6eefdd097eab9e486050dfee7136d5f4d875e0
   branch: main
@@ -138,6 +130,8 @@ GEM
     defra_ruby_area (2.0.0)
       nokogiri (~> 1.10.4)
       rest-client (~> 2.0)
+    defra_ruby_aws (0.4.1)
+      aws-sdk-s3
     defra_ruby_email (1.1.0)
       notifications-ruby-client
       rails (~> 6.0.3.1)
@@ -445,7 +439,7 @@ DEPENDENCIES
   bullet
   cancancan (~> 2.0)
   database_cleaner
-  defra_ruby_aws!
+  defra_ruby_aws (~> 0.4)
   defra_ruby_features (~> 0.1)
   defra_ruby_style
   devise

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/DEFRA/defra-ruby-aws
+  revision: 22d88810c6ec4814366a1230aa78ff475ece2376
+  branch: feature/filename
+  specs:
+    defra_ruby_aws (0.3.1)
+      aws-sdk-s3
+
+GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
   revision: 8b6eefdd097eab9e486050dfee7136d5f4d875e0
   branch: main
@@ -92,20 +100,20 @@ GEM
       rbtree3 (~> 0.5)
     ast (2.4.1)
     aws-eventstream (1.1.0)
-    aws-partitions (1.341.0)
-    aws-sdk-core (3.103.0)
+    aws-partitions (1.402.0)
+    aws-sdk-core (3.110.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.36.0)
-      aws-sdk-core (~> 3, >= 3.99.0)
+    aws-sdk-kms (1.39.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.74.0)
-      aws-sdk-core (~> 3, >= 3.102.1)
+    aws-sdk-s3 (1.86.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.2.1)
+    aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.16)
     binding_of_caller (0.8.0)
@@ -130,8 +138,6 @@ GEM
     defra_ruby_area (2.0.0)
       nokogiri (~> 1.10.4)
       rest-client (~> 2.0)
-    defra_ruby_aws (0.3.1)
-      aws-sdk-s3
     defra_ruby_email (1.1.0)
       notifications-ruby-client
       rails (~> 6.0.3.1)
@@ -439,7 +445,7 @@ DEPENDENCIES
   bullet
   cancancan (~> 2.0)
   database_cleaner
-  defra_ruby_aws (~> 0.3.0)
+  defra_ruby_aws!
   defra_ruby_features (~> 0.1)
   defra_ruby_style
   devise

--- a/app/services/concerns/can_load_file_to_aws.rb
+++ b/app/services/concerns/can_load_file_to_aws.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module CanLoadFileToAws
-  def load_file_to_aws_bucket
+  def load_file_to_aws_bucket(options = {})
     result = nil
 
     3.times do
-      result = bucket.load(File.new(file_path, "r"))
+      result = bucket.load(File.new(file_path, "r"), options)
 
       break if result.successful?
     end

--- a/app/services/reports/epr_export_service.rb
+++ b/app/services/reports/epr_export_service.rb
@@ -9,7 +9,9 @@ module Reports
     def run
       populate_temp_file
 
-      load_file_to_aws_bucket
+      options = { s3_directory: "EPR" }
+
+      load_file_to_aws_bucket(options)
     rescue StandardError => e
       Airbrake.notify e, file_name: file_name
       Rails.logger.error "Generate EPR export csv error for #{file_name}:\n#{e}"

--- a/spec/services/reports/epr_export_service_spec.rb
+++ b/spec/services/reports/epr_export_service_spec.rb
@@ -10,7 +10,7 @@ module Reports
           create_list(:registration_exemption, 2, :with_registration, :active)
           file_name = "waste_exemptions_epr_daily_full"
 
-          stub_request(:put, %r{https://.*\.s3\.eu-west-1\.amazonaws\.com/#{file_name}\.csv.*})
+          stub_request(:put, %r{https://.*\.s3\.eu-west-1\.amazonaws\.com/EPR/#{file_name}\.csv.*})
 
           # Expect no error gets notified
           expect(Airbrake).to_not receive(:notify)
@@ -27,7 +27,7 @@ module Reports
 
           stub_request(
             :put,
-            %r{https://.*\.s3\.eu-west-1\.amazonaws\.com/#{file_name}\.csv.*}
+            %r{https://.*\.s3\.eu-west-1\.amazonaws\.com/EPR/#{file_name}\.csv.*}
           ).to_return(status: 403)
 
           # Expect an error to get notified


### PR DESCRIPTION
This PR switches to an updated version of the defra-ruby-aws gem to enable us to upload to a subdirectory.

S3 doesn't really have subdirectories so it's actually just appending an "EPR/" prefix to the file on upload.