### PR TITLE
Navigation header edits

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,27 +19,27 @@
     <nav id="proposition-menu">
       <ul id="proposition-links" class="govuk-header__navigation" aria-label="Top Level Navigation">
         <li class="govuk-header__navigation-item">
-          <%= link_to t("layouts.application.menu.dashboard"),
+          <%= link_to_unless_current t("layouts.application.menu.dashboard"),
                       main_app.root_path,
                       class: "govuk-header__link" %>
         </li>
         <% if can?(:read, current_user) %>
           <li class="govuk-header__navigation-item">
-            <%= link_to t("layouts.application.menu.users"),
+            <%= link_to_unless_current t("layouts.application.menu.users"),
                         main_app.users_path,
                         class: "govuk-header__link" %>
           </li>
         <% end %>
         <% if can?(:read, Reports::GeneratedReport) %>
           <li class="govuk-header__navigation-item">
-            <%= link_to t("layouts.application.menu.exports"),
+            <%= link_to_unless_current t("layouts.application.menu.exports"),
                         main_app.bulk_exports_path,
                         class: "govuk-header__link" %>
           </li>
         <% end %>
         <% if can?(:manage, WasteExemptionsEngine::FeatureToggle, current_user) %>
           <li class="govuk-header__navigation-item">
-            <%= link_to t("layouts.application.menu.feature_toggles"),
+            <%= link_to_unless_current t("layouts.application.menu.feature_toggles"),
                         features_engine.feature_toggles_path,
                         class: "govuk-header__link" %>
           </li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,27 +19,27 @@
     <nav id="proposition-menu">
       <ul id="proposition-links" class="govuk-header__navigation" aria-label="Top Level Navigation">
         <li class="govuk-header__navigation-item">
-          <%= link_to_unless_current t("layouts.application.menu.dashboard"),
+          <%= link_to t("layouts.application.menu.dashboard"),
                       main_app.root_path,
                       class: "govuk-header__link" %>
         </li>
         <% if can?(:read, current_user) %>
           <li class="govuk-header__navigation-item">
-            <%= link_to_unless_current t("layouts.application.menu.users"),
+            <%= link_to t("layouts.application.menu.users"),
                         main_app.users_path,
                         class: "govuk-header__link" %>
           </li>
         <% end %>
         <% if can?(:read, Reports::GeneratedReport) %>
           <li class="govuk-header__navigation-item">
-            <%= link_to_unless_current t("layouts.application.menu.exports"),
+            <%= link_to t("layouts.application.menu.exports"),
                         main_app.bulk_exports_path,
                         class: "govuk-header__link" %>
           </li>
         <% end %>
         <% if can?(:manage, WasteExemptionsEngine::FeatureToggle, current_user) %>
           <li class="govuk-header__navigation-item">
-            <%= link_to_unless_current t("layouts.application.menu.feature_toggles"),
+            <%= link_to t("layouts.application.menu.feature_toggles"),
                         features_engine.feature_toggles_path,
                         class: "govuk-header__link" %>
           </li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,8 +14,6 @@
       class: "govuk-header__link govuk-header__link--service-name",
       id: "proposition-name" %>
 
-  <%= link_to t(:global_proposition_header), main_app.root_path, id: "proposition-name" %>
-
   <% if user_signed_in? %>
     <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide navigation menu">Menu</button>
     <nav id="proposition-menu">


### PR DESCRIPTION
Remove erroneous link from header (a bug was reported for this: https://eaflood.atlassian.net/browse/RUBY-1642?focusedCommentId=348427)

~~Enable `link_to_unless_current` for navigation links~~ 