### PR TITLE
Styling: Dashboard

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,7 @@
 @import "defra_ruby_template";
+@import "partials/pagination";
+
+.actions-panel {
+  background-color: #f8f8f8;
+  padding: 10px;
+}

--- a/app/assets/stylesheets/partials/_pagination.scss
+++ b/app/assets/stylesheets/partials/_pagination.scss
@@ -1,0 +1,66 @@
+// Cribbed from https://home-office-digital-patterns.herokuapp.com/components/pagination
+.pagination .pagination_list-items {
+
+  li {
+    display: inline-block;
+    a {
+      // @extend .bold-small;
+      color: $govuk-brand-colour;
+      display: inline-block;
+      margin-right: 15px;
+      padding: 15px 5px 10px 5px;
+      text-decoration: none;
+
+      &:focus {
+        outline: 0;
+      }
+    }
+    &.active a,
+    &.active a:hover {
+      -webkit-box-shadow: inset 0px -5px 0px 0px $govuk-brand-colour;
+      -moz-box-shadow: inset 0px -5px 0px 0px $govuk-brand-colour;
+      box-shadow: inset 0px -5px 0px 0px $govuk-brand-colour;
+      color: $govuk-brand-colour;
+    }
+  }
+}
+
+.pagination {
+  margin-bottom: 30px;
+  padding: 0;
+}
+.pagination__item {
+  display: inline-block;
+  list-style: none;
+}
+.pagination__link {
+  display: block;
+  padding: 5px 10px;
+  text-decoration: none;
+
+  &:hover, &:focus {
+    background: govuk-colour("light-grey");
+    outline: 3px solid $govuk-focus-colour;
+  }
+
+  &.current {
+    border: none;
+    color: $govuk-link-active-colour;
+    cursor: default;
+    font-weight: 700;
+    pointer-events: none;
+
+    &:hover, &:focus {
+      background: none;
+      color: $govuk-link-active-colour;
+    }
+  }
+}
+
+.pagination__summary {
+  padding: 15px 0;
+
+  @media (min-width: 642px) {
+    float: right;
+  }
+}

--- a/app/views/dashboards/_actions.html.erb
+++ b/app/views/dashboards/_actions.html.erb
@@ -1,0 +1,13 @@
+<div class="actions-panel">
+  <h2 class="govuk-heading-s">
+    <%= t(".user_info.heading") %>
+  </h2>
+  <p class="govuk-body">
+    <%= t(".user_info.signed_in_user") %>
+    <span><%= current_user.email %></span>
+  </p>
+  <% if can? :create, WasteExemptionsEngine::Registration.new %>
+    <p class="govuk-body"><%= link_to t(".user_info.new_registration_link"), ad_privacy_policy_path %></p>
+  <% end %>
+  <p><%= link_to t(".user_info.sign_out_link"), destroy_user_session_path, class: "govuk-button" %></p>
+</div>

--- a/app/views/dashboards/_form.html.erb
+++ b/app/views/dashboards/_form.html.erb
@@ -1,0 +1,37 @@
+<%= form_tag(root_path, method: :get) do %>
+  <fieldset id="search-filters" class="govuk-fieldset">
+    <legend class="govuk-visually-hidden">
+      <%= t(".search.filters.legend") %>
+    </legend>
+
+    <div class="govuk-radios">
+      <div class="govuk-radios__item">
+        <%= radio_button_tag :filter,
+                             :registrations,
+                             preselect_registrations_radio_button?,
+                             class: "govuk-radios__input" %>
+        <%= label_tag "filter_registrations",
+                      t(".search.filters.registrations"),
+                      class: "govuk-label govuk-radios__label" %>
+      </div>
+      <div class="govuk-radios__item">
+        <%= radio_button_tag :filter,
+                             :new_registrations,
+                             preselect_new_registrations_radio_button?,
+                             class: "govuk-radios__input" %>
+        <%= label_tag "filter_new_registrations",
+                      t(".search.filters.new_registrations"),
+                      class: "govuk-label govuk-radios__label" %>
+      </div>
+    </div>
+  </fieldset>
+
+  <p>
+    <%= label_tag :term, t(".search.label"), class: "govuk-visually-hidden" %>
+    <%= text_field_tag :term, @term, placeholder: t(".search.placeholder"), class: "govuk-input" %>
+  </p>
+
+  <p>
+    <%= submit_tag t(".search.submit"), class: "govuk-button" %>
+  </p>
+<% end %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -1,73 +1,23 @@
-<div class="grid-row">
-  <div class="column-full">
-    <h1 class="heading-large">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
       <%= t(".heading") %>
     </h1>
