### PR TITLE
Fix return value and marking of sent emails on registrations

### DIFF
--- a/app/presenters/reports/registration_deregistration_email_presenter.rb
+++ b/app/presenters/reports/registration_deregistration_email_presenter.rb
@@ -28,7 +28,8 @@ module Reports
       relevant_exemptions = registration_exemptions.order(:exemption_id).select do |re|
         re.may_expire? || re.expired?
       end
-      relevant_exemptions.map { |ex| "#{ex.exemption.code} #{ex.exemption.summary}" }
+
+      relevant_exemptions.map { |ex| "#{ex.exemption.code} #{ex.exemption.summary}" }.join(", ")
     end
 
     private

--- a/spec/models/reports/deregistration_email_batch_serializer_spec.rb
+++ b/spec/models/reports/deregistration_email_batch_serializer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Reports::DeregistrationEmailBatchSerializer do
       end
 
       it "includes the correct header" do
-        expect(csv.first.map(&:to_sym)).to eq([:email, *described_class::ATTRIBUTES])
+        expect(csv.first.map(&:to_sym)).to eq([:"email address", *described_class::ATTRIBUTES])
       end
 
       it "includes the correct fields" do
@@ -37,7 +37,7 @@ RSpec.describe Reports::DeregistrationEmailBatchSerializer do
           "http://localhost:3000/renew/#{registration.renew_token}",
           registration.exemptions.map do |ex|
             "#{ex.code} #{ex.summary}"
-          end.to_s
+          end.join(", ")
         ]
 
         expect(csv.second).to eq(expected)

--- a/spec/presenters/reports/registration_deregistration_email_presenter_spec.rb
+++ b/spec/presenters/reports/registration_deregistration_email_presenter_spec.rb
@@ -30,7 +30,7 @@ module Reports
       let(:expected) do
         registration.exemptions.map do |ex|
           "#{ex.code} #{ex.summary}"
-        end
+        end.join(", ")
       end
 
       it "returns the correct value" do

--- a/spec/services/reports/deregistration_email_batch_export_service_spec.rb
+++ b/spec/services/reports/deregistration_email_batch_export_service_spec.rb
@@ -9,6 +9,7 @@ module Reports
       let(:aws_response) { instance_double(DefraRuby::Aws::Response, successful?: true) }
       let(:bucket_name) { "buck-it" }
       let(:file_name) { "foo" }
+      let(:registration) { create(:registration, :eligible_for_deregistration) }
 
       subject(:service) { described_class.new }
 
@@ -25,7 +26,7 @@ module Reports
         allow(service).to receive(:file_name).and_return("foo")
         allow(DefraRuby::Aws).to receive(:get_bucket).and_return(bucket)
 
-        create(:registration, :eligible_for_deregistration)
+        registration
       end
 
       context "when succesful" do
@@ -34,7 +35,9 @@ module Reports
         end
 
         it "generates a CSV file containing all active exemptions and uploads it to AWS" do
-          service.run(batch_size: 1)
+          expect(service.run(batch_size: 1)).to be(true)
+
+          expect(registration.reload.deregistration_email_sent_at).not_to be_blank
 
           expect(bucket).to have_received(:load)
 


### PR DESCRIPTION
- Set `deregistration_email_sent_at` timestamp on exported registrations
- Explicitly return `true` from serializer to indicate happy path succeeded
- Set correct column header for email address (`email address`)
- Join exemption details using commas