### PR TITLE
Styling: Manage users     

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,12 +3,16 @@
 class UsersController < ApplicationController
   def index
     authorize! :read, current_user
-    @users = list_of_users.page params[:page]
+
+    @users = User.where(active: true).order(email: :asc).page(params[:page]).per(100)
   end
 
-  private
+  def all
+    authorize! :read, current_user
 
-  def list_of_users
-    User.all.order(email: :asc)
+    @users = User.all.order(email: :asc).page(params[:page]).per(100)
+
+    @show_all_users = true
+    render :index
   end
 end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,19 +1,18 @@
-<div class="govuk-grid-row">
-  <div class="govuk-column-full">
-    <%= render("waste_exemptions_engine/shared/back", back_path: root_path) %>
+<%= render("waste_exemptions_engine/shared/back", back_path: root_path) %>
 
-    <h1 class="govuk-heading-l">
-      <%= t(".heading") %>
-    </h1>
-  </div>
-</div>
+<h1 class="govuk-heading-l">
+  <%= t(".heading") %>
+</h1>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <p class="govuk-body"><%= link_to t(".invite_user_link_text"), new_user_invitation_path %></p>
-  </div>
-</div>
+<p class="govuk-body"><%= link_to t(".invite_user_link_text"), new_user_invitation_path %></p>
 
+<p class="govuk-body">
+  <% if @show_all_users %>
+    <%= link_to t(".show_enabled_users_only"), users_path %>
+  <% else %>
+    <%= link_to t(".show_all_users"), all_users_path %>
+  <% end %>
+</p>
 
 <% if @users.present? %>
   <div class="govuk-grid-row">

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,42 +1,42 @@
-<div class="grid-row">
-  <div class="column-full">
+<div class="govuk-grid-row">
+  <div class="govuk-column-full">
     <%= render("waste_exemptions_engine/shared/back", back_path: root_path) %>
 
-    <h1 class="heading-large">
+    <h1 class="govuk-heading-l">
       <%= t(".heading") %>
     </h1>
   </div>
 </div>
 
-<div class="grid-row">
-  <div class="column-full">
-    <p><%= link_to t(".invite_user_link_text"), new_user_invitation_path %></p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <p class="govuk-body"><%= link_to t(".invite_user_link_text"), new_user_invitation_path %></p>
   </div>
 </div>
 
 
 <% if @users.present? %>
-  <div class="grid-row">
-    <div class="column-full">
-      <table>
-        <thead>
-          <tr>
-            <th><%= t(".user_list.th.email") %></th>
-            <th><%= t(".user_list.th.role") %></th>
-            <th><%= t(".user_list.th.status") %></th>
-            <th><%= t(".user_list.th.actions") %></th>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <table class="govuk-table" aria-label="<%= t(".heading") %>">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="col"><%= t(".user_list.th.email") %></th>
+            <th class="govuk-table__header" scope="col"><%= t(".user_list.th.role") %></th>
+            <th class="govuk-table__header" scope="col"><%= t(".user_list.th.status") %></th>
+            <th class="govuk-table__header" scope="col"><%= t(".user_list.th.actions") %></th>
           </tr>
         </thead>
-        <tbody>
+        <tbody class="govuk-table__body">
           <% @users.each do |user| %>
-            <tr>
-              <td>
+             <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
                 <%= user.email %>
               </td>
-              <td>
+              <td class="govuk-table__cell">
                 <%= t(".user_list.roles.#{user.role}") %>
               </td>
-              <td>
+              <td class="govuk-table__cell">
                 <% if !user.active? %>
                   <%= t(".user_list.statuses.deactivated") %>
                 <% elsif user.invitation_token.present? %>
@@ -45,12 +45,12 @@
                   <%= t(".user_list.statuses.active") %>
                 <% end %>
               </td>
-              <td>
-                <ul>
+              <td class="govuk-table__cell">
+                <ul class="govuk-list">
                   <li>
                     <%= link_to user_role_form_path(user.id) do %>
                       <%= t(".user_list.actions.change_role.link_text") %>
-                      <span class="visually-hidden">
+                      <span class="govuk-visually-hidden">
                        <%= t(".user_list.actions.change_role.visually_hidden_text",
                              email: user.email) %>
                      </span>
@@ -60,7 +60,7 @@
                     <% if user.active? %>
                       <%= link_to deactivate_user_form_path(user.id) do %>
                         <%= t(".user_list.actions.deactivate.link_text") %>