-  </div>
-</div>
-
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <p><%= t(".search.paragraph_1") %></p>
-    <ul class="list list-bullet">
-      <% t(".search.searchable_attributes").each do |attribute| %>
-        <li><%= attribute %></li>
-      <% end %>
-    </ul>
-
-    <div class="form-group">
-      <%= form_tag(root_path, method: :get) do %>
-        <%= label_tag :term, t(".search.label"), class: "form-label visually-hidden" %>
-        <%= text_field_tag :term, @term, placeholder: t(".search.placeholder"), class: "form-control" %>
-        <%= submit_tag t(".search.submit"), class: "button" %>
-
-        <div class="filters">
-          <div class="form-group">
-            <fieldset id="search-filters">
-              <legend class="visually-hidden">
-                <%= t(".search.filters.legend") %>
-              </legend>
-              <div class="multiple-choice">
-                <%= radio_button_tag :filter,
-                                     :registrations,
-                                     preselect_registrations_radio_button? %>
-                <%= label_tag "filter_registrations",
-                              t(".search.filters.registrations") %>
-              </div>
-              <div class="multiple-choice">
-                <%= radio_button_tag :filter,
-                                     :new_registrations,
-                                     preselect_new_registrations_radio_button? %>
-                <%= label_tag "filter_new_registrations",
-                              t(".search.filters.new_registrations") %>
-              </div>
-            </fieldset>
-          </div>
-        </div>
-      <% end %>
-    </div>
+    <p class="govuk-body">
+      <%= t(".paragraph_1") %>
+      <%= t(".searchable_attributes").to_sentence %>
+    </p>
+    <%= render partial: "form" %>
   </div>
 
-  <div class="column-one-third">
-    <div class="user-info">
-      <h2 class="heading-medium">
-        <%= t(".user_info.heading") %>
-      </h2>
-      <p>
-        <%= t(".user_info.signed_in_user") %>
-        <span><%= current_user.email %></span>
-      </p>
-      <% if can? :create, WasteExemptionsEngine::Registration.new %>
-        <p><%= link_to t(".user_info.new_registration_link"), ad_privacy_policy_path %></p>
-      <% end %>
-      <p><%= link_to t(".user_info.sign_out_link"), destroy_user_session_path, class: "button" %></p>
-    </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "actions" %>
   </div>
 </div>
 
 <% if flash[:message].present? || flash[:error].present? %>
-  <div class="grid-row">
-    <div class="column-full">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <%= render("shared/message", message: flash[:message]) if flash[:message].present? %>
       <%= render("shared/error", error: flash[:error], details: flash[:error_details]) if flash[:error].present? %>
     </div>
@@ -76,14 +26,13 @@
 
 <% if @results.present? %>
   <div id="search-results">
-  <% @results.each do |result| %>
-    <%= render("shared/search_result", result: result) %>
-  <% end %>
+    <% @results.each do |result| %>
+      <%= render("shared/search_result", result: result) %>
+    <% end %>
   </div>
-
-  <div class="grid-row">
-    <div class="column-full">
-      <nav role="navigation" class="pagination" aria-label="Pagination">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <nav role="navigation" class="pagination govuk-body" aria-label="Pagination">
         <div class="pagination__summary">
           <%= page_entries_info @results, entry_name: "item" %>
         </div>
@@ -92,9 +41,9 @@
     </div>
   </div>
 <% elsif @term.present? %>
