### PR TITLE
Map assistance_mode values for boxi registrations export

### DIFF
--- a/app/models/reports/boxi/registrations_serializer.rb
+++ b/app/models/reports/boxi/registrations_serializer.rb
@@ -12,6 +12,17 @@ module Reports
       def records_scope
         WasteExemptionsEngine::Registration.all
       end
+
+      def parse_assistance_mode(mode)
+        case mode
+        when "full"
+          "Fully assisted"
+        when "partial"
+          "Partially assisted"
+        else
+          "Unassisted"
+        end
+      end
     end
   end
 end

--- a/spec/models/reports/boxi/registrations_serializer_spec.rb
+++ b/spec/models/reports/boxi/registrations_serializer_spec.rb
@@ -22,27 +22,19 @@ module Reports
       end
 
       describe "#parse_assistance_mode" do
-        # let(:registration) { create(:registration) }
-
         context "for an unassisted registration" do
-          # before { allow(registration).to receive(:assistance_mode).and_return(nil) }
-
           it "returns 'Unassisted'" do
             expect(described_class.new.parse_assistance_mode(nil)).to eq("Unassisted")
           end
         end
 
         context "for a fully assisted registration" do
-          # before { allow(registration).to receive(:assistance_mode).and_return("full") }
-
           it "returns 'Fully assisted'" do
             expect(described_class.new.parse_assistance_mode("full")).to eq("Fully assisted")
           end
         end
 
         context "for a partially assisted registration" do
-          # before { allow(registration).to receive(:assistance_mode).and_return("partial") }
-
           it "returns 'Partially assisted'" do
             expect(described_class.new.parse_assistance_mode("partial")).to eq("Partially assisted")
           end

--- a/spec/models/reports/boxi/registrations_serializer_spec.rb
+++ b/spec/models/reports/boxi/registrations_serializer_spec.rb
@@ -20,6 +20,35 @@ module Reports
           expect(result_lines.count).to eq(2)
         end
       end
+
+      describe "#parse_assistance_mode" do
+        # let(:registration) { create(:registration) }
+
+        context "for an unassisted registration" do
+          # before { allow(registration).to receive(:assistance_mode).and_return(nil) }
+
+          it "returns 'Unassisted'" do
+            expect(described_class.new.parse_assistance_mode(nil)).to eq("Unassisted")
+          end
+        end
+
+        context "for a fully assisted registration" do
+          # before { allow(registration).to receive(:assistance_mode).and_return("full") }
+
+          it "returns 'Fully assisted'" do
+            expect(described_class.new.parse_assistance_mode("full")).to eq("Fully assisted")
+          end
+        end
+
+        context "for a partially assisted registration" do
+          # before { allow(registration).to receive(:assistance_mode).and_return("partial") }
+
+          it "returns 'Partially assisted'" do
+            expect(described_class.new.parse_assistance_mode("partial")).to eq("Partially assisted")
+          end
+        end
+
+      end
     end
   end
 end


### PR DESCRIPTION
This change modifies the existing export of registration `assistance_mode` to meaningful text values for BOXI reports purposes.
https://eaflood.atlassian.net/browse/RUBY-1989