### PR TITLE
Add service and rake task for Notify confirmation letter

### DIFF
--- a/app/services/notify_confirmation_letter_service.rb
+++ b/app/services/notify_confirmation_letter_service.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "notifications/client"
+
+class NotifyConfirmationLetterService < ::WasteExemptionsEngine::BaseService
+  # So we can use displayable_address()
+  include ::WasteExemptionsEngine::ApplicationHelper
+
+  def run(registration:)
+    @registration = NotifyConfirmationLetterPresenter.new(registration)
+
+    client = Notifications::Client.new(WasteExemptionsEngine.configuration.notify_api_key)
+
+    client.send_letter(template_id: template,
+                       personalisation: personalisation)
+  end
+
+  private
+
+  def template
+    "81cae4bd-9f4c-4e14-bf3c-44573cee4f5b"
+  end
+
+  def personalisation
+    {
+      reference: @registration.reference,
+      date_registered: @registration.date_registered,
+      applicant_name: @registration.applicant_name,
+      applicant_email: @registration.applicant_email,
+      applicant_phone: @registration.applicant_phone,
+      business_details: @registration.business_details_section,
+      contact_name: @registration.contact_name,
+      contact_details: @registration.contact_details_section,
+      site_details: @registration.location_section,
+      exemption_details: @registration.exemptions_section,
+      deregistered_exemption_details: @registration.deregistered_exemptions_section,
+      show_deregistered_exemption_details: @registration.deregistered_exemptions_section.present?
+    }.merge(address_lines)
+  end
+
+  def address_lines
+    address_values = [
+      @registration.contact_name,
+      displayable_address(@registration.contact_address)
+    ].flatten
+
+    address_hash = {}
+
+    address_values.each_with_index do |value, index|
+      line_number = index + 1
+      address_hash["address_line_#{line_number}"] = value
+    end
+
+    address_hash
+  end
+end

--- a/lib/tasks/notify.rake
+++ b/lib/tasks/notify.rake
@@ -15,5 +15,12 @@ namespace :notify do
 
       SecondRenewalReminderEmailService.run(registration: registration)
     end
+
+    desc "Send a test confirmation letter to the newest registration in the DB"
+    task ad_confirmation_letter: :environment do
+      registration = WasteExemptionsEngine::Registration.last
+
+      NotifyConfirmationLetterService.run(registration: registration)
+    end
   end
 end