-  <div class="grid-row">
-    <div class="column-full">
-      <%= t(".no_results") %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <p class="govuk-body"><%= t(".no_results") %></p>
     </div>
   </div>
 <% end %>

--- a/app/views/shared/_error.html.erb
+++ b/app/views/shared/_error.html.erb
@@ -1,8 +1,8 @@
-<div class="error-summary" role="alert" aria-labelledby="error-summary-heading-1">
-  <h2 class="heading-medium error-summary-heading" id="error-summary-heading-1">
+<div class="govuk-error-summary" role="alert" aria-labelledby="error-summary-heading-1">
+  <h2 class="govuk-heading-m error-summary-heading" id="error-summary-heading-1">
     <%= error %>
   </h2>
-  <p>
-    <%= details%>
+  <p class="govuk-body">
+    <%= details %>
   </p>
 </div>

--- a/app/views/shared/_message.html.erb
+++ b/app/views/shared/_message.html.erb
@@ -1,5 +1,5 @@
-<div class="error-summary flash_message" role="alert" aria-labelledby="message-summary-heading-1" tabindex="-1">
-  <h2 class="heading-medium error-summary-heading" id="message-summary-heading-1">
+<div class="govuk-error-summary flash_message" role="alert" aria-labelledby="message-summary-heading-1" tabindex="-1">
+  <h2 class="govuk-heading-m error-summary-heading" id="message-summary-heading-1">
     <%= message %>
   </h2>
 </div>

--- a/app/views/shared/_search_result.html.erb
+++ b/app/views/shared/_search_result.html.erb
@@ -1,145 +1,141 @@
-<div class="grid-row registration-list" id="<%= result.reference %>">
-  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-  <div class="column-one-quarter">
-    <ul class="registration-details">
-      <li>
-        <span><%= t(".labels.status") %></span>
-        <span class="<%= "status-tag-#{status_tag_for(result)}" %>"><%= t(".statuses.#{status_tag_for(result)}") %></span>
-      </li>
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-      <% if result.operator_name.present? %>
-        <li>
-          <span><%= t(".labels.operator_name") %></span>
+<div class="govuk-grid-row" id="<%= result.reference %>">
+  <div class="govuk-grid-column-two-thirds">
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= t(".labels.status") %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <span class="<%= "status-tag-#{status_tag_for(result)}" %>"><%= t(".statuses.#{status_tag_for(result)}") %></span>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= t(".labels.operator_name") %>
+        </dt>
+        <dd class="govuk-summary-list__value">
           <%= result.operator_name %>
-        </li>
-      <% end %>
-
-      <% if result.reference.present? %>
-        <li>
-          <span><%= t(".labels.reference") %></span>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= t(".labels.reference") %>
+        </dt>
+        <dd class="govuk-summary-list__value">
           <%= result.reference %>
-        </li>
-      <% end %>
-    </ul>
-  </div>
-  <div class="column-one-quarter">
-    <% if result.site_address.present? %>
-      <ul class="registration-details">
-        <% if result.site_address.postcode.present? %>
-          <li>
-            <span><%= t(".labels.address") %></span>
-            <ul>
-              <% displayable_address(result.site_address).each do |address_line| %>
-                <li><%= address_line %></li>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= t(".labels.applicant") %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= result.applicant_first_name %> <%= result.applicant_last_name %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= t(".labels.contact") %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= result.contact_first_name %> <%= result.contact_last_name %>
+        </dd>
+      </div>
+      <% if result.business_type == "partnership" %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= t(".labels.partners") %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <ul class="govuk-list">
+              <% result.people.each do |partner| %>
+                <li><%= partner.first_name %> <%= partner.last_name %></li>
               <% end %>
             </ul>
-          </li>
-        <% end %>
+          </dd>
+        </div>
+      <% end %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= t(".labels.grid_reference") %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= result.site_address.grid_reference %>
+        </dd>
+      </div>
+    </dl>
+  </div>
 
