### PR TITLE
Update db schema with latest migrations

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_08_160306) do
+ActiveRecord::Schema.define(version: 2022_04_07_103123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "ad_renewal_letters_exports", id: :serial, force: :cascade do |t|
+    t.date "expires_on"
+    t.string "file_name"
+    t.integer "number_of_letters"
+    t.string "printed_by"
+    t.date "printed_on"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "status", default: 0
+  end
 
   create_table "addresses", id: :serial, force: :cascade do |t|
     t.integer "address_type", default: 0
@@ -197,6 +208,10 @@ ActiveRecord::Schema.define(version: 2021_03_08_160306) do
     t.datetime "updated_at", null: false
     t.string "type", null: false
     t.boolean "temp_renew_without_changes"
+    t.boolean "temp_reuse_applicant_phone"
+    t.boolean "temp_reuse_applicant_email"
+    t.boolean "temp_reuse_operator_address"
+    t.string "temp_reuse_address_for_site_location"
     t.index ["token"], name: "index_transient_registrations_on_token", unique: true
   end
 


### PR DESCRIPTION
This change updates the back-office schema.rb file to take account of recent migrations. Without these schema changes, db:reset fails with an error about pending migrations.