### PR TITLE
Update text for one-off area fix

### DIFF
--- a/lib/tasks/one_off/area_fix.rake
+++ b/lib/tasks/one_off/area_fix.rake
@@ -9,7 +9,7 @@ namespace :one_off do
     references.each do |reference|
       print "Updating area for #{reference}..."
       reg = WasteExemptionsEngine::Registration.where(reference: reference).first
-      puts reg.site_address.update(area: "Staffs Warwickshire and West Midlands")
+      puts reg.site_address.update(area: "West Midlands")
     end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1234

These registrations should be uploaded with "West Midlands", not the specific counties.