### PR TITLE
create registration for testing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,7 +177,7 @@ GEM
       phonelib
       rest-client (~> 2.0)
       validates_email_format_of
-    devise (4.8.1)
+    devise (4.9.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -370,9 +370,9 @@ GEM
     regexp_parser (2.7.0)
     request_store (1.5.1)
       rack (>= 1.4)
-    responders (3.0.1)
-      actionpack (>= 5.0)
-      railties (>= 5.0)
+    responders (3.1.0)
+      actionpack (>= 5.2)
+      railties (>= 5.2)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)

--- a/app/controllers/testing_controller.rb
+++ b/app/controllers/testing_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "factory_bot_rails"
+
+class TestingController < ApplicationController
+
+  before_action :non_production_only
+
+  def create_registration
+    expiry_date = Date.parse(params[:expiry_date])
+
+    # https://github.com/thoughtbot/factory_bot/blob/ca810767e70ccd85c7cb63f775bc16f653a97dc8/GETTING_STARTED.md#rails-preloaders-and-rspec
+    FactoryBot.reload
+    
+    registration_exemption = FactoryBot.build(:registration_exemption, expires_on: expiry_date)
+    registration = FactoryBot.create(:registration, registration_exemptions: [registration_exemption])
+
+    render :show, locals: { registration: registration }
+  end
+
+  private
+
+  def non_production_only
+    raise ActionController::RoutingError, "Not Found" if ["production", nil].include?(ENV.fetch("AIRBRAKE_ENV_NAME"))
+  end
+end

--- a/app/controllers/testing_controller.rb
+++ b/app/controllers/testing_controller.rb
@@ -21,6 +21,8 @@ class TestingController < ApplicationController
   private
 
   def non_production_only
+    return if Rails.env.test?
+
     return unless ["production", nil].include?(ENV.fetch("AIRBRAKE_ENV_NAME", nil))
 
     raise ActionController::RoutingError, "Not Found"

--- a/app/controllers/testing_controller.rb
+++ b/app/controllers/testing_controller.rb
@@ -21,6 +21,8 @@ class TestingController < ApplicationController
   private
 
   def non_production_only
-    raise ActionController::RoutingError, "Not Found" if ["production", nil].include?(ENV.fetch("AIRBRAKE_ENV_NAME"))
+    return unless ["production", nil].include?(ENV.fetch("AIRBRAKE_ENV_NAME", nil))
+
+    raise ActionController::RoutingError, "Not Found"
   end
 end

--- a/app/controllers/testing_controller.rb
+++ b/app/controllers/testing_controller.rb
@@ -11,7 +11,7 @@ class TestingController < ApplicationController
 
     # https://github.com/thoughtbot/factory_bot/blob/ca810767e70ccd85c7cb63f775bc16f653a97dc8/GETTING_STARTED.md#rails-preloaders-and-rspec
     FactoryBot.reload
-    
+
     registration_exemption = FactoryBot.build(:registration_exemption, expires_on: expiry_date)
     registration = FactoryBot.create(:registration, registration_exemptions: [registration_exemption])
 

--- a/app/views/testing/show.html.erb
+++ b/app/views/testing/show.html.erb
@@ -1,0 +1,1 @@
+Created registration: <%= registration.reference %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,9 @@ Rails.application.routes.draw do
       to: "quarterly_stats#show",
       as: "quarterly_stats"
 
+  get "/testing/create_registration/:expiry_date",
+       to: "testing#create_registration"
+
   # Engine
   mount WasteExemptionsEngine::Engine => "/"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,7 +83,7 @@ Rails.application.routes.draw do
       as: "quarterly_stats"
 
   get "/testing/create_registration/:expiry_date",
-       to: "testing#create_registration"
+      to: "testing#create_registration"
 
   # Engine
   mount WasteExemptionsEngine::Engine => "/"

--- a/lib/tasks/test_magic_link.rake
+++ b/lib/tasks/test_magic_link.rake
@@ -7,7 +7,7 @@ namespace :test do
     @registration = WasteExemptionsEngine::Registration.find_by(reference: args[:reference])
     if @registration.nil?
       puts "Failed to find registration with reference \"#{args[:reference]}\""
-      exit
+      next
     end
 
     puts magic_link_url

--- a/lib/tasks/test_magic_link.rake
+++ b/lib/tasks/test_magic_link.rake
@@ -6,7 +6,7 @@ namespace :test do
 
     @registration = WasteExemptionsEngine::Registration.find_by(reference: args[:reference])
     if @registration.nil?
-      puts "Failed to find registration with reg_identifier \"#{args[:reference]}\""
+      puts "Failed to find registration with reference \"#{args[:reference]}\""
       exit
     end
 

--- a/spec/requests/testing_spec.rb
+++ b/spec/requests/testing_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Testing" do
+
+  let(:user) { create(:user) }
+
+  before { sign_in(user) }
+
+  describe "/create_registration" do
+    let(:expiry_date) { 2.days.from_now.strftime("%Y-%m-%d") }
+
+    it "creates a registration" do
+      expect { get "/testing/create_registration/#{expiry_date}" }.to change(WasteExemptionsEngine::Registration, :count).by(1)
+    end
+  end
+end

--- a/spec/requests/testing_spec.rb
+++ b/spec/requests/testing_spec.rb
@@ -11,8 +11,23 @@ RSpec.describe "Testing" do
   describe "/create_registration" do
     let(:expiry_date) { 2.days.from_now.strftime("%Y-%m-%d") }
 
-    it "creates a registration" do
-      expect { get "/testing/create_registration/#{expiry_date}" }.to change(WasteExemptionsEngine::Registration, :count).by(1)
+    context "when in a non-production environment" do
+      before { stub_const("ENV", ENV.to_hash.merge("AIRBRAKE_ENV_NAME" => "devwcr")) }
+
+      it "creates a registration" do
+        expect { get "/testing/create_registration/#{expiry_date}" }.to change(WasteExemptionsEngine::Registration, :count).by(1)
+      end
+    end
+
+    context "when in a production environment" do
+      before do
+        allow(Rails.env).to receive(:test?).and_return(false)
+        stub_const("ENV", ENV.to_hash.merge("AIRBRAKE_ENV_NAME" => "production"))
+      end
+
+      it "raises a routing error" do
+        expect { get "/testing/create_registration/#{expiry_date}" }.to raise_error ActionController::RoutingError
+      end
     end
   end
 end


### PR DESCRIPTION
This adds a route to create a registration via FactoryBot, to support automated testing.
https://eaflood.atlassian.net/browse/RUBY-2368