### PR TITLE
Remove redundant aria-labelledby

### DIFF
--- a/app/views/shared/_message.html.erb
+++ b/app/views/shared/_message.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-notification-banner govuk-notification-banner--success" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+<div class="govuk-notification-banner govuk-notification-banner--success" role="region" data-module="govuk-notification-banner">
   <div class="govuk-notification-banner__content">
     <h3 class="govuk-notification-banner__heading">
       <%= message %>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1646

There's no label for this so we can remove the tag.