### PR TITLE
Bump loofah gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,7 +264,7 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    loofah (2.13.0)
+    loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)


### PR DESCRIPTION
- In response to:
`loofah gem 2.13.0 is vulnerable (CVE-2018-8048). Upgrade to 2.2.1`