### PR TITLE
Adding telephone to the search criteria

### DIFF
--- a/app/models/concerns/can_be_searched_like_registration.rb
+++ b/app/models/concerns/can_be_searched_like_registration.rb
@@ -7,7 +7,8 @@ module CanBeSearchedLikeRegistration
     scope :search_registration_and_relations, lambda { |term|
       where(id: search_registration(term).ids +
                 search_for_site_address_postcode(term).ids +
-                search_for_person_name(term).ids)
+                search_for_person_name(term).ids +
+                search_for_telephone(term).ids)
     }
 
     scope :search_registration, lambda { |term|
@@ -17,17 +18,13 @@ module CanBeSearchedLikeRegistration
           OR UPPER(contact_email) = ?\
           OR UPPER(CONCAT(contact_first_name, ' ', contact_last_name)) LIKE ?\
           OR UPPER(operator_name) LIKE ?\
-          OR UPPER(reference) = ?\
-          OR UPPER(applicant_phone) = ?\
-          OR UPPER(contact_phone) = ?",
+          OR UPPER(reference) = ?",
         term&.upcase,        # applicant_email
         "%#{term&.upcase}%", # applicant names
         term&.upcase,        # contact_email
         "%#{term&.upcase}%", # contact names
         "%#{term&.upcase}%", # operator_name
-        term&.upcase,        # reference
-        term&.upcase,        # applicant_phone
-        term&.upcase         # contact_phone
+        term&.upcase         # reference
       )
     }
   end

--- a/app/models/concerns/can_be_searched_like_registration.rb
+++ b/app/models/concerns/can_be_searched_like_registration.rb
@@ -17,13 +17,17 @@ module CanBeSearchedLikeRegistration
           OR UPPER(contact_email) = ?\
           OR UPPER(CONCAT(contact_first_name, ' ', contact_last_name)) LIKE ?\
           OR UPPER(operator_name) LIKE ?\
-          OR UPPER(reference) = ?",
+          OR UPPER(reference) = ?\
+          OR UPPER(applicant_phone) = ?\
+          OR UPPER(contact_phone) = ?",
         term&.upcase,        # applicant_email
         "%#{term&.upcase}%", # applicant names
         term&.upcase,        # contact_email
         "%#{term&.upcase}%", # contact names
         "%#{term&.upcase}%", # operator_name
-        term&.upcase         # reference
+        term&.upcase,        # reference
+        term&.upcase,        # applicant_phone
+        term&.upcase         # contact_phone
       )
     }
   end

--- a/app/models/concerns/can_be_searched_like_telephone.rb
+++ b/app/models/concerns/can_be_searched_like_telephone.rb
@@ -22,7 +22,7 @@ module CanBeSearchedLikeTelephone
       end
 
       # Regex can search for a number with spaces and dashes anywhere and for UK numbers either starting in 0 or +44