-                        <span class="visually-hidden">
+                        <span class="govuk-visually-hidden">
                          <%= t(".user_list.actions.deactivate.visually_hidden_text",
                                email: user.email) %>
                        </span>
@@ -68,7 +68,7 @@
                    <% else %>
                      <%= link_to activate_user_form_path(user.id) do %>
                        <%= t(".user_list.actions.activate.link_text") %>
-                       <span class="visually-hidden">
+                       <span class="govuk-visually-hidden">
                         <%= t(".user_list.actions.activate.visually_hidden_text",
                               email: user.email) %>
                       </span>
@@ -81,16 +81,14 @@
           <% end %>
         </tbody>
       </table>
-    </div>
-  </div>
 
-  <div class="grid-row">
-    <div class="column-full">
       <nav role="navigation" class="pagination" aria-label="Pagination">
-        <div class="pagination__summary">
+        <div class="pagination__summary govuk-body">
           <%= page_entries_info @users, entry_name: "item" %>
         </div>
-        <%= paginate @users %>
+        <span class="govuk-body">
+          <%= paginate @users %>
+        </span>
       </nav>
     </div>
   </div>

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -4,6 +4,9 @@ en:
       title: "Manage back office users"
       heading: "Manage back office users"
       invite_user_link_text: "Invite a new user"
+      show_all_users: "Show all users"
+      show_enabled_users_only: "Show enabled users only"
+
       user_list:
         th:
           email: "User email"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
              path_names: { sign_in: "sign_in", sign_out: "sign_out" }
 
   get "/users", to: "users#index", as: :users
+  get "/users/all", to: "users#all", as: :all_users
 
   get "/users/role/:id", to: "user_roles#edit", as: :user_role_form
   post "/users/role/:id", to: "user_roles#update", as: :user_role

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -4,21 +4,24 @@ require "rails_helper"
 
 RSpec.describe "Users", type: :request do
   describe "/users" do
-    context "when a system is signed in" do
+    context "when a system user is signed in" do
       let(:user) { create(:user, :system) }
       before(:each) do
         sign_in(user)
       end
 
-      it "renders the index template, returns a 200 response, includes the correct content and displays a list of users" do
-        listed_user = create(:user, email: "aaaaaaaaaaa@example.com")
+      it "renders the index template, returns a 200 response and includes the correct content" do
+        active_user = create(:user, email: "aaaaaaaaaaa@example.com")
+        deactivated_user = create(:user, email: "aaaaaaaaaaa2@example.com", active: false)
 
         get "/users"
 
         expect(response).to render_template(:index)
         expect(response).to have_http_status(200)
         expect(response.body).to include("Manage back office users")
-        expect(response.body).to include(listed_user.email)
+        expect(response.body).to include("Show all users")
+        expect(response.body).to include(active_user.email)
+        expect(response.body).to_not include(deactivated_user.email)
       end
     end
 
@@ -38,6 +41,49 @@ RSpec.describe "Users", type: :request do
     context "when no user is signed in" do
       it "redirects the user to the sign in page" do
         get "/users"
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "/users/all" do
+    context "when a system user is signed in" do
+      let(:user) { create(:user, :system) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "renders the index template, returns a 200 response and includes the correct content" do
+        active_user = create(:user, email: "aaaaaaaaaaa@example.com")
+        deactivated_user = create(:user, email: "aaaaaaaaaaa2@example.com", active: false)
+
+        get "/users/all"
+
+        expect(response).to render_template(:index)
+        expect(response).to have_http_status(200)
+        expect(response.body).to include("Show enabled users only")
+        expect(response.body).to include(active_user.email)
+        expect(response.body).to include(deactivated_user.email)
+      end
+    end
+
+    context "when a non-system user is signed in" do
+      let(:user) { create(:user, :data_agent) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        get "/users/all"
+
+        expect(response).to redirect_to("/pages/permission")
+      end
+    end
+
+    context "when no user is signed in" do
+      it "redirects the user to the sign in page" do
+        get "/users/all"
 
         expect(response).to redirect_to(new_user_session_path)
       end


### PR DESCRIPTION
 https://eaflood.atlassian.net/browse/RUBY-1647

Styles 'Manage Users' page and adds the following usability enhancements:
- list 100 users per page so the in-browser find feature can be used to search if needed
- only list active and invited users by default
- add a toggle to list deactivated users as well