### PR TITLE
Remove config for AWS letters bucket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ jobs:
       AWS_BULK_EXPORT_ACCESS_KEY_ID: keyid
       AWS_BULK_EXPORT_SECRET_ACCESS_KEY: secretkey
       AWS_BULK_EXPORT_BUCKET: bulk-exports
-      AWS_LETTERS_EXPORT_ACCESS_KEY_ID: keyid
-      AWS_LETTERS_EXPORT_SECRET_ACCESS_KEY: secretkey
-      AWS_LETTERS_EXPORT_BUCKET: letters-exports
       AWS_BOXI_EXPORT_ACCESS_KEY_ID: keyid
       AWS_BOXI_EXPORT_SECRET_ACCESS_KEY: secretkey
       AWS_BOXI_EXPORT_BUCKET: boxi-exports

--- a/config/application.rb
+++ b/config/application.rb
@@ -62,7 +62,6 @@ module WasteExemptionsBackOffice
 
     # Data export config
     config.bulk_reports_bucket_name = ENV["AWS_BULK_EXPORT_BUCKET"]
-    config.letters_export_bucket_name = ENV["AWS_LETTERS_EXPORT_BUCKET"]
     config.epr_reports_bucket_name = ENV["AWS_DAILY_EXPORT_BUCKET"]
     config.boxi_exports_bucket_name = ENV["AWS_BOXI_EXPORT_BUCKET"]
     config.epr_export_filename = ENV["EPR_DAILY_REPORT_FILE_NAME"] || "waste_exemptions_epr_daily_full"

--- a/config/initializers/defra_ruby_aws.rb
+++ b/config/initializers/defra_ruby_aws.rb
@@ -34,16 +34,6 @@ DefraRuby::Aws.configure do |c|
     encrypt_with_kms: ENV["AWS_BOXI_ENCRYPT_WITH_KMS"]
   }
 
-  letters_export_bucket = {
-    name: ENV["AWS_LETTERS_EXPORT_BUCKET"],
-    region: ENV["AWS_REGION"],
-    credentials: {
-      access_key_id: ENV["AWS_LETTERS_EXPORT_ACCESS_KEY_ID"],
-      secret_access_key: ENV["AWS_LETTERS_EXPORT_SECRET_ACCESS_KEY"]
-    },
-    encrypt_with_kms: ENV["AWS_LETTERS_ENCRYPT_WITH_KMS"]
-  }
-
-  c.buckets = [bulk_bucket, epr_bucket, boxi_export_bucket, letters_export_bucket]
+  c.buckets = [bulk_bucket, epr_bucket, boxi_export_bucket]
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
We no longer use this bucket as all letters go through Notify.