-      regex = "^(\\+44|0|\\+)?[\\s-]*" + telephone_number.scan(/\d/).map { |c| "#{c}[\\s-]*" }.join
+      regex = "(\\+44|0|\\+)?[\\s-]*" + telephone_number.scan(/\d/).map { |c| "#{c}[\\s-]*" }.join
 
       where(
         "contact_phone ~* ?\

--- a/app/models/concerns/can_be_searched_like_telephone.rb
+++ b/app/models/concerns/can_be_searched_like_telephone.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module CanBeSearchedLikeTelephone
+  extend ActiveSupport::Concern
+
+  included do
+    scope :search_for_telephone, lambda { |term|
+
+      return if term.blank?
+
+      # Remove any whitespace
+      telephone_number = term.gsub(/\s+/, "")
+      # Remove any dashes
+      telephone_number.gsub!("-", "")
+
+      # Removing the 0 or +44 at the beggining of the number as this is already included in the regex
+      # For numbers not starting in either of these the regex will still work as the 0 and +44 is optional
+      if telephone_number.start_with?("+44")
+        telephone_number.gsub!("+44", "")
+      elsif telephone_number.start_with?("0")
+        telephone_number.slice!(0)
+      end
+
+      # Regex can search for a number with spaces and dashes anywhere and for UK numbers either starting in 0 or +44
+      regex = "^(\\+44|0)?[\\s-]*" + telephone_number.scan(/\d/).map { |c| "#{c}[\\s-]*" }.join
+
+      where(
+        "contact_phone ~* ?\
+          OR applicant_phone ~* ?",
+        regex,  # contact_phone
+        regex   # applicant_phone
+      )
+    }
+  end
+end

--- a/app/models/concerns/can_be_searched_like_telephone.rb
+++ b/app/models/concerns/can_be_searched_like_telephone.rb
@@ -22,7 +22,7 @@ module CanBeSearchedLikeTelephone
       end
 
       # Regex can search for a number with spaces and dashes anywhere and for UK numbers either starting in 0 or +44
-      regex = "^(\\+44|0)?[\\s-]*" + telephone_number.scan(/\d/).map { |c| "#{c}[\\s-]*" }.join
+      regex = "^(\\+44|0|\\+)?[\\s-]*" + telephone_number.scan(/\d/).map { |c| "#{c}[\\s-]*" }.join
 
       where(
         "contact_phone ~* ?\

--- a/app/models/waste_exemptions_engine/new_registration.rb
+++ b/app/models/waste_exemptions_engine/new_registration.rb
@@ -5,6 +5,7 @@ require WasteExemptionsEngine::Engine.root.join("app", "models", "waste_exemptio
 module WasteExemptionsEngine
   class NewRegistration < TransientRegistration
     include CanBeSearchedLikeRegistration
+    include CanBeSearchedLikeTelephone
 
     scope :search_for_site_address_postcode, lambda { |term|
       joins(:transient_addresses).merge(TransientAddress.search_for_postcode(term).site)

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -5,6 +5,7 @@ require WasteExemptionsEngine::Engine.root.join("app", "models", "waste_exemptio
 module WasteExemptionsEngine
   class Registration < ::WasteExemptionsEngine::ApplicationRecord
     include CanBeSearchedLikeRegistration
+    include CanBeSearchedLikeTelephone
 
     scope :search_for_site_address_postcode, lambda { |term|
       joins(:addresses).merge(Address.search_for_postcode(term).site)

--- a/config/locales/dashboards.en.yml
+++ b/config/locales/dashboards.en.yml
@@ -11,6 +11,7 @@ en:
         - "applicant name"
         - "applicant email"
         - "contact name"
+        - "telephone number"
         - "contact email"
       no_results: "No results"
     form:

--- a/spec/factories/new_registration.rb
+++ b/spec/factories/new_registration.rb
@@ -34,6 +34,10 @@ FactoryBot.define do
       "0123456789#{n}"
     end
 
+    sequence :applicant_phone do |n|
+      "0123456789#{n}"
+    end
+
     transient_addresses do
       [build(:transient_address, :operator),
        build(:transient_address, :contact),

--- a/spec/factories/new_registration.rb
+++ b/spec/factories/new_registration.rb
@@ -30,6 +30,10 @@ FactoryBot.define do
       "Operator #{n}"
     end
 
+    sequence :contact_phone do |n|
+      "0123456789#{n}"
+    end
+
     transient_addresses do
       [build(:transient_address, :operator),
        build(:transient_address, :contact),

--- a/spec/models/new_registration_spec.rb
+++ b/spec/models/new_registration_spec.rb
@@ -31,16 +31,6 @@ RSpec.describe WasteExemptionsEngine::NewRegistration, type: :model do
     end
 
     context "when the search is a phone number" do
-      let(:normal_number) { "01234567890" }
-      let(:number_with_spaces) { "012 3456 7890" }
-      let(:number_with_dashes) { "012-3456-7890" }
-      let(:number_starting_with_44) { "+441234567890" }
-
-      before do
-        non_matching_registration.update_attribute(:applicant_phone, "0121117890")
-        non_matching_registration.update_attribute(:contact_phone, "0121117890")
-      end
-
       context "when searching applicant number" do
         it_behaves_like "searching phone number attribute", :applicant_phone
       end

--- a/spec/models/new_registration_spec.rb
+++ b/spec/models/new_registration_spec.rb
@@ -205,26 +205,3 @@ RSpec.describe WasteExemptionsEngine::NewRegistration, type: :model do
     end
   end
 end
-
-################
-# Need contact phone term
-#   -normal
-#   -dashes
-#   -space
-#   -+44
-# contact phone db
-#   -normal
-#   -dashes
-#   -space
-#   -+44
-# applicant phone term
-#   -normal
-#   -dashes
-#   -space
-#   -+44
-# applicant phone db
-#   -normal
-#   -dashes
-#   -space
-#   -+44
-################

--- a/spec/models/new_registration_spec.rb
+++ b/spec/models/new_registration_spec.rb
@@ -30,6 +30,26 @@ RSpec.describe WasteExemptionsEngine::NewRegistration, type: :model do
       end
     end
 
+    context "when the search is a phone number" do
+      let(:normal_number) { "01234567890" }
+      let(:number_with_spaces) { "012 3456 7890" }
+      let(:number_with_dashes) { "012-3456-7890" }
+      let(:number_starting_with_44) { "+441234567890" }
+
+      before do
+        non_matching_registration.update_attribute(:applicant_phone, "0121117890")
+        non_matching_registration.update_attribute(:contact_phone, "0121117890")
+      end
+
+      context "when searching applicant number" do
+        it_behaves_like "searching phone number attribute", :applicant_phone
+      end
+
+      context "when searching contact number" do
+        it_behaves_like "searching phone number attribute", :contact_phone
+      end
+    end
+
     context "when the search term is an applicant_first_name" do
       let(:term) { matching_registration.applicant_first_name }
 
@@ -185,3 +205,26 @@ RSpec.describe WasteExemptionsEngine::NewRegistration, type: :model do
     end
   end
 end
+
+################
+# Need contact phone term
+#   -normal
+#   -dashes
+#   -space
+#   -+44
+# contact phone db
+#   -normal
+#   -dashes
+#   -space
+#   -+44
+# applicant phone term
+#   -normal
+#   -dashes
+#   -space
+#   -+44
+# applicant phone db
+#   -normal
+#   -dashes
+#   -space
+#   -+44
+################

--- a/spec/models/waste_exemptions_engine/registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/registration_spec.rb
@@ -143,6 +143,26 @@ RSpec.describe WasteExemptionsEngine::Registration, type: :model do
       end
     end
 
+    context "when the search is a phone number" do
+      let(:normal_number) { "01234567890" }
+      let(:number_with_spaces) { "012 3456 7890" }
+      let(:number_with_dashes) { "012-3456-7890" }
+      let(:number_starting_with_44) { "+441234567890" }
+
+      before do
+        non_matching_registration.update_attribute(:applicant_phone, "0121117890")
+        non_matching_registration.update_attribute(:contact_phone, "0121117890")
+      end
+
+      context "when searching applicant number" do
+        it_behaves_like "searching phone number attribute", :applicant_phone
+      end
+
+      context "when searching contact number" do
+        it_behaves_like "searching phone number attribute", :contact_phone
+      end
+    end
+
     context "when the search term is an applicant_first_name" do
       let(:term) { matching_registration.applicant_first_name }
 

--- a/spec/models/waste_exemptions_engine/registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/registration_spec.rb
@@ -144,16 +144,6 @@ RSpec.describe WasteExemptionsEngine::Registration, type: :model do
     end
 
     context "when the search is a phone number" do
-      let(:normal_number) { "01234567890" }
-      let(:number_with_spaces) { "012 3456 7890" }
-      let(:number_with_dashes) { "012-3456-7890" }
-      let(:number_starting_with_44) { "+441234567890" }
-
-      before do
-        non_matching_registration.update_attribute(:applicant_phone, "0121117890")
-        non_matching_registration.update_attribute(:contact_phone, "0121117890")
-      end
-
       context "when searching applicant number" do
         it_behaves_like "searching phone number attribute", :applicant_phone
       end

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -43,6 +43,19 @@ RSpec.describe SearchService do
       end
     end
 
+    context "when the model is set to new_registrations" do
+      let(:model) { :new_registrations }
+      let(:term) { new_registration.contact_phone }
+
+      it "should return matching new_registrations" do
+        expect(results).to include(new_registration)
+      end
+
+      it "should not return non-matching new_registrations" do
+        expect(results).to_not include(other_new_registration)
+      end
+    end
+
     context "when the search term has excess whitespace" do
       let(:term) { "  foo  " }
 

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -56,6 +56,19 @@ RSpec.describe SearchService do
       end
     end
 
+    context "when the model is set to registration" do
+      let(:model) { :registrations }
+      let(:term) { registration.contact_phone }
+
+      it "should return matching new_registrations" do
+        expect(results).to include(registration)
+      end
+
+      it "should not return non-matching new_registrations" do
+        expect(results).to_not include(other_new_registration)
+      end
+    end
+
     context "when the search term has excess whitespace" do
       let(:term) { "  foo  " }
 

--- a/spec/support/shared_examples/searching_phone_number_attribute.rb
+++ b/spec/support/shared_examples/searching_phone_number_attribute.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.shared_examples "matching and non matching registrations" do
+  it "returns a matching registration" do
+    expect(scope).to include(matching_registration)
+  end
+
+  it "does not return others" do
+    expect(scope).not_to include(non_matching_registration)
+  end
+end
+
+RSpec.shared_examples "searching phone number attribute" do |phone_type|
+  context "when the number in the database has not got any spaces or dashes and doesn't start in +44" do
+    before do
+      matching_registration.update_attribute(phone_type, normal_number)
+    end
+
+    context "and the search term has not got any spaces or dashes and doesn't start in +44" do
+      let(:term) { normal_number.to_s }
+      it_behaves_like "matching and non matching registrations"
+    end
+
+    context "but the search term has spaces" do
+      let(:term) { number_with_spaces.to_s }
+      it_behaves_like "matching and non matching registrations"
+    end
+
+    context "but the search term has dashes" do
+      let(:term) { number_with_dashes.to_s }
+      it_behaves_like "matching and non matching registrations"
+    end
+
+    context "but the search term starts with +44" do
+      let(:term) { number_starting_with_44.to_s }
+      it_behaves_like "matching and non matching registrations"
+    end
+  end
+
+  context "when the number in the search term has got any spaces or dashes and doesn't start in +44" do
+    let(:term) { normal_number.to_s }
+    context "and the database has not got any spaces or dashes and doesn't start in +44" do
+      before do
+        matching_registration.update_attribute(phone_type, normal_number)
+      end
+      it_behaves_like "matching and non matching registrations"
+    end
+
+    context "but the database has spaces" do
+      before do
+        matching_registration.update_attribute(phone_type, number_with_spaces)
+      end
+      it_behaves_like "matching and non matching registrations"
+    end
+
+    context "but the database has dashes" do
+      before do
+        matching_registration.update_attribute(phone_type, number_with_dashes)
+      end
+      it_behaves_like "matching and non matching registrations"
+    end
+
+    context "but the database starts with +44" do
+      before do
+        matching_registration.update_attribute(phone_type, number_starting_with_44)
+      end
+      it_behaves_like "matching and non matching registrations"
+    end
+  end
+end

--- a/spec/support/shared_examples/searching_phone_number_attribute.rb
+++ b/spec/support/shared_examples/searching_phone_number_attribute.rb
@@ -18,6 +18,7 @@ RSpec.shared_examples "searching phone number attribute" do |phone_type|
   let(:number_with_dashes) { "012-3456-7890" }
   let(:number_starting_with_44) { "+441234567890" }
   let(:interntational_number) { "+78121234567" }
+  let(:number_with_text) { "Landline 01234567890" }
 
   before do
     non_matching_registration.update_attribute(:applicant_phone, "0121117890")
@@ -87,6 +88,18 @@ RSpec.shared_examples "searching phone number attribute" do |phone_type|
 
       before do
         matching_registration.update_attribute(phone_type, interntational_number)
+      end
+
+      it_behaves_like "matching and non matching registrations"
+    end
+  end
+
+  context "when the database telephone number has text with it" do
+    context "it matches the phone number" do
+      let(:term) { normal_number.to_s }
+
+      before do
+        matching_registration.update_attribute(phone_type, number_with_text)
       end
 
       it_behaves_like "matching and non matching registrations"

--- a/spec/support/shared_examples/searching_phone_number_attribute.rb
+++ b/spec/support/shared_examples/searching_phone_number_attribute.rb
@@ -13,6 +13,17 @@ RSpec.shared_examples "matching and non matching registrations" do
 end
 
 RSpec.shared_examples "searching phone number attribute" do |phone_type|
+  let(:normal_number) { "01234567890" }
+  let(:number_with_spaces) { "012 3456 7890" }
+  let(:number_with_dashes) { "012-3456-7890" }
+  let(:number_starting_with_44) { "+441234567890" }
+  let(:interntational_number) { "+78121234567" }
+
+  before do
+    non_matching_registration.update_attribute(:applicant_phone, "0121117890")
+    non_matching_registration.update_attribute(:contact_phone, "0121117890")
+  end
+
   context "when the number in the database has not got any spaces or dashes and doesn't start in +44" do
     before do
       matching_registration.update_attribute(phone_type, normal_number)
@@ -66,6 +77,18 @@ RSpec.shared_examples "searching phone number attribute" do |phone_type|
       before do
         matching_registration.update_attribute(phone_type, number_starting_with_44)
       end
+      it_behaves_like "matching and non matching registrations"
+    end
+  end
+
+  context "when the search term is an international number" do
+    context "it only produces exact matches" do
+      let(:term) { interntational_number.to_s }
+
+      before do
+        matching_registration.update_attribute(phone_type, interntational_number)
+      end
+
       it_behaves_like "matching and non matching registrations"
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-2057 
Here we have the changes for adding in applicant and contact telephone to the search results on the dashboard. 
This is only for an exact match and not a partial match