### PR TITLE
Add presenter for Notify version of confirmation letter

### DIFF
--- a/app/presenters/notify_confirmation_letter_presenter.rb
+++ b/app/presenters/notify_confirmation_letter_presenter.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
 class NotifyConfirmationLetterPresenter < BasePresenter
   def business_details_section
     items = []
@@ -111,13 +112,13 @@ class NotifyConfirmationLetterPresenter < BasePresenter
   def contact_email_text
     label_and_value("waste_operation_contact.email", contact_email)
   end
-  
+
   # Location
 
   def grid_reference_text
     label_and_value("waste_operation_location.ngr", site_address.grid_reference)
   end
-  
+
   def site_details_text
     label_and_value("waste_operation_location.details", site_address.description)
   end
@@ -174,3 +175,4 @@ class NotifyConfirmationLetterPresenter < BasePresenter
     registration_exemptions.includes(:exemption)
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/presenters/notify_confirmation_letter_presenter.rb
+++ b/app/presenters/notify_confirmation_letter_presenter.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+class NotifyConfirmationLetterPresenter < BasePresenter
+  def business_details_section
+    items = []
+
+    items << business_type_text
+
+    if partnership?
+      people.each_with_index do |person, index|
+        items << partners_text(person, index)
+      end
+    else
+      items << business_name_text
+      items << company_no_text if company_no.present?
+    end
+
+    items << business_address_text
+
+    items
+  end
+
+  def contact_details_section
+    items = []
+
+    items << contact_name_text
+    items << contact_position_text if contact_position.present?
+    items << contact_phone_text
+    items << contact_email_text
+
+    items
+  end
+
+  def location_section
+    items = []
+
+    if site_address.located_by_grid_reference?
+      items << grid_reference_text
+      items << site_details_text
+    else
+      items << site_address_text
+    end
+
+    items
+  end
+
+  def exemptions_section
+    items = []
+
+    sorted_active_registration_exemptions.each do |registration_exemption|
+      items << exemption_text(registration_exemption)
+    end
+
+    items
+  end
+
+  def deregistered_exemptions_section
+    items = []
+
+    sorted_deregistered_registration_exemptions.each do |registration_exemption|
+      items << exemption_text(registration_exemption)
+    end
+
+    items
+  end
+
+  private
+
+  # Business details
+
+  def business_type_text
+    human_business_type = I18n.t("waste_exemptions_engine.pdfs.certificate.busness_types.#{business_type}")
+    label_and_value("business_details.type", human_business_type)
+  end
+
+  def partners_text(person, index)
+    label_text = I18n.t("confirmation_letter.show.business_details.partner_enumerator", count: index + 1)
+    person_name = "#{person.first_name} #{person.last_name}"
+
+    "#{label_text} #{person_name}"
+  end
+
+  def business_name_text
+    label_and_value("business_details.name.#{business_type}", operator_name)
+  end
+
+  def company_no_text
+    label_and_value("business_details.number.#{business_type}", company_no)
+  end
+
+  def business_address_text
+    address = address_lines(operator_address).join(", ")
+    label_and_value("business_details.address.#{business_type}", address)
+  end
+
+  # Contact details
+
+  def contact_name_text
+    name = "#{contact_first_name} #{contact_last_name}"
+    label_and_value("waste_operation_contact.name", name)
+  end
+
+  def contact_position_text
+    label_and_value("waste_operation_contact.position", contact_position)
+  end
+
+  def contact_phone_text
+    label_and_value("waste_operation_contact.telephone", contact_phone)
+  end
+
+  def contact_email_text
+    label_and_value("waste_operation_contact.email", contact_email)
+  end
+  
+  # Location
+
+  def grid_reference_text
+    label_and_value("waste_operation_location.ngr", site_address.grid_reference)
+  end
+  
+  def site_details_text
+    label_and_value("waste_operation_location.details", site_address.description)
+  end
+
+  def site_address_text
+    address = address_lines(site_address).join(", ")
+    label_and_value("waste_operation_location.address", address)
+  end
+
+  # Exemptions
+
+  def sorted_active_registration_exemptions
+    registration_exemptions_with_exemptions.where(state: :active).order(:exemption_id)
+  end
+
+  def sorted_deregistered_registration_exemptions
+    registration_exemptions_with_exemptions.where("state != ?", :active).order_by_state_then_exemption_id
+  end
+
+  def exemption_text(registration_exemption)
+    status = registration_exemption_status(registration_exemption)
+    "#{registration_exemption.exemption.code}: #{registration_exemption.exemption.summary} – #{status}"
+  end
+
+  # Utility methods
+
+  def label_and_value(label, value)
+    label_text = I18n.t("confirmation_letter.show.#{label}")
+    "#{label_text} #{value}"
+  end
+
+  def address_lines(address)
+    return [] unless address
+
+    address_fields = %i[organisation premises street_address locality city postcode]
+    address_fields.map { |field| address.public_send(field) }.reject(&:blank?)
+  end
+
+  def registration_exemption_status(registration_exemption)
+    display_date = if registration_exemption.active? || registration_exemption.expired?
+                     registration_exemption.expires_on.to_formatted_s(:day_month_year)
+                   else
+                     registration_exemption.deregistered_at.to_formatted_s(:day_month_year)
+                   end
+
+    I18n.t(
+      "waste_exemptions.status.#{registration_exemption.state}",
+      scope: "confirmation_letter.show",
+      display_date: display_date
+    )
+  end
+
+  def registration_exemptions_with_exemptions
+    registration_exemptions.includes(:exemption)
+  end
+end

