### PR TITLE
WIP - Remove registrations that have been deregistered for 7 years

### DIFF
--- a/app/services/remove_deletable_registrations_service.rb
+++ b/app/services/remove_deletable_registrations_service.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class RemoveDeletableRegistrationsService < ::WasteExemptionsEngine::BaseService
+  def run
+    log "========================"
+    PaperTrail.enabled = false
+    remove_registrations_deregistered_over_seven_years_ago
+    PaperTrail.enabled = true
+    log "========================"
+  end
+
+  private
+
+  def remove_registrations_deregistered_over_seven_years_ago
+    log "Starting removal of registrations deregistered over 7 years ago"
+
+    registration_exemptions_deregistered_over_seven_years_ago.find_each do |registration_exemption|
+      remove_registration(registration_exemption)
+    end
+
+    log "Removal completed"
+  end
+
+  def registration_exemptions_deregistered_over_seven_years_ago
+    WasteExemptionsEngine::RegistrationExemption
+      .includes(:registration)
+      .where("deregistered_at < ?", 7.years.ago)
+  end
+
+  def remove_registration(registration_exemption)
+    registration = registration_exemption.registration
+    paper_trail_versions = registration.versions
+
+    registration.destroy
+
+    paper_trail_versions.delete_all
+
+    log "Removed registration: #{registration.reference}"
+  end
+
+  def log(msg)
+    # Avoid cluttering up the test logs
+    puts msg unless Rails.env.test?
+  end
+end

--- a/spec/services/remove_deletable_registrations_service_spec.rb
+++ b/spec/services/remove_deletable_registrations_service_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RemoveDeletableRegistrationsService do
+  let!(:expired_8_years_ago) do
+    Timecop.freeze(8.years.ago) do
+      create(:registration, :with_ceased_exemptions)
+    end
+  end
+
+  let!(:recently_expired) do
+    create(:registration, :with_ceased_exemptions)
+  end
+
+  describe ".run" do
+    it "removes registrations expired > 7 years ago" do
+      expect(WasteExemptionsEngine::Registration.all).to eq(
+        [
+          expired_8_years_ago,
+          recently_expired
+        ]
+      )
+
+      described_class.run
+
+      expect(WasteExemptionsEngine::Registration.all).to eq(
+        [recently_expired]
+      )
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1868

- This is a work in progress

- Note that (currently) we are iterating through the registration exemption
and deleting the associated registration. This might not be the best approach.

- What if a registration_exemption was removed 7 years ago but the registration
continued to be used?

- Please treat this as a spike, For info purpose only!