### PR TITLE
[1868] Use expires_on over updated_at

### DIFF
--- a/app/services/expired_registration_cleanup_service.rb
+++ b/app/services/expired_registration_cleanup_service.rb
@@ -27,7 +27,7 @@ class ExpiredRegistrationCleanupService < ::WasteExemptionsEngine::BaseService
       .where("deregistered_at <= ?", date)
       .or(
         WasteExemptionsEngine::RegistrationExemption.expired.where(
-          "updated_at <= ?", date
+          "expires_on <= ?", date
         )
       )
   end

--- a/spec/services/expired_registration_cleanup_service_spec.rb
+++ b/spec/services/expired_registration_cleanup_service_spec.rb
@@ -4,11 +4,50 @@ require "rails_helper"
 
 RSpec.describe ExpiredRegistrationCleanupService do
   subject(:service) { described_class }
-  let(:registration) { create(:registration, :with_ceased_exemptions, :with_people) }
   let(:id) { registration.id }
 
   describe ".run" do
-    context "when older than 7 years" do
+    context "when expiry is 7 years ago" do
+      let(:registration) { create(:registration, :with_people) }
+
+      before do
+        registration.registration_exemptions.update_all(state: :expired, expires_on: 7.years.ago)
+      end
+
+      it "deletes the registration" do
+        expect { service.run }.to change { WasteExemptionsEngine::Registration.where(id: id).count }.from(1).to(0)
+      end
+
+      it "deletes registration addresses" do
+        address_count = registration.addresses.count
+
+        expect { service.run }.to change { WasteExemptionsEngine::Address.where(registration_id: id).count }.from(address_count).to(0)
+      end
+
+      it "deletes registration people" do
+        people_count = registration.people.count
+
+        expect { service.run }.to change { WasteExemptionsEngine::Person.where(registration_id: id).count }.from(people_count).to(0)
+      end
+
+      it "deletes registration registration_exemptions" do
+        re_count = registration.registration_exemptions.count
+
+        expect { service.run }.to change { WasteExemptionsEngine::RegistrationExemption.where(registration_id: id).count }.from(re_count).to(0)
+      end
+
+      it "deletes registration paper_trail version data", versioning: true do
+        paper_trail_count = registration.versions.count
+
+        expect { service.run }.to change {
+          PaperTrail::Version.where(item_type: "WasteExemptionsEngine::Registration").count
+        }.from(paper_trail_count).to(0)
+      end
+    end
+
+    context "when ceased and older than 7 years" do
+      let(:registration) { create(:registration, :with_ceased_exemptions, :with_people) }
+
       before do
         registration.registration_exemptions.update_all(deregistered_at: 7.years.ago)
       end
@@ -44,7 +83,25 @@ RSpec.describe ExpiredRegistrationCleanupService do
       end
     end
 
-    context "when a registration is newer than 7 years" do
+    context "when a ceased registration is newer than 7 years" do
+      let(:registration) { create(:registration, :with_ceased_exemptions, :with_people) }
+
+      before do
+        registration.registration_exemptions.update_all(deregistered_at: 6.years.ago)
+      end
+
+      it "does not delete it" do
+        expect { service.run }.to_not change { WasteExemptionsEngine::Registration.where(id: id).count }.from(1)
+      end
+    end
+
+    context "when an expiration is newer than 7 years" do
+      let(:registration) { create(:registration, :with_people) }
+
+      before do
+        registration.registration_exemptions.update_all(state: :expired, expires_on: 6.years.ago)
+      end
+
       it "does not delete it" do
         expect { service.run }.to_not change { WasteExemptionsEngine::Registration.where(id: id).count }.from(1)
       end


### PR DESCRIPTION
uses `expires_on` instead of `updated_at + state: :expired` for clearing registrations.