--- a/app/presenters/notify_confirmation_letter_presenter.rb
+++ b/app/presenters/notify_confirmation_letter_presenter.rb
@@ -2,6 +2,19 @@
 
 # rubocop:disable Metrics/ClassLength
 class NotifyConfirmationLetterPresenter < BasePresenter
+  def date_registered
+    # Currently you can only add exemptions when you register, so we can assume they expire at the same time
+    registration_exemptions.first.registered_on.to_formatted_s(:day_month_year)
+  end
+
+  def applicant_name
+    "#{applicant_first_name} #{applicant_last_name}"
+  end
+
+  def contact_name
+    "#{contact_first_name} #{contact_last_name}"
+  end
+
   def business_details_section
     items = []
 
@@ -97,8 +110,7 @@ class NotifyConfirmationLetterPresenter < BasePresenter
   # Contact details
 
   def contact_name_text
-    name = "#{contact_first_name} #{contact_last_name}"
-    label_and_value("waste_operation_contact.name", name)
+    label_and_value("waste_operation_contact.name", contact_name)
   end
 
   def contact_position_text

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -62,19 +62,23 @@ FactoryBot.define do
 
     trait :local_authority do
       business_type { "localAuthority" }
+      company_no { nil }
     end
 
     trait :charity do
       business_type { "charity" }
+      company_no { nil }
     end
 
     trait :partnership do
       business_type { "partnership" }
       people { build_list(:person, 2) }
+      company_no { nil }
     end
 
     trait :sole_trader do
       business_type { "soleTrader" }
+      company_no { nil }
     end
 
     trait :site_uses_address do

