### PR TITLE
Revert rubocop-inspired change to config.ru to fix Rails config loading

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -2,5 +2,5 @@
 
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path("../config/environment", __dir__)
+require ::File.expand_path("../config/environment", __FILE__)
 run Rails.application


### PR DESCRIPTION
This change is to undo a change to config.ru which broke Rails config loading.