### PR TITLE
Move resend deregistration email link

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -46,7 +46,8 @@ module ActionLinksHelper
   def display_resend_deregistration_email_link_for?(resource)
     resource.is_a?(WasteExemptionsEngine::Registration) &&
       can?(:resend_registration_email, resource) &&
-      !resource.in_renewal_window?
+      !resource.in_renewal_window? &&
+      !resource.already_renewed?
   end
 
   def display_confirmation_letter_link_for?(resource)

--- a/app/views/shared/_resource_details.html.erb
+++ b/app/views/shared/_resource_details.html.erb
@@ -128,6 +128,18 @@
         </p>
       <% end %>
 
+      <% if display_resend_deregistration_email_link_for?(resource) %>
+        <p class="govuk-body">
+          <%= link_to resend_deregistration_emails_path(resource), id: "resend_deregistration_email_#{resource.reference}" do %>
+            <%= t(".actions.resend_deregistration_email.link_text") %>
+            <span class="govuk-visually-hidden">
+            <%= t(".actions.resend_deregistration_email.visually_hidden_text",
+                  name: result_name_for_visually_hidden_text(resource)) %>
+          </span>
+          <% end %>
+        </p>
+      <% end %>
+
       <% if display_already_renewed_text_for?(resource) %>
         <p class="govuk-body"><%= t(".actions.renew.already_renewed") %></p>
       <% elsif display_renew_links_for?(resource) %>

--- a/app/views/shared/_search_result.html.erb
+++ b/app/views/shared/_search_result.html.erb
@@ -107,18 +107,6 @@
       </p>
     <% end %>
 
-    <% if display_resend_deregistration_email_link_for?(result) %>
-      <p class="govuk-body">
-        <%= link_to resend_deregistration_emails_path(result), id: "resend_deregistration_email_#{result.reference}" do %>
-          <%= t(".actions.resend_deregistration_email.link_text") %>
-          <span class="govuk-visually-hidden">
-           <%= t(".actions.resend_deregistration_email.visually_hidden_text",
-                 name: result_name_for_visually_hidden_text(result)) %>
-         </span>
-        <% end %>
-      </p>
-    <% end %>
-
     <% if display_already_renewed_text_for?(result) %>
       <p class="govuk-body">
         <%= t(".actions.renew.already_renewed") %>

--- a/config/locales/partials/resource_details.en.yml
+++ b/config/locales/partials/resource_details.en.yml
@@ -70,6 +70,9 @@ en:
           link_text: "Resend renewal email"
           visually_hidden_text: "of %{name}"
         resend_renewal_letter: "Resend renewal letter"
+        resend_deregistration_email:
+          link_text: "Send deregistration invite"
+          visually_hidden_text: "resend deregistration email of %{name}"
       no_applicant_data: "No applicant details"
       no_contact_data: "No contact details"
       no_exemptions: "No exemptions"

--- a/config/locales/partials/search_result.en.yml
+++ b/config/locales/partials/search_result.en.yml
@@ -29,9 +29,6 @@ en:
         resume:
           link_text: "Resume"
           visually_hidden_text: "registering %{name}"
-        resend_deregistration_email:
-          link_text: "Send deregistration invite"
-          visually_hidden_text: "resend deregistration email of %{name}"
         renew:
           link_text: "Start renewal"
           visually_hidden_text: "of %{name}"

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -197,16 +197,16 @@ RSpec.describe ActionLinksHelper do
   end
 
   describe "display_resend_deregistration_email_link_for?" do
-    context "when the resource is an active registration" do
-      let(:resource) do
-        registration = create(:registration)
-        registration.registration_exemptions.each do |re|
-          re.state = "active"
-          re.save!
-        end
-        registration
+    let(:resource) do
+      registration = create(:registration)
+      registration.registration_exemptions.each do |re|
+        re.state = "active"
+        re.save!
       end
+      registration
+    end
 
+    context "when the resource is an active registration" do
       before { allow(helper).to receive(:can?).with(:resend_registration_email, resource).and_return(can) }
 
       context "when the user has permission to deregister a registration" do
@@ -235,6 +235,16 @@ RSpec.describe ActionLinksHelper do
         it "returns false" do
           expect(helper.display_resend_deregistration_email_link_for?(resource)).to be(false)
         end
+      end
+    end
+
+    context "when the resource is an already renewed registration" do
+      before do
+        resource.referring_registration = create(:registration)
+      end
+
+      it "returns false" do
+        expect(helper.display_resend_deregistration_email_link_for?(resource)).to be(false)
       end
     end
 


### PR DESCRIPTION
Move deregistration email link from search results to resource details page and only show it for not already renewed registrations.

https://eaflood.atlassian.net/browse/RUBY-2366