### PR TITLE
Show magic link

### DIFF
--- a/lib/tasks/test_magic_link.rake
+++ b/lib/tasks/test_magic_link.rake
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+namespace :test do
+  desc "Generate and print to console a renewal/deregistration link for a specified registration"
+  task :magic_link, %i[reference] => :environment do |_t, args|
+
+    @registration = WasteExemptionsEngine::Registration.find_by(reference: args[:reference])
+    if @registration.nil?
+      puts "Failed to find registration with reg_identifier \"#{args[:reference]}\""
+      exit
+    end
+
+    puts magic_link_url
+  end
+
+  def magic_link_url
+    Rails.configuration.front_office_url +
+      WasteExemptionsEngine::Engine.routes.url_helpers.renew_path(token: magic_link_token)
+  end
+
+  def magic_link_token
+    @registration.regenerate_renew_token if @registration.renew_token.nil?
+    @registration.renew_token
+  end
+end

--- a/spec/lib/tasks/test_magic_link_spec.rb
+++ b/spec/lib/tasks/test_magic_link_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# rubocop:disable RSpec/ExpectOutput
+RSpec.describe "test:magic_link", type: :rake do
+  include_context "rake"
+
+  original_stdout = $stdout
+
+  let(:registration) { create(:registration) }
+
+  before do
+    # suppress noisy outputs during unit test
+    $stdout = StringIO.new
+  end
+
+  after do
+    $stdout = original_stdout
+  end
+
+  it "runs without error" do
+    expect { Rake::Task[subject].invoke(registration.reference) }.not_to raise_error
+  end
+end
+# rubocop:enable RSpec/ExpectOutput

--- a/spec/lib/tasks/test_magic_link_spec.rb
+++ b/spec/lib/tasks/test_magic_link_spec.rb
@@ -19,8 +19,12 @@ RSpec.describe "test:magic_link", type: :rake do
     $stdout = original_stdout
   end
 
-  it "runs without error" do
+  it "runs without error with a valid registration reference" do
     expect { Rake::Task[subject].invoke(registration.reference) }.not_to raise_error
+  end
+
+  it "runs without error with an invalid registration reference" do
+    expect { Rake::Task[subject].invoke("foo") }.not_to raise_error
   end
 end
 # rubocop:enable RSpec/ExpectOutput


### PR DESCRIPTION
This adds a rake task for outputting a renew/deregister magic link for test purposes.