### PR TITLE
Configure WEX AD email address instead of hardcoding

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: 50c23ccbb48f8a70bb0a145258c4087a98438476
+  revision: 01d45d889f47786ee7ae82a3c644a60d3fc51f4c
   branch: main
   specs:
     waste_exemptions_engine (0.0.1)
@@ -211,7 +211,7 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (1.8.8)
+    i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
     jquery-rails (4.4.0)
@@ -242,7 +242,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.1104)
+    mime-types-data (3.2021.0212)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -6,7 +6,7 @@ module WasteExemptionsEngine
   class Registration < ::WasteExemptionsEngine::ApplicationRecord
     include CanBeSearchedLikeRegistration
 
-    NCCC_EMAIL = "waste-exemptions@environment-agency.gov.uk"
+    NCCC_EMAIL = WasteExemptionsEngine.configuration.assisted_digital_email
 
     scope :search_for_site_address_postcode, lambda { |term|
       joins(:addresses).merge(Address.search_for_postcode(term).site)

--- a/app/services/ad_confirmation_letters_export_service.rb
+++ b/app/services/ad_confirmation_letters_export_service.rb
@@ -47,7 +47,7 @@ class AdConfirmationLettersExportService < ::WasteExemptionsEngine::BaseService
 
       WasteExemptionsEngine::Registration
         .order(:reference)
-        .where(contact_email: "waste-exemptions@environment-agency.gov.uk")
+        .where(contact_email: WasteExemptionsEngine.configuration.assisted_digital_email)
         .where(
           id: WasteExemptionsEngine::RegistrationExemption
                 .all_active_exemptions

--- a/config/initializers/waste_exemptions_engine.rb
+++ b/config/initializers/waste_exemptions_engine.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 WasteExemptionsEngine.configure do |configuration|
+  # Assisted digital config
+  configuration.assisted_digital_email = ENV["WEX_ASSISTED_DIGITAL_EMAIL"] ||
+                                         "waste-exemptions@environment-agency.gov.uk"
+
   # General config
   configuration.application_name = "waste-exemptions-back-office"
   configuration.git_repository_url = "https://github.com/DEFRA/waste-exemptions-back-office"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1208

This PR adds configuration for the assisted digital email address, rather than hardcoding it all over multiple apps (ew). Now we can switch it up with an ENV var if we want.