### PR TITLE
Resend AD renewal letters on demand

### DIFF
--- a/app/controllers/resend_renewal_letter_controller.rb
+++ b/app/controllers/resend_renewal_letter_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class ResendRenewalLetterController < ApplicationController
+  include CanSetFlashMessages
+
+  def new
+    authorize
+
+    @registration = registration
+  end
+
+  def create
+    authorize
+
+    begin
+      NotifyRenewalLetterService.run(registration: registration)
+
+      flash_success I18n.t("resend_renewal_letter.messages.success", reference: registration.reference)
+    rescue StandardError => e
+      Airbrake.notify e, registration: registration.reference
+      Rails.logger.error "Failed to re-send renewal letter for registration #{registration.reference}"
+
+      message = I18n.t("resend_renewal_letter.messages.failure", reference: registration.reference)
+      description = I18n.t("resend_renewal_letter.messages.failure_details")
+
+      flash_error(message, description)
+    end
+
+    redirect_to registration_path(registration.reference)
+  end
+
+  private
+
+  def registration
+    @_registration ||= WasteExemptionsEngine::Registration
+                       .find_by(reference: params[:reference])
+  end
+
+  def authorize
+    authorize! :renew, WasteExemptionsEngine::Registration
+  end
+end

--- a/app/views/resend_renewal_letter/new.html.erb
+++ b/app/views/resend_renewal_letter/new.html.erb
@@ -1,0 +1,30 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render("waste_exemptions_engine/shared/back", back_path: registration_path(@registration.reference)) %>
+
+    <h1 class="heading-large">
+      <%= t(".heading") %>
+    </h1>
+
+    <p>
+      <%= t(".paragraph_1", reference: @registration.reference) %>
+    </p>
+
+    <ul class="list">
+      <% displayable_address(@registration.contact_address).each do |line| %>
+        <li><%= line %></li>
+      <% end %>
+    </ul>
+
+    <p>
+      <%= t(".paragraph_2") %>
+    </p>
+
+    <p>
+      <%= link_to t(".send_link"), resend_renewal_letter_path(@registration.reference), method: :post, class: "button" %>
+    </p>
+    <p>
+      <%= link_to t(".do_not_send_link"), registration_path(@registration.reference) %>
+    </p>
+  </div>
+</div>

--- a/app/views/shared/_resource_details.html.erb
+++ b/app/views/shared/_resource_details.html.erb
@@ -156,6 +156,9 @@
             <% end %>
           </li>
           <li>
+            <%= link_to t(".actions.resend_renewal_letter"), resend_renewal_letter_path(resource.reference) %>
+          </li>
+          <li>
             <%= link_to t(".actions.renewal_letter"), renewal_letter_path(resource), id: "renewal_letter_#{resource.reference}", target: "_blank" %>
           </li>
         <% elsif display_renew_window_closed_text_for?(resource) %>

--- a/config/locales/partials/resource_details.en.yml
+++ b/config/locales/partials/resource_details.en.yml
@@ -69,6 +69,7 @@ en:
         resend_renew_email:
           link_text: "Resend renewal email"
           visually_hidden_text: "of %{name}"
+        resend_renewal_letter: "Resend renewal letter"
         renewal_letter: "View renewal letter"
       no_applicant_data: "No applicant details"
       no_contact_data: "No contact details"

--- a/config/locales/resend_renewal_letter.en.yml
+++ b/config/locales/resend_renewal_letter.en.yml
@@ -1,0 +1,12 @@
+en:
+  resend_renewal_letter:
+    new:
+      heading: "Are you sure you want to resend this renewal letter?"
+      paragraph_1: "The renewal letter for %{reference} will be posted to:"
+      paragraph_2: "If you confirm that you want to send this letter, it will automatically be posted by the GOV.UK Notify service."
+      send_link: "Confirm and send letter"
+      do_not_send_link: "Don't send a letter"
+    messages:
+      success: Renewal letter sent to %{reference}
+      failure: We could not send a renewal letter to %{reference}
+      failure_details: The error has been logged. Try again later or contact an administrator.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,14 @@ Rails.application.routes.draw do
        to: "resend_confirmation_letter#create",
        as: "resend_confirmation_letter"
 
