### PR TITLE
Feature/edit forms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem "sucker_punch", "~> 3.1"
 # Use the waste exemptions engine for the user journey
 gem "waste_exemptions_engine",
     git: "https://github.com/DEFRA/waste-exemptions-engine",
-    branch: "main"
+    branch: "feature/edit_registration"
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.

--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem "sucker_punch", "~> 3.1"
 # Use the waste exemptions engine for the user journey
 gem "waste_exemptions_engine",
     git: "https://github.com/DEFRA/waste-exemptions-engine",
-    branch: "feature/edit_registration"
+    branch: "main"
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.

--- a/app/controllers/testing_controller.rb
+++ b/app/controllers/testing_controller.rb
@@ -17,7 +17,7 @@ class TestingController < ApplicationController
 
     # Ensure edit_token_created_at is populated
     registration.regenerate_and_timestamp_edit_token
-    
+
     render :show, locals: { registration: registration }
   end
 

--- a/app/controllers/testing_controller.rb
+++ b/app/controllers/testing_controller.rb
@@ -15,6 +15,9 @@ class TestingController < ApplicationController
     registration = FactoryBot.create(:registration,
                                      registration_exemptions: registration_exemptions(3))
 
+    # Ensure edit_token_created_at is populated
+    registration.regenerate_and_timestamp_edit_token
+    
     render :show, locals: { registration: registration }
   end
 

--- a/app/views/testing/show.html.erb
+++ b/app/views/testing/show.html.erb
@@ -1,1 +1,2 @@
 Created registration: <%= registration.reference %>
+Edit token: <%= registration.edit_token %>


### PR DESCRIPTION
This change updates an automated test helper route `create_registration` to refresh the registration's edit_token and return the token value in the response.
https://eaflood.atlassian.net/browse/RUBY-2566
https://eaflood.atlassian.net/browse/RUBY-2563
https://eaflood.atlassian.net/browse/RUBY-2561
https://eaflood.atlassian.net/browse/RUBY-2562
https://eaflood.atlassian.net/browse/RUBY-2598
https://eaflood.atlassian.net/browse/RUBY-2602
https://eaflood.atlassian.net/browse/RUBY-2565
https://eaflood.atlassian.net/browse/RUBY-2643
https://eaflood.atlassian.net/browse/RUBY-2644