### PR TITLE
Renew link, companies house data retrieval

### DIFF
--- a/app/controllers/renews_controller.rb
+++ b/app/controllers/renews_controller.rb
@@ -7,7 +7,12 @@ class RenewsController < ApplicationController
     authorize
 
     @transient_registration = WasteExemptionsEngine::RenewalStartService.run(registration: registration)
-
+    @transient_registration.workflow_state =
+      if @transient_registration.company_no_required?
+        :check_registered_name_and_address_form
+      else
+        :renewal_start_form
+      end
     redirect_to_correct_form
   end
 

--- a/spec/requests/renews_spec.rb
+++ b/spec/requests/renews_spec.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "defra_ruby_companies_house"
 
 RSpec.describe "Renews", type: :request do
   let(:registration) { create(:registration) }
+  let(:transient_registration_token) { WasteExemptionsEngine::RenewingRegistration.last.token }
+  let(:company_name) { Faker::Company.name }
+  let(:company_address) { ["10 Downing St", "Horizon House", "Bristol", "BS1 5AH"] }
+
+  before do
+    allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:load_company).and_return(true)
+    allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:company_name).and_return(company_name)
+    allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:registered_office_address_lines).and_return(company_address)
+  end
 
   describe "GET /renews/:reference" do
     let(:request_path) { "/renew/#{registration.reference}" }
@@ -29,22 +39,42 @@ RSpec.describe "Renews", type: :request do
       it "return a 303 redirect code and redirect to the renewal start form" do
         get request_path
 
-        expect(response.code).to eq("303")
-
-        renewing_registration = WasteExemptionsEngine::RenewingRegistration.last
-        path = WasteExemptionsEngine::Engine.routes.url_helpers.new_renewal_start_form_path(token: renewing_registration.token)
+        path = WasteExemptionsEngine::Engine.routes.url_helpers.check_registered_name_and_address_forms_path(token: transient_registration_token)
         expect(response).to redirect_to(path)
+        expect(response.code).to eq("303")
       end
 
       context "when the renewal was already started" do
         let(:renewing_registration) { create(:renewing_registration, workflow_state: "contact_name_form") }
-        let(:registration) { renewing_registration.referring_registration }
+        let(:request_path) { "/renew/#{renewing_registration.reference}" }
 
         it "redirects to the correct template status" do
           get request_path
-          follow_redirect!
 
-          expect(response).to render_template("waste_exemptions_engine/contact_name_forms/new")
+          path = WasteExemptionsEngine::Engine.routes.url_helpers.check_registered_name_and_address_forms_path(token: transient_registration_token)
+          expect(response).to redirect_to(path)
+        end
+      end
+
+      context "when the business type is a company or llp" do
+        it "redirects to the check registered name and address form, creates a new RenewingRegistration and returns a 303 status code" do
+          get request_path
+
+          path = WasteExemptionsEngine::Engine.routes.url_helpers.check_registered_name_and_address_forms_path(token: transient_registration_token)
+          expect(response).to redirect_to(path)
+          expect(response.code).to eq("303")
+        end
+      end
+
+      context "when the business type is not a company or llp" do
+        before { registration.update_attribute(:business_type, "soleTrader") }
+
+        it "redirects to the renewal start form, creates a new RenewingRegistration and returns a 303 status code" do
+          get request_path
+
+          path = WasteExemptionsEngine::Engine.routes.url_helpers.new_renewal_start_form_path(token: transient_registration_token)
+          expect(response).to redirect_to(path)
+          expect(response.code).to eq("303")
         end
       end
     end

--- a/spec/requests/renews_spec.rb
+++ b/spec/requests/renews_spec.rb
@@ -6,14 +6,6 @@ require "defra_ruby_companies_house"
 RSpec.describe "Renews", type: :request do
   let(:registration) { create(:registration) }
   let(:transient_registration_token) { WasteExemptionsEngine::RenewingRegistration.last.token }
-  let(:company_name) { Faker::Company.name }
-  let(:company_address) { ["10 Downing St", "Horizon House", "Bristol", "BS1 5AH"] }
-
-  before do
-    allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:load_company).and_return(true)
-    allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:company_name).and_return(company_name)
-    allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:registered_office_address_lines).and_return(company_address)
-  end
 
   describe "GET /renews/:reference" do
     let(:request_path) { "/renew/#{registration.reference}" }
@@ -35,6 +27,12 @@ RSpec.describe "Renews", type: :request do
 
     context "when an admin agent user is signed in" do
       let(:user) { create(:user, :admin_agent) }
+
+      before do
+        allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:load_company).and_return(true)
+        allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:company_name).and_return(Faker::Company.name)
+        allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:registered_office_address_lines).and_return(["10 Downing St", "Horizon House", "Bristol", "BS1 5AH"])
+      end
 
       it "return a 303 redirect code and redirect to the renewal start form" do
         get request_path


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1993

Here we have the routing changes to the back office renewal link button. This change allows a company or llp renewing to be redirected to the check_registered_name_and_address_form to validate their company name and address before being shown the check_your_answers+page in the renewal. For non companies the journey is still the same