-        <% if result.site_address.grid_reference.present? %>
-          <li>
-            <span><%= t(".labels.grid_reference") %></span>
-            <%= result.site_address.grid_reference %>
-          </li>
+  <div class="govuk-grid-column-one-third registration-details">
+    <h2 class="govuk-heading-m">
+      <%= t(".labels.actions") %>
+    </h2>
+
+    <p class="govuk-body">
+      <%= link_to view_link_for(result), id: "view_#{result.reference}" do %>
+        <%= t(".actions.view.link_text") %>
+        <span class="govuk-visually-hidden">
+          <%= t(".actions.view.visually_hidden_text",
+                name: result_name_for_visually_hidden_text(result)) %>
+        </span>
+      <% end %>
+    </p>
+
+    <% if display_edit_link_for?(result) %>
+      <p class="govuk-body">
+        <%= link_to edit_link_for(result), id: "edit_#{result.reference}" do %>
+          <%= t(".actions.edit.link_text") %>
+          <span class="govuk-visually-hidden">
+           <%= t(".actions.edit.visually_hidden_text",
+                 name: result_name_for_visually_hidden_text(result)) %>
+         </span>
         <% end %>
-      </ul>
-    <% else %>
-      <br>
+      </p>
     <% end %>
-  </div>
 
-  <div class="column-one-quarter">
-    <ul class="registration-details">
-      <% if result.applicant_first_name.present? %>
-        <li>
-          <span><%= t(".labels.applicant") %></span>
-          <%= result.applicant_first_name %> <%= result.applicant_last_name %>
-        </li>
-      <% end %>
+    <% if display_resume_link_for?(result) %>
+      <p class="govuk-body">
+        <%= link_to resume_link_for(result), id: "resume_#{result.reference}" do %>
+          <%= t(".actions.resume.link_text") %>
+          <span class="govuk-visually-hidden">
+           <%= t(".actions.resume.visually_hidden_text",
+                 name: result_name_for_visually_hidden_text(result)) %>
+         </span>
+        <% end %>
+      </p>
+    <% end %>
 
-      <% if result.contact_first_name.present? %>
-      <li>
-        <span><%= t(".labels.contact") %></span>
-        <%= result.contact_first_name %> <%= result.contact_last_name %>
-      </li>
-      <% end %>
+    <% if display_already_renewed_text_for?(result) %>
+      <p class="govuk-body">
+        <%= t(".actions.renew.already_renewed") %>
+      </p>
 
-      <% if result.people.present? && result.business_type == "partnership" %>
-        <li>
-          <span><%= t(".labels.partners") %></span>
-          <ul>
-            <% result.people.each do |partner| %>
-              <li><%= partner.first_name %> <%= partner.last_name %></li>
-            <% end %>
-          </ul>
-        </li>
-      <% end %>
-    </ul>
-  </div>
-  <div class="column-one-quarter">
-    <ul class="registration-details">
-      <li>
-        <span><%= t(".labels.actions") %></span>
-        <ul>
-          <li>
-            <%= link_to view_link_for(result), id: "view_#{result.reference}" do %>
-              <%= t(".actions.view.link_text") %>
-              <span class="visually-hidden">
-                <%= t(".actions.view.visually_hidden_text",
-                      name: result_name_for_visually_hidden_text(result)) %>
-              </span>
-            <% end %>
-          </li>
-          <% if display_edit_link_for?(result) %>
-            <li>
-              <%= link_to edit_link_for(result), id: "edit_#{result.reference}" do %>
-                <%= t(".actions.edit.link_text") %>
-                <span class="visually-hidden">
-                 <%= t(".actions.edit.visually_hidden_text",
-                       name: result_name_for_visually_hidden_text(result)) %>
-               </span>
-              <% end %>
-            </li>
-          <% end %>
+    <% elsif display_renew_links_for?(result) %>
+      <p class="govuk-body">
+        <%= link_to ad_privacy_policy_path(renew_registration: result.reference), id: "renew_#{result.reference}" do %>
+          <%= t(".actions.renew.link_text") %>
+          <span class="govuk-visually-hidden">
+           <%= t(".actions.renew.visually_hidden_text",
+                 name: result_name_for_visually_hidden_text(result)) %>
+          </span>
+        <% end %>
+      </p>
+      <p class="govuk-body">
+        <%= link_to resend_renewal_email_path(reference: result.reference), id: "resend_renew_email_#{result.reference}" do %>
+          <%= t(".actions.resend_renew_email.link_text") %>
+          <span class="govuk-visually-hidden">
+           <%= t(".actions.resend_renew_email.visually_hidden_text",
+                 name: result_name_for_visually_hidden_text(result)) %>
+          </span>
+        <% end %>
+      </p>
 
