### PR TITLE
Add renewals column to boxi exemptions export

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -457,7 +457,7 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
-    webmock (3.16.0)
+    webmock (3.17.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)

--- a/app/models/reports/boxi/registration_exemptions_serializer.rb
+++ b/app/models/reports/boxi/registration_exemptions_serializer.rb
@@ -3,7 +3,7 @@
 module Reports
   module Boxi
     class RegistrationExemptionsSerializer < BaseSerializer
-      ATTRIBUTES = WasteExemptionsEngine::RegistrationExemption.column_names
+      ATTRIBUTES = WasteExemptionsEngine::RegistrationExemption.column_names + ["renewal"]
 
       def file_name
         "registration_exemptions.csv"

--- a/app/models/waste_exemptions_engine/registration_exemption.rb
+++ b/app/models/waste_exemptions_engine/registration_exemption.rb
@@ -27,5 +27,11 @@ module WasteExemptionsEngine
         .includes(registration: :addresses)
         .order(:registered_on, :registration_id)
     }
+
+    # This is called "renewal" rather than "renewal?" so that it can behave
+    # like an attribute in the Boxi export service without any mapping logic.
+    def renewal
+      registration&.renewal? ? "Yes" : "No"
+    end
   end
 end

--- a/app/models/waste_exemptions_engine/registration_exemption.rb
+++ b/app/models/waste_exemptions_engine/registration_exemption.rb
@@ -31,7 +31,7 @@ module WasteExemptionsEngine
     # This is called "renewal" rather than "renewal?" so that it can behave
     # like an attribute in the Boxi export service without any mapping logic.
     def renewal
-      registration&.renewal? ? "Yes" : "No"
+      registration&.renewal?
     end
   end
 end

--- a/spec/models/registration_exemption_spec.rb
+++ b/spec/models/registration_exemption_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe WasteExemptionsEngine::RegistrationExemption, type: :model do
       let(:registration) { build(:registration) }
 
       it "returns false" do
-        expect(subject.renewal).to eq "No"
+        expect(subject.renewal).to be false
       end
     end
 
@@ -73,7 +73,7 @@ RSpec.describe WasteExemptionsEngine::RegistrationExemption, type: :model do
       let(:registration) { build(:registration, referring_registration: build(:registration)) }
 
       it "returns true" do
-        expect(subject.renewal).to eq "Yes"
+        expect(subject.renewal).to be true
       end
     end
   end

--- a/spec/models/registration_exemption_spec.rb
+++ b/spec/models/registration_exemption_spec.rb
@@ -57,4 +57,24 @@ RSpec.describe WasteExemptionsEngine::RegistrationExemption, type: :model do
       end
     end
   end
+
+  describe "#renewal" do
+    subject(:registration_exemption) { registration.registration_exemptions.first }
+
+    context "without a referring registration" do
+      let(:registration) { build(:registration) }
+
+      it "returns false" do
+        expect(subject.renewal).to eq "No"
+      end
+    end
+
+    context "with a referring registration" do
+      let(:registration) { build(:registration, referring_registration: build(:registration)) }
+
+      it "returns true" do
+        expect(subject.renewal).to eq "Yes"
+      end
+    end
+  end
 end

--- a/spec/models/reports/boxi/registration_exemptions_serializer_spec.rb
+++ b/spec/models/reports/boxi/registration_exemptions_serializer_spec.rb
@@ -17,6 +17,7 @@ module Reports
           result_lines = result.split("\n")
 
           expect(result_lines.first.split(",")).to include(*WasteExemptionsEngine::RegistrationExemption.column_names)
+          expect(result_lines.first.split(",")).to include("renewal")
           expect(result_lines.count).to eq(2)
         end
 


### PR DESCRIPTION
This change adds a "renewals" column to the Boxi `registration_exemptions` export.
https://eaflood.atlassian.net/browse/RUBY-1978