### PR TITLE
Bulk-send AD renewal letters via Notify

### DIFF
--- a/app/services/bulk_notify_renewal_letters_service.rb
+++ b/app/services/bulk_notify_renewal_letters_service.rb
@@ -4,10 +4,21 @@ class BulkNotifyRenewalLettersService < ::WasteExemptionsEngine::BaseService
   def run(expires_on)
     @expires_on = expires_on
 
-    ad_expiring_registrations.map(&:reference)
+    ad_expiring_registrations.each do |registration|
+      send_letter(registration)
+    end
+
+    ad_expiring_registrations
   end
 
   private
+
+  def send_letter(registration)
+    NotifyRenewalLetterService.run(registration: registration)
+  rescue StandardError => e
+    Airbrake.notify e
+    Rails.logger.error "Bulk renewal letters error:\n#{e}"
+  end
 
   def ad_expiring_registrations
     @_ad_expiring_registrations ||= lambda do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -42,6 +42,12 @@ every :day, at: (ENV["CLEANUP_TRANSIENT_REGISTRATIONS_RUN_TIME"] || "00:35"), ro
   rake "cleanup:transient_registrations"
 end
 
+# This is the Notify AD renewal letters job. When run it will send out Notify
+# renewal letters for all AD registrations expiring in 35 days' time
+every :day, at: (ENV["NOTIFY_AD_RENEWAL_LETTERS_TIME"] || "02:35"), roles: [:db] do
+  rake "notify:letters:ad_renewals"
+end
+
 # This is the AD renewal letters export job. When run it will generate a single
 # PDF containing renewal reminder letters for all AD registrations expirying
 # in 35 days time

--- a/lib/tasks/notify.rake
+++ b/lib/tasks/notify.rake
@@ -10,9 +10,9 @@ namespace :notify do
       registrations = BulkNotifyRenewalLettersService.run(expires_on)
 
       if registrations.any?
-        puts registrations
+        Rails.logger.info "Notify AD renewal letters sent for #{registrations.map(&:reference).join(', ')}"
       else
-        puts "No matching registrations"
+        Rails.logger.info "No matching registrations for Notify AD renewal letters"
       end
     end
   end

--- a/spec/lib/tasks/notify_spec.rb
+++ b/spec/lib/tasks/notify_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Notify task", type: :rake do
 
   describe "notify:letters:ad_renewals" do
     it "runs without error" do
-      expect(BulkNotifyRenewalLettersService).to receive(:run).and_return([])
+      expect(BulkNotifyRenewalLettersService).to receive(:run).and_return([build(:registration)])
       expect { subject.invoke }.not_to raise_error
     end
   end

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Whenever schedule" do
 
   it "makes sure 'rake' statements exist" do
     rake_jobs = schedule.jobs[:rake]
-    expect(rake_jobs.count).to eq(11)
+    expect(rake_jobs.count).to eq(12)
 
     epr_jobs = rake_jobs.select { |j| j[:task] == "reports:export:epr" }
     bulk_jobs = rake_jobs.select { |j| j[:task] == "reports:export:bulk" }
@@ -75,6 +75,13 @@ RSpec.describe "Whenever schedule" do
 
     expect(job_details[:every][0]).to eq(:day)
     expect(job_details[:every][1][:at]).to eq("00:05")
+  end
+
+  it "picks up the Notify AD renewal letters run frequency and time" do
+    job_details = schedule.jobs[:rake].find { |h| h[:task] == "notify:letters:ad_renewals" }
+
+    expect(job_details[:every][0]).to eq(:day)
+    expect(job_details[:every][1][:at]).to eq("02:35")
   end
 
   it "picks up the export AD renewal letters run frequency and time" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1247

This PR updates the BulkNotifyRenewalLettersService to send a renewal letter for each registration that's due to expire on the given date.

If one letter fails to send, it should notify Errbit but continue working for the rest of the batch.