### PR TITLE
Update minimum Rails version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem "pgreset"
 # See: https://github.com/sass/sassc-rails/issues/114
 gem "sassc-rails"
 # Bundle edge Rails instead: gem "rails', github: 'rails/rails'
-gem "rails", "~> 6.0.3.1"
+gem "rails", "~> 6.0.3.7"
 # Use SCSS for stylesheets
 # gem "sass-rails", "~> 5.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -502,7 +502,7 @@ DEPENDENCIES
   pg (~> 0.18.4)
   pgreset
   pry-byebug
-  rails (~> 6.0.3.1)
+  rails (~> 6.0.3.7)
   rails-controller-testing
   rspec-rails
   rubyzip


### PR DESCRIPTION
As part of dealing with this security issue: https://www.ruby-lang.org/en/news/2021/05/02/os-command-injection-in-rdoc/