### PR TITLE
Feature/site grid reference

### DIFF
--- a/app/views/shared/_resource_address.html.erb
+++ b/app/views/shared/_resource_address.html.erb
@@ -7,7 +7,10 @@
     <% end %>
   </dt>
   <dd class="govuk-summary-list__value">
-    <% if address.located_by_grid_reference? %>
+    <p class="govuk-body govuk-!-font-weight-bold">
+      <%= t(".labels.grid_reference") %>
+    </p>
+    <% if address.grid_reference.present? %>
       <p class=govuk-body>
         <%= address.grid_reference %>
       </p>

--- a/app/views/shared/_resource_address.html.erb
+++ b/app/views/shared/_resource_address.html.erb
@@ -7,6 +7,7 @@
     <% end %>
   </dt>
   <dd class="govuk-summary-list__value">
+  <% if address.address_type == 'site' %>
     <p class="govuk-body govuk-!-font-weight-bold">
       <%= t(".labels.grid_reference") %>
     </p>
@@ -15,8 +16,12 @@
         <%= address.grid_reference %>
       </p>
     <% end %>
+  <% end %>
 
     <% if address.postcode.present? %>
+      <p class="govuk-body govuk-!-font-weight-bold">
+        <%= t(".labels.site_address") %>
+      </p>
       <ul class="govuk-list">
         <% displayable_address(address).each do |line| %>
           <li>

--- a/config/locales/partials/resource_address.en.yml
+++ b/config/locales/partials/resource_address.en.yml
@@ -9,6 +9,7 @@ en:
       labels:
         mode: "Mode"
         grid_reference: "Site grid reference"
+        site_address: "Site address"
         description: "Description"
         x: "X coordinate"
         y: "Y coordinate"

--- a/config/locales/partials/resource_address.en.yml
+++ b/config/locales/partials/resource_address.en.yml
@@ -8,6 +8,7 @@ en:
         site: "Site location"
       labels:
         mode: "Mode"
+        grid_reference: "Site grid reference"
         description: "Description"
         x: "X coordinate"
         y: "Y coordinate"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1931

Here we have added site grid reference into the site location section on the displayable registration page. 
We have added a header to the site address so its clear which is the address and which is the grid reference. 
The grid reference has logic in it so it will only show for the site location and not for the contact or registered location sections. 
Even if the grid reference is nil the header will still be shown as per the A\C. This alerts the BO user that the grid reference hasn't been successfully created. 