--- a/spec/presenters/notify_confirmation_letter_presenter_spec.rb
+++ b/spec/presenters/notify_confirmation_letter_presenter_spec.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NotifyConfirmationLetterPresenter do
+  let(:registration) { create(:registration, :with_active_exemptions) }
+  subject { described_class.new(registration) }
+
+  describe "#business_details_section" do
+    context "when the registration is a sole trader" do
+      let(:registration) { create(:registration, :sole_trader, :with_active_exemptions) }
+
+      it "returns an array with the correct data and labels" do
+        address = registration.operator_address
+        address_text = [
+          address.organisation,
+          address.premises,
+          address.street_address,
+          address.locality,
+          address.city,
+          address.postcode
+        ].reject(&:blank?).join(", ")
+
+        expected_array = [
+          "Business or organisation type: Individual or sole trader",
+          "Business or organisation name: #{registration.operator_name}",
+          "Business or organisation address: #{address_text}"
+        ]
+
+        expect(subject.business_details_section).to eq(expected_array)
+      end
+    end
+
+    context "when the registration is a partnership" do
+      let(:registration) { create(:registration, :partnership, :with_active_exemptions) }
+
+      it "returns an array with the correct data and labels" do
+        partner_1 = "#{registration.people.first.first_name} #{registration.people.first.last_name}"
+        partner_2 = "#{registration.people.last.first_name} #{registration.people.last.last_name}"
+        address = registration.operator_address
+        address_text = [
+          address.organisation,
+          address.premises,
+          address.street_address,
+          address.locality,
+          address.city,
+          address.postcode
+        ].reject(&:blank?).join(", ")
+
+        expected_array = [
+          "Business or organisation type: Partnership",
+          "Accountable partner 1: #{partner_1}",
+          "Accountable partner 2: #{partner_2}",
+          "Partnership address: #{address_text}"
+        ]
+
+        expect(subject.business_details_section).to eq(expected_array)
+      end
+    end
+
+    context "when the registration is a limited company" do
+      let(:registration) { create(:registration, :limited_company, :with_active_exemptions) }
+
+      it "returns an array with the correct data and labels" do
+        address = registration.operator_address
+        address_text = [
+          address.organisation,
+          address.premises,
+          address.street_address,
+          address.locality,
+          address.city,
+          address.postcode
+        ].reject(&:blank?).join(", ")
+
+        expected_array = [
+          "Business or organisation type: Limited company",
+          "Registered name of the company: #{registration.operator_name}",
+          "Registration number of the company: #{registration.company_no}",
+          "Registered address of the company: #{address_text}"
+        ]
+
+        expect(subject.business_details_section).to eq(expected_array)
+      end
+    end
+  end
+
+  describe "#contact_details_section" do
+    let(:registration) { create(:registration, :with_active_exemptions) }
+
+    it "returns an array with the correct data and labels" do
+      expected_array = [
+        "Name: #{registration.contact_first_name} #{registration.contact_last_name}",
+        "Telephone: #{registration.contact_phone}",
+        "Email: #{registration.contact_email}"
+      ]
+
+      expect(subject.contact_details_section).to eq(expected_array)
+    end
+
+    context "when a contact position is specified" do
+      let(:registration) { create(:registration, :with_active_exemptions, contact_position: "Head of Waste") }
+
+      it "returns an array with the correct data and labels" do
+        expected_array = [
+          "Name: #{registration.contact_first_name} #{registration.contact_last_name}",
+          "Position: Head of Waste",
+          "Telephone: #{registration.contact_phone}",
+          "Email: #{registration.contact_email}"
+        ]
+
+        expect(subject.contact_details_section).to eq(expected_array)
+      end
+    end
+  end
+
+  describe "#location_section" do
+    context "when the site location is an address" do
+      let(:registration) { create(:registration, :site_uses_address, :with_active_exemptions) }
+
+      it "returns an array with the correct data and labels" do
+        address = registration.site_address
+        address_text = [
+          address.organisation,
+          address.premises,
+          address.street_address,
+          address.locality,
+          address.city,
+          address.postcode
+        ].reject(&:blank?).join(", ")
+
+        expected_array = [
+          "Waste operation location: #{address_text}"
+        ]
+
+        expect(subject.location_section).to eq(expected_array)
+      end
+    end
+
+    context "when the site location is a grid reference" do
+      let(:registration) { create(:registration, :with_short_site_description, :with_active_exemptions) }
+
+      it "returns an array with the correct data and labels" do
+        expected_array = [
+          "Grid reference: #{registration.site_address.grid_reference}",
+          "Site details: #{registration.site_address.description}"
+        ]
+
+        expect(subject.location_section).to eq(expected_array)
+      end
+    end
+  end
+
+  describe "#exemptions_section" do
+    let(:registration) { create(:registration, :with_active_exemptions) }
+
+    before do
+      allow_any_instance_of(WasteExemptionsEngine::RegistrationExemption).to receive(:expires_on).and_return(Date.new(2099, 1, 1))
+    end
+
+    it "returns an array with the correct exemptions" do
+      expected_array = []
+      registration.exemptions.each do |exemption|
+        expected_array << "#{exemption.code}: #{exemption.summary} – Expires on 1 January 2099"
+      end
+
+      expect(subject.exemptions_section).to eq(expected_array)
+    end
+
+    context "when some exemptions are not active" do
+      before do
+        registration.registration_exemptions[1].update(state: "ceased")
+        registration.registration_exemptions[2].update(state: "revoked")
+      end
+
+      it "only lists active exemptions" do
+        active_exemption = registration.exemptions[0]
+        expected_array = [
+          "#{active_exemption.code}: #{active_exemption.summary} – Expires on 1 January 2099"
+        ]
+  
+        expect(subject.exemptions_section).to eq(expected_array)
+      end
+    end
+  end
+
+  describe "#deregistered_exemptions_section" do
+    let(:registration) { create(:registration, :with_active_exemptions) }
+
+    before do
+      allow_any_instance_of(WasteExemptionsEngine::RegistrationExemption).to receive(:deregistered_at).and_return(Date.new(2000, 1, 1))
+
+      registration.registration_exemptions[1].update(state: "ceased")
+      registration.registration_exemptions[2].update(state: "revoked")
+    end
+
+    it "only lists inactive exemptions" do
+      ceased_exemption = registration.exemptions[1]
+      revoked_exemption = registration.exemptions[2]
+      expected_array = [
+        "#{ceased_exemption.code}: #{ceased_exemption.summary} – Ceased on 1 January 2000",
+        "#{revoked_exemption.code}: #{revoked_exemption.summary} – Revoked on 1 January 2000"
+      ]
+
+      expect(subject.deregistered_exemptions_section).to eq(expected_array)
+    end
+  end
+end

