### PR TITLE
Refresh companies house button working

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -8,6 +8,13 @@ class RegistrationsController < ApplicationController
     authorize
   end
 
+  def update_companies_house_details
+    reference = params[:reference]
+    WasteExemptionsEngine::RefreshCompaniesHouseNameService.run(reference)
+
+    redirect_back(fallback_location: registration_path(reference))
+  end
+
   private
 
   def find_resource(reference)

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -60,4 +60,10 @@ module ActionLinksHelper
       resource.in_renewal_window? &&
       resource.already_renewed?
   end
+
+  def display_refresh_registered_company_name_link_for?(resource)
+    return false unless display_edit_link_for?(resource)
+
+    resource.active? && resource.company_no_required?
+  end
 end

--- a/app/views/shared/_resource_details.html.erb
+++ b/app/views/shared/_resource_details.html.erb
@@ -156,7 +156,7 @@
         <p class="govuk-body"><%= t(".actions.renew.renew_window_closed") %></p>
       <% end %>
 
-      <% if display_edit_link_for?(resource) %>
+      <% if display_refresh_registered_company_name_link_for?(resource) %>
           <%= link_to t(".actions.refresh_companies_house"),
                         registration_companies_house_details_path(resource.reference),
                         method: :patch %>

--- a/app/views/shared/_resource_details.html.erb
+++ b/app/views/shared/_resource_details.html.erb
@@ -156,6 +156,12 @@
         <p class="govuk-body"><%= t(".actions.renew.renew_window_closed") %></p>
       <% end %>
 
+      <% if display_edit_link_for?(resource) %>
+          <%= link_to t(".actions.refresh_companies_house"),
+                        registration_companies_house_details_path(resource.reference),
+                        method: :patch %>
+      <% end %>
+
       <% if display_deregister_link_for?(resource) %>
         <p class="govuk-!-margin-top-6">
           <%= link_to t(".actions.deregister"), deregister_registrations_form_path(resource) %>

--- a/config/locales/partials/resource_details.en.yml
+++ b/config/locales/partials/resource_details.en.yml
@@ -60,6 +60,7 @@ en:
         resume: "Resume"
         resend_confirmation_email: "Resend confirmation email"
         resend_confirmation_letter: "Resend confirmation letter"
+        refresh_companies_house: "Refresh Companies House information"
         renew:
           link_text: "Start renewal"
           visually_hidden_text: "of %{name}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,10 @@ Rails.application.routes.draw do
        to: "resend_renewal_letter#create",
        as: "resend_renewal_letter"
 
+  patch "/companies_house_details:reference",
+        to: "registrations#update_companies_house_details",
+        as: :registration_companies_house_details
+
   # Engine
   mount WasteExemptionsEngine::Engine => "/"
 

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -443,4 +443,53 @@ RSpec.describe ActionLinksHelper, type: :helper do
       end
     end
   end
+
+  describe "#display_refresh_registered_company_name_link?" do
+    context "when the resource is a registration" do
+      let(:resource) { create(:registration) }
+
+      before do
+        allow(helper).to receive(:can?).with(:update, resource).and_return(can)
+      end
+
+      context "when the user has permission to update a registration" do
+        let(:can) { true }
+
+        context "when the resource is a limited company or limited liability partnership" do
+          before do
+            allow(resource).to receive(:company_no_required?).and_return(true)
+          end
+
+          it "returns true" do
+            expect(helper.display_refresh_registered_company_name_link_for?(resource)).to eq(true)
+          end
+        end
+
+        context "when the resource is neither a limited company nor a limited liability partnership" do
+          before do
+            allow(resource).to receive(:company_no_required?).and_return(false)
+          end
+
+          it "returns false" do
+            expect(helper.display_refresh_registered_company_name_link_for?(resource)).to eq(false)
+          end
+        end
+      end
+
+      context "when the user doesn't have permission to update a registration" do
+        let(:can) { false }
+        it "returns false" do
+          expect(helper.display_refresh_registered_company_name_link_for?(resource)).to eq(false)
+        end
+      end
+    end
+
+    context "when the resourse is not a registration" do
+      let(:resource) { nil }
+
+      it "returns false" do
+        expect(helper.display_refresh_registered_company_name_link_for?(resource)).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/requests/refresh_companies_house_spec.rb
+++ b/spec/requests/refresh_companies_house_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Refresh companies house", type: :request do
       it_behaves_like "all companies house details requests"
     end
 
-    context "with an existing registere company name" do
+    context "with an existing registered company name" do
       let(:old_registered_name) { Faker::Company.name }
 
       context "when the new company name is the same as the old one" do

--- a/spec/requests/refresh_companies_house_spec.rb
+++ b/spec/requests/refresh_companies_house_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Refresh companies house", type: :request do
+  describe "PATCH /bo/registrations/:reg_identifier/companies_house_details" do
+
+    subject { patch registration_companies_house_details_path(registration.reference) }
+
+    RSpec.shared_examples "all companies house details requests" do
+
+      it "redirects to the same page" do
+        subject
+        expect(response.status).to eq 302
+        expect(response.location).to end_with registration_path(registration.reference)
+      end
+    end
+
+    let(:user) { create(:user) }
+    let(:new_registration_name) { Faker::Company.name }
+    let(:registration) { create(:registration, operator_name: old_registered_name) }
+
+    before do
+      sign_in(user)
+      stub_request(:get, "#{Rails.configuration.companies_house_host}#{registration.company_no}").to_return(
+        status: 200,
+        body: { company_name: new_registration_name }.to_json
+      )
+    end
+
+    context "with no previous companies house name" do
+      let(:old_registered_name) { nil }
+
+      it_behaves_like "all companies house details requests"
+    end
+
+    context "with an existing registere company name" do
+      let(:old_registered_name) { Faker::Company.name }
+
+      context "when the new company name is the same as the old one" do
+        let(:new_registration_name) { old_registered_name }
+
+        it_behaves_like "all companies house details requests"
+      end
+
+      context "when the new company name is different to the old one" do
+        it_behaves_like "all companies house details requests"
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1877

Here we have the companies house refresh button added into the back office. This allows the NCCC to perform a refresh on the registered company name if the company name has been changed since creating the registration . 