### PR TITLE
Modify uglifier instantiation to support ES6

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,8 @@ Rails.application.configure do
   config.serve_static_files = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
+
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
This is to fix an issue with assets precompilation during production deployments.
https://eaflood.atlassian.net/browse/RUBY-2478