### PR TITLE
Confirmation letters can only be resent to active regs

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -40,7 +40,7 @@ module ActionLinksHelper
   end
 
   def display_confirmation_letter_link_for?(resource)
-    resource.is_a?(WasteExemptionsEngine::Registration)
+    resource.is_a?(WasteExemptionsEngine::Registration) && resource.active?
   end
 
   def display_renew_links_for?(resource)

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -186,8 +186,22 @@ RSpec.describe ActionLinksHelper, type: :helper do
     context "when the resource is a registration" do
       let(:resource) { create(:registration) }
 
-      it "returns true" do
-        expect(helper.display_confirmation_letter_link_for?(resource)).to eq(true)
+      context "when the registration is active" do
+        it "returns true" do
+          expect(helper.display_confirmation_letter_link_for?(resource)).to eq(true)
+        end
+      end
+
+      context "when the resource is an inactive registration" do
+        let(:resource) do
+          registration = create(:registration)
+          registration.registration_exemptions.each(&:revoke!)
+          registration
+        end
+
+        it "returns false" do
+          expect(helper.display_confirmation_letter_link_for?(resource)).to eq(false)
+        end
       end
     end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1268

This updates the logic on the action links so users aren't given the option to resend confirmation letters for registrations which are not active (either because they were expired, ceased or revoked).