-          <% if display_resume_link_for?(result) %>
-            <li>
-              <%= link_to resume_link_for(result), id: "resume_#{result.reference}" do %>
-                <%= t(".actions.resume.link_text") %>
-                <span class="visually-hidden">
-                 <%= t(".actions.resume.visually_hidden_text",
-                       name: result_name_for_visually_hidden_text(result)) %>
-               </span>
-              <% end %>
-            </li>
-          <% end %>
-
-          <% if display_already_renewed_text_for?(result) %>
-            <li><%= t(".actions.renew.already_renewed") %></li>
-          <% elsif display_renew_links_for?(result) %>
-            <li>
-              <%= link_to ad_privacy_policy_path(renew_registration: result.reference), id: "renew_#{result.reference}" do %>
-                <%= t(".actions.renew.link_text") %>
-                <span class="visually-hidden">
-                 <%= t(".actions.renew.visually_hidden_text",
-                       name: result_name_for_visually_hidden_text(result)) %>
-                </span>
-              <% end %>
-            </li>
-            <li>
-              <%= link_to resend_renewal_email_path(reference: result.reference), id: "resend_renew_email_#{result.reference}" do %>
-                <%= t(".actions.resend_renew_email.link_text") %>
-                <span class="visually-hidden">
-                 <%= t(".actions.resend_renew_email.visually_hidden_text",
-                       name: result_name_for_visually_hidden_text(result)) %>
-                </span>
-              <% end %>
-            </li>
-          <% elsif display_renew_window_closed_text_for?(result) %>
-            <li><%= t(".actions.renew.renew_window_closed") %></li>
-          <% end %>
-        </ul>
-      </li>
-    </ul>
+    <% elsif display_renew_window_closed_text_for?(result) %>
+      <p class="govuk-body">
+        <%= t(".actions.renew.renew_window_closed") %>
+      </p>
+    <% end %>
   </div>
 </div>

--- a/config/locales/dashboards.en.yml
+++ b/config/locales/dashboards.en.yml
@@ -1,17 +1,20 @@
 en:
   dashboards:
     index:
+      heading: "Waste exemptions dashboard"
       title: "Waste exemptions dashboard"
+      paragraph_1: "You can search for a registration by:"
+      searchable_attributes:
+        - "site postcode"
+        - "registration reference number"
+        - "business or partner name"
+        - "applicant name"
+        - "applicant email"
+        - "contact name"
+        - "contact email"
+      no_results: "No results"
+    form:
       search:
-        paragraph_1: "You can search for a registration by:"
-        searchable_attributes:
-          - "site postcode"
-          - "registration reference number"
-          - "business or partner name"
-          - "applicant name"
-          - "applicant email"
-          - "contact name"
-          - "contact email"
         label: "Search for registrations"
         placeholder: "Enter your search term here"
         filters:
@@ -19,10 +22,10 @@ en:
           registrations: "Submitted"
           new_registrations: "Not yet submitted"
         submit: "Search"
+    actions:
       user_info:
         heading: "Current user"
         signed_in_user: "Signed in as"
         new_registration_link: "Start a new registration"
         sign_out_link: "Sign out"
-      heading: "Waste exemptions dashboard"
-      no_results: "No results"
+


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1642

This PR styles the dashboard. Wireframe: https://2xyt3d.axshare.com/#g=1&p=dashboard

There is a suggestion that the link to 'Resend renewal email' _could_ be removed. Haven't done that here as there would need some analysis/refactoring of the tests