### PR TITLE
Track partial assisted digital

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: 4e96995127b5f10fab64f60d73afd6af863894fe
+  revision: e80c6235477791553d98d9248819bb6c3b275fc8
   branch: main
   specs:
     waste_exemptions_engine (0.0.1)
@@ -89,7 +89,7 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
-    airbrake (13.0.2)
+    airbrake (13.0.3)
       airbrake-ruby (~> 6.0)
     airbrake-ruby (6.2.0)
       rbtree3 (~> 0.5)
@@ -265,7 +265,7 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    loofah (2.18.0)
+    loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -303,7 +303,7 @@ GEM
       rake (>= 0.8.1)
     pg (1.4.3)
     pgreset (0.3)
-    phonelib (0.7.2)
+    phonelib (0.7.3)
     protocol-hpack (1.4.2)
     protocol-http (0.22.0)
     protocol-http1 (0.14.1)
@@ -470,7 +470,7 @@ GEM
       whenever
     wicked_pdf (2.6.3)
       activesupport
-    zeitwerk (2.6.0)
+    zeitwerk (2.6.1)
 
 PLATFORMS
   ruby

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -15,6 +15,9 @@ module ActionLinksHelper
   def resume_link_for(resource)
     return "#" unless resource.is_a?(WasteExemptionsEngine::NewRegistration)
 
+    # If the assistance_mode is nil, the registration was started in the front-office
+    resource.update(assistance_mode: "partial") unless resource.assistance_mode.present?
+
     token = resource.token
     path = "new_#{resource.workflow_state}_path".to_sym
     WasteExemptionsEngine::Engine.routes.url_helpers.public_send(path, token)

--- a/app/presenters/reports/exemption_bulk_report_presenter.rb
+++ b/app/presenters/reports/exemption_bulk_report_presenter.rb
@@ -112,10 +112,13 @@ module Reports
     end
 
     def assistance_type
-      if registration.assistance_mode == "full"
-        "fully assisted"
+      case registration.assistance_mode
+      when "full"
+        "Fully assisted"
+      when "partial"
+        "Partially assisted"
       else
-        "unassisted"
+        "Unassisted"
       end
     end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_18_160813) do
+ActiveRecord::Schema.define(version: 2022_10_04_145505) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -206,6 +206,7 @@ ActiveRecord::Schema.define(version: 2022_07_18_160813) do
     t.datetime "companies_house_updated_at"
     t.boolean "temp_reuse_applicant_name"
     t.text "workflow_history", default: [], array: true
+    t.string "assistance_mode"
     t.index ["token"], name: "index_transient_registrations_on_token", unique: true
   end
 

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -39,6 +39,20 @@ RSpec.describe ActionLinksHelper, type: :helper do
         path = WasteExemptionsEngine::Engine.routes.url_helpers.new_start_form_path(resource.token)
         expect(helper.resume_link_for(resource)).to eq(path)
       end
+
+      context "when the registration was started in the back office" do
+        it "does not change the assistance_mode" do
+          expect { helper.resume_link_for(resource) }.not_to change(resource, :assistance_mode)
+        end
+      end
+
+      context "when the registration was started in the front office" do
+        before { resource.assistance_mode = nil }
+
+        it "changes the assistance mode to partial" do
+          expect { helper.resume_link_for(resource) }.to change(resource, :assistance_mode).to("partial")
+        end
+      end
     end
 
     context "when the resource is not a new_registration" do

--- a/spec/presenters/reports/exemption_bulk_report_presenter_spec.rb
+++ b/spec/presenters/reports/exemption_bulk_report_presenter_spec.rb
@@ -378,7 +378,15 @@ module Reports
         let(:assistance_mode) { nil }
 
         it "returns the string 'unassisted'" do
-          expect(exemption_bulk_report_presenter.assistance_type).to eq("unassisted")
+          expect(exemption_bulk_report_presenter.assistance_type).to eq("Unassisted")
+        end
+      end
+
+      context "when assistance_mode is set to 'partial'" do
+        let(:assistance_mode) { "partial" }
+
+        it "returns the string 'Partially assisted'" do
+          expect(exemption_bulk_report_presenter.assistance_type).to eq("Partially assisted")
         end
       end
 
@@ -386,7 +394,7 @@ module Reports
         let(:assistance_mode) { "full" }
 
         it "returns the string 'fully assisted'" do
-          expect(exemption_bulk_report_presenter.assistance_type).to eq("fully assisted")
+          expect(exemption_bulk_report_presenter.assistance_type).to eq("Fully assisted")
         end
       end
     end


### PR DESCRIPTION
This change tracks partially-assisted registrations for inclusion in the Boxi export.
https://eaflood.atlassian.net/browse/RUBY-2002