### PR TITLE
Fix/ruby 2481 comms history

### DIFF
--- a/app/views/communication_logs/index.html.erb
+++ b/app/views/communication_logs/index.html.erb
@@ -33,7 +33,7 @@
                 <%= log.sent_to %>
               </td>
               <td class="govuk-table__cell">
-                <%= log.created_at.to_formatted_s(:day_month_and_time) %>
+                <%= log.created_at.to_formatted_s(:time_on_day_month_year) %>
               </td>
             </tr>
           <% end %>

--- a/lib/tasks/one_off/move_deregistration_email_sent_at_to_communication_logs.rake
+++ b/lib/tasks/one_off/move_deregistration_email_sent_at_to_communication_logs.rake
@@ -22,7 +22,9 @@ namespace :one_off do
         registration.communication_logs << WasteExemptionsEngine::CommunicationLog.new(
           message_type: "email",
           template_id: "9148895b-e239-4118-8ffd-dadd9b2cf462",
-          template_label: "Deregistration confirmation email",
+          template_label: "Self serve exemption deregistration invite",
+          # override created_at to use the time the email was sent
+          created_at: registration.deregistration_email_sent_at,
           # we can't be sure whether the email was sent to the contact email, applicant email or both, so leave nil
           sent_to: nil
         )

--- a/spec/lib/tasks/one_off/move_deregistration_email_sent_at_to_communication_logs_spec.rb
+++ b/spec/lib/tasks/one_off/move_deregistration_email_sent_at_to_communication_logs_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe "one_off:move_deregistration_email_sent_at_to_communication_logs"
   after { rake_task.reenable }
 
   let(:not_set_registrations) { create_list(:registration, 2, deregistration_email_sent_at: nil) }
-  let(:set_registrations) { create_list(:registration, 5, deregistration_email_sent_at: Time.zone.now) }
+  let(:set_registrations) { create_list(:registration, 5, deregistration_email_sent_at: sent_time) }
+  let(:sent_time) { 2.months.ago }
   let(:registration_count_with_attribute) do
     WasteExemptionsEngine::Registration.where.not(deregistration_email_sent_at: nil).count
   end
@@ -26,10 +27,37 @@ RSpec.describe "one_off:move_deregistration_email_sent_at_to_communication_logs"
     expect { rake_task.invoke }.not_to raise_error
   end
 
+  context "when deregistration_email_sent_at is not set" do
+    it "does not update the registration" do
+      expect { rake_task.invoke }.not_to change { not_set_registrations }
+    end
+  end
+
+  context "when deregistration_email_sent_at is set" do
+    it "copies the expected data to communication_logs" do
+      rake_task.invoke
+
+      reg = set_registrations.last
+      log = reg.communication_logs.last
+      expect(log.message_type).to eq "email"
+      expect(log.template_id).to eq "9148895b-e239-4118-8ffd-dadd9b2cf462"
+      expect(log.template_label).to eq "Self serve exemption deregistration invite"
+      expect(log.sent_to).to be_nil
+      # Allow for sub-millisecond rounding
+      expect(log.created_at).to be_within(0.000001.seconds).of(sent_time)
+    end
+
+    it "clears the deregistration_email_sent_at value from the registration" do
+      expect { rake_task.invoke }
+        .to change { WasteExemptionsEngine::Registration.where.not(deregistration_email_sent_at: nil).count }
+        .to(0)
+    end
+  end
+
   describe "batch size configuration" do
 
     context "with the default batch size" do
-      it "processes all registraitons" do
+      it "processes all registrations" do
         rake_task.invoke
 
         expect(registration_count_with_attribute).to be_zero
@@ -37,7 +65,7 @@ RSpec.describe "one_off:move_deregistration_email_sent_at_to_communication_logs"
     end
 
     context "with a specified batch size lower than the number of qualifying registrations" do
-      it "runs the service with the specified lead time" do
+      it "processes only the specified number of registrations" do
         rake_task.invoke(3)
 
         expect(registration_count_with_attribute).to eq 2


### PR DESCRIPTION
- Add year to date/time in comms history table
- Use deregistration_email_sent_at value as timestamp in comms history
- Fix deregistration invite email tempalte name
https://eaflood.atlassian.net/browse/RUBY-2481
