### PR TITLE
Identify registrations which should receive Notify renewal letter

### DIFF
--- a/app/services/bulk_notify_renewal_letters_service.rb
+++ b/app/services/bulk_notify_renewal_letters_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class BulkNotifyRenewalLettersService < ::WasteExemptionsEngine::BaseService
+  def run(expires_on)
+    @expires_on = expires_on
+
+    ad_expiring_registrations.map(&:reference)
+  end
+
+  private
+
+  def ad_expiring_registrations
+    @_ad_expiring_registrations ||= lambda do
+      WasteExemptionsEngine::Registration
+        .order(:reference)
+        .where(contact_email: WasteExemptionsEngine.configuration.assisted_digital_email)
+        .where(
+          id: WasteExemptionsEngine::RegistrationExemption
+                .all_active_exemptions
+                .where(expires_on: @expires_on)
+                .select(:registration_id)
+        )
+    end.call
+  end
+end

--- a/lib/tasks/notify.rake
+++ b/lib/tasks/notify.rake
@@ -1,6 +1,22 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 namespace :notify do
+  namespace :letters do
+    desc "List all registrations which will receive the renewal letter"
+    task ad_renewals: :environment do
+      expires_on = WasteExemptionsBackOffice::Application.config.ad_letters_exports_expires_in.to_i.days.from_now
+
+      registrations = BulkNotifyRenewalLettersService.run(expires_on)
+
+      if registrations.any?
+        puts registrations
+      else
+        puts "No matching registrations"
+      end
+    end
+  end
+
   namespace :test do
     desc "Send a test first renewal reminder email to the newest registration in the DB"
     task first_renewal_reminder: :environment do
@@ -31,3 +47,4 @@ namespace :notify do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -99,6 +99,14 @@ FactoryBot.define do
       end
     end
 
+    trait :with_ceased_exemptions do
+      registration_exemptions { build_list(:registration_exemption, 3, :ceased) }
+    end
+
+    trait :expires_tomorrow do
+      registration_exemptions { build_list(:registration_exemption, 3, :expires_tomorrow) }
+    end
+
     trait :with_short_site_description do
       addresses do
         [build(:address, :operator),

--- a/spec/factories/registration_exemption.rb
+++ b/spec/factories/registration_exemption.rb
@@ -29,5 +29,10 @@ FactoryBot.define do
     trait :with_registration do
       registration
     end
+
+    trait :expires_tomorrow do
+      expires_on { Date.today + 1.day }
+      registered_on { (Date.today + 1.day) - 3.years }
+    end
   end
 end

--- a/spec/lib/tasks/notify_spec.rb
+++ b/spec/lib/tasks/notify_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Notify task", type: :rake do
+  include_context "rake"
+
+  describe "notify:letters:ad_renewals" do
+    it "runs without error" do
+      expect(BulkNotifyRenewalLettersService).to receive(:run).and_return([])
+      expect { subject.invoke }.not_to raise_error
+    end
+  end
+end

--- a/spec/services/bulk_notify_renewal_letters_service_spec.rb
+++ b/spec/services/bulk_notify_renewal_letters_service_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BulkNotifyRenewalLettersService do
+  describe ".run" do
+    let(:ad_registrations) { create_list(:registration, 2, :ad_registration) }
+    let(:non_ad_registration) { create(:registration) }
+    let(:non_matching_date_registration) { create(:registration, :ad_registration, :expires_tomorrow) }
+    let(:inactive_registration) { create(:registration, :ad_registration, :with_ceased_exemptions) }
+
+    let(:expires_on) { ad_registrations.first.registration_exemptions.first.expires_on }
+
+    it "returns a list of relevant references" do
+      expect(Airbrake).to_not receive(:notify)
+
+      expect(described_class.run(expires_on)).to eq([ad_registrations[0].reference,
+                                                     ad_registrations[1].reference])
+      expect(described_class.run(expires_on)).to_not include(non_ad_registration.reference)
+      expect(described_class.run(expires_on)).to_not include(non_matching_date_registration.reference)
+      expect(described_class.run(expires_on)).to_not include(inactive_registration.reference)
+    end
+
+    context "when an error happens" do
+      skip "notify Airbrake" do
+        expect_any_instance_of(ApplicationController).to receive(:render_to_string).and_raise("An error")
+        expect(Airbrake).to receive(:notify)
+
+        expect { described_class.run(expires_on) }.to raise_error("An error")
+      end
+    end
+
+    context "when there are no registrations" do
+      let(:expires_on) { 500.years.ago }
+
+      it "returns a result" do
+        expect(described_class.run(expires_on)).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1246

This PR creates the BulkNotifyRenewalLettersService, which will ultimately be responsible for sending the renewal letters via Notify. But for now it just identifies which registrations should receive the letter.

This can be tested using `rake notify:letters:ad_renewals`.