+  get "/resend-renewal-letter/:reference",
+      to: "resend_renewal_letter#new",
+      as: "confirm_resend_renewal_letter"
+
+  post "/resend-renewal-letter/:reference",
+       to: "resend_renewal_letter#create",
+       as: "resend_renewal_letter"
+
   # Engine
   mount WasteExemptionsEngine::Engine => "/"
 

--- a/spec/requests/resend_renewal_letter_spec.rb
+++ b/spec/requests/resend_renewal_letter_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "ResendRenewalLetter", type: :request do
+  let(:registration) { create(:registration) }
+
+  describe "GET /resend-renewal-letter/:reference" do
+    let(:request_path) { "/resend-renewal-letter/#{registration.reference}" }
+
+    before { sign_in(user) if defined?(user) }
+
+    context "when a data agent user is signed in" do
+      let(:user) { create(:user, :data_agent) }
+
+      it "redirects to permission page" do
+        get request_path, params: {}, headers: { "HTTP_REFERER" => "/" }
+        follow_redirect!
+
+        expect(response).to render_template("pages/permission")
+      end
+    end
+
+    context "when an admin agent user is signed in" do
+      let(:user) { create(:user, :admin_agent) }
+
+      it "returns a 200 code and includes the correct data" do
+        get request_path, params: {}, headers: { "HTTP_REFERER" => "/" }
+
+        expect(response.code).to eq("200")
+        expect(response.body).to include(registration.contact_address.postcode)
+      end
+    end
+  end
+
+  describe "POST /resend-renewal-letter/:reference" do
+    let(:request_path) { "/resend-renewal-letter/#{registration.reference}" }
+
+    before { sign_in(user) if defined?(user) }
+
+    context "when a data agent user is signed in" do
+      let(:user) { create(:user, :data_agent) }
+
+      it "redirects to permission page" do
+        post request_path, params: {}, headers: { "HTTP_REFERER" => "/" }
+        follow_redirect!
+
+        expect(response).to render_template("pages/permission")
+      end
+    end
+
+    context "when an admin agent user is signed in" do
+      let(:user) { create(:user, :admin_agent) }
+
+      it "return a 302 redirect code" do
+        VCR.use_cassette("notify_renewal_letter") do
+          post request_path, params: {}, headers: { "HTTP_REFERER" => "/" }
+
+          expect(response.code).to eq("302")
+        end
+      end
+
+      it "return a success message" do
+        VCR.use_cassette("notify_renewal_letter") do
+          success_message = I18n.t("resend_renewal_letter.messages.success", reference: registration.reference)
+
+          post request_path, params: {}, headers: { "HTTP_REFERER" => "/" }
+          follow_redirect!
+
+          expect(response.body).to include(success_message)
+        end
+      end
+
+      context "when an error happens", disable_bullet: true do
+        before do
+          expect(NotifyRenewalLetterService).to receive(:run).and_raise(StandardError)
+        end
+
+        it "return a 302 redirect code" do
+          post request_path, params: {}, headers: { "HTTP_REFERER" => "/" }
+
+          expect(response.code).to eq("302")
+        end
+
+        it "return an error message" do
+          error_message = I18n.t("resend_renewal_letter.messages.failure_details")
+
+          post request_path, params: {}, headers: { "HTTP_REFERER" => "/" }
+          follow_redirect!
+
+          expect(response.body).to include(error_message)
+        end
+      end
+    end
+
+    context "when a valid user is not signed in" do
+      before { sign_out(create(:user)) }
+
+      it "redirects to the sign-in page" do
+        post request_path, params: {}, headers: { "HTTP_REFERER" => "/" }
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1268

Currently there is a way to "view" an old renewal letter PDF. This is generally used when we want to resend a letter to someone on demand.

Since we are moving these letters to Notify, this PR adds the ability to resend the letters via Notify instead.