--- a/spec/cassettes/notify_confirmation_letter.yml
+++ b/spec/cassettes/notify_confirmation_letter.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.notifications.service.gov.uk/v2/notifications/letter
+    body:
+      encoding: UTF-8
+      string: '{"template_id":"81cae4bd-9f4c-4e14-bf3c-44573cee4f5b","personalisation":{"reference":"WEX000001","date_registered":"10
+        January 2021","applicant_name":"Firstapp1 Lastapp1","applicant_email":"applicant1@example.com","applicant_phone":"01234567890","business_details":["Business
+        or organisation type: Limited company","Registered name of the company: Operator
+        1","Registration number of the company: 09360070","Registered address of the
+        company: premises_1, street_address_1, locality_1, city_1, BS1 1AA"],"contact_name":"Firstcontact1
+        Lastcontact1","contact_details":["Name: Firstcontact1 Lastcontact1","Telephone:
+        01234567890","Email: contact1@example.com"],"site_details":["Grid reference:
+        ST 58337 72855","Site details: The waste is stored in an out-building next
+        to the barn."],"exemption_details":["F1: Use of spam in cooking – Expires
+        on 10 January 2024","F2: Use of spam in cooking – Expires on 10 January 2024","F3:
+        Use of spam in cooking – Expires on 10 January 2024"],"deregistered_exemption_details":[],"show_deregistered_exemption_details":false,"address_line_1":"Firstcontact1
+        Lastcontact1","address_line_2":"premises_2","address_line_3":"street_address_2","address_line_4":"locality_2","address_line_5":"city_2","address_line_6":"BS1
+        1AA"}}'
+    headers:
+      User-Agent:
+      - NOTIFY-API-RUBY-CLIENT/5.3.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic <API_KEY>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type,Authorization
+      Access-Control-Allow-Methods:
+      - GET,PUT,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 10 Jan 2021 14:04:54 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-B3-Spanid:
+      - a09e63cae73ffc89
+      X-B3-Traceid:
+      - a09e63cae73ffc89
+      X-Vcap-Request-Id:
+      - 52f7d1b4-89be-410c-6ae2-74184e43f784
+      Content-Length:
+      - '2631'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"content":{"body":"Dear Firstcontact1 Lastcontact1\r\n\r\n# Your reference:
+        WEX000001\r\n\r\nCheck on the back of this sheet as this may print on more
+        than one page.\r\n\r\n# Your responsibilities\r\n\r\nThe business or organisation
+        responsible for carrying out the exempt waste operations agrees to:\r\n\r\n-
+        comply with all conditions governing how waste must be stored, handled and
+        treated\r\n- carry out the operations without endangering human health or
+        harming the environment\r\n\r\nFor the operations to remain exempt they must
+        be carried out without:\r\n\r\n- causing risk to water, air, soil, plants
+        or animals\r\n- causing a nuisance through noise and odours\r\n- negatively
+        affecting the countryside or places of special interest\r\n\r\nIn sensitive
+        locations extra controls may be needed over and above those set out in the
+        exemptions to make sure this happens.\r\n\r\n# Registration details\r\n\r\nReference
+        number: WEX000001\r\nActivation date: 10 January 2021\r\n\r\n# Registration
+        completed by\r\n\r\n- Name: Firstapp1 Lastapp1\r\n- Business telephone number:
+        01234567890\r\n- Business email: applicant1@example.com\r\n\r\n# Business
+        details\r\n\r\n\n\n* Business or organisation type: Limited company\n* Registered
+        name of the company: Operator 1\n* Registration number of the company: 09360070\n*
+        Registered address of the company: premises_1, street_address_1, locality_1,
+        city_1, BS1 1AA\r\n\r\n# Waste operation contact\r\n\r\n\n\n* Name: Firstcontact1
+        Lastcontact1\n* Telephone: 01234567890\n* Email: contact1@example.com\r\n\r\n#
+        Waste operation location or site\r\n\r\n\n\n* Grid reference: ST 58337 72855\n*
+        Site details: The waste is stored in an out-building next to the barn.\r\n\r\n#
+        Waste exemptions\r\n\r\n\n\n* F1: Use of spam in cooking \u2013 Expires on
+        10 January 2024\n* F2: Use of spam in cooking \u2013 Expires on 10 January
+        2024\n* F3: Use of spam in cooking \u2013 Expires on 10 January 2024\r\n\r\n\r\n\r\n\r\n\r\n#
+        If you need to contact us\r\n\r\nIf you need help or advice call the Environment
+        Agency helpline: 03708 506506\r\n\r\nIt''s open Monday to Friday, between
+        8am and 6pm.\r\n\r\nYours sincerely,\r\nWaste Exemptions Team","subject":"Confirmation
+        of waste exemption registration"},"id":"b1c8f502-cde1-41d1-9ce7-ea501ba31934","reference":null,"scheduled_for":null,"template":{"id":"81cae4bd-9f4c-4e14-bf3c-44573cee4f5b","uri":"https://api.notifications.service.gov.uk/services/367ec8d8-ae34-4e85-bb3e-870659f93c43/templates/81cae4bd-9f4c-4e14-bf3c-44573cee4f5b","version":8},"uri":"https://api.notifications.service.gov.uk/v2/notifications/b1c8f502-cde1-41d1-9ce7-ea501ba31934"}
+
+'
+  recorded_at: Sun, 10 Jan 2021 14:04:54 GMT
+recorded_with: VCR 6.0.0

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :address, class: WasteExemptionsEngine::Address do
     sequence :postcode do |n|
-      "BS#{n}AA"
+      "BS#{n}#{n}AA"
     end
 
     sequence :uprn do |n|

--- a/spec/services/notify_confirmation_letter_service_spec.rb
+++ b/spec/services/notify_confirmation_letter_service_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NotifyConfirmationLetterService do
+  describe "run" do
+    let(:registration) { create(:registration) }
+    let(:service) do
+      NotifyConfirmationLetterService.run(registration: registration)
+    end
+
+    it "sends a letter" do
+      VCR.use_cassette("notify_confirmation_letter") do
+        # Make sure it's a real postcode for Notify validation purposes
+        allow_any_instance_of(WasteExemptionsEngine::Address).to receive(:postcode).and_return("BS1 1AA")
+
+        expect_any_instance_of(Notifications::Client).to receive(:send_letter).and_call_original
+
+        response = service
+
+        expect(response).to be_a(Notifications::Client::ResponseNotification)
+        expect(response.template["id"]).to eq("81cae4bd-9f4c-4e14-bf3c-44573cee4f5b")
+        expect(response.content["subject"]).to include("Confirmation of waste exemption registration")
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1190

This PR adds a service to send confirmation letters to Notify, as well as a rake task for testing.

Also updated the address factory as it wasn't generating valid postcodes.

---

Depends on https://github.com/DEFRA/waste-exemptions-back-office/pull/646