--- a/spec/presenters/notify_confirmation_letter_presenter_spec.rb
+++ b/spec/presenters/notify_confirmation_letter_presenter_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe NotifyConfirmationLetterPresenter do
       let(:registration) { create(:registration, :partnership, :with_active_exemptions) }
 
       it "returns an array with the correct data and labels" do
-        partner_1 = "#{registration.people.first.first_name} #{registration.people.first.last_name}"
-        partner_2 = "#{registration.people.last.first_name} #{registration.people.last.last_name}"
+        first_partner = "#{registration.people.first.first_name} #{registration.people.first.last_name}"
+        second_partner = "#{registration.people.last.first_name} #{registration.people.last.last_name}"
         address = registration.operator_address
         address_text = [
           address.organisation,
@@ -49,8 +49,8 @@ RSpec.describe NotifyConfirmationLetterPresenter do
 
         expected_array = [
           "Business or organisation type: Partnership",
-          "Accountable partner 1: #{partner_1}",
-          "Accountable partner 2: #{partner_2}",
+          "Accountable partner 1: #{first_partner}",
+          "Accountable partner 2: #{second_partner}",
           "Partnership address: #{address_text}"
         ]
 
@@ -177,7 +177,7 @@ RSpec.describe NotifyConfirmationLetterPresenter do
         expected_array = [
           "#{active_exemption.code}: #{active_exemption.summary} – Expires on 1 January 2099"
         ]
-  
+
         expect(subject.exemptions_section).to eq(expected_array)
       end
     end

--- a/spec/presenters/notify_confirmation_letter_presenter_spec.rb
+++ b/spec/presenters/notify_confirmation_letter_presenter_spec.rb
@@ -6,6 +6,25 @@ RSpec.describe NotifyConfirmationLetterPresenter do
   let(:registration) { create(:registration, :with_active_exemptions) }
   subject { described_class.new(registration) }
 
+  describe "#date_registered" do
+    it "returns the correct value" do
+      expect(registration.registration_exemptions.first).to receive(:registered_on).and_return(Date.new(2020, 1, 1))
+      expect(subject.date_registered).to eq("1 January 2020")
+    end
+  end
+
+  describe "#applicant_name" do
+    it "returns the correct value" do
+      expect(subject.applicant_name).to eq("#{registration.applicant_first_name} #{registration.applicant_last_name}")
+    end
+  end
+
+  describe "#contact_name" do
+    it "returns the correct value" do
+      expect(subject.contact_name).to eq("#{registration.contact_first_name} #{registration.contact_last_name}")
+    end
+  end
+
   describe "#business_details_section" do
     context "when the registration is a sole trader" do
       let(:registration) { create(:registration, :sole_trader, :with_active_exemptions) }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1190

This is the presenter that will be used for formatting text needed in the AD confirmation letter, as implemented in Notify.

Because some of the formatting for this can be rather complicated, with lots of conditions around what is displayed and how, we have to do a lot of this in the presenter before we send any of it to the Notify template.