### PR TITLE
[RUBY-2976] Add unsubscribe functionality for renewal emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem "sucker_punch", "~> 3.1"
 # Use the waste exemptions engine for the user journey from the local repo
 gem "waste_exemptions_engine",
     git: "https://github.com/DEFRA/waste-exemptions-engine",
-    branch: "RUBY-2976-wex-add-unsubscribe-functionality-to-the-renewal-reminder-emails-in-wex"
+    branch: "main"
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.

--- a/Gemfile
+++ b/Gemfile
@@ -66,10 +66,10 @@ gem "paper_trail"
 # Used for handling background processes
 gem "sucker_punch", "~> 3.1"
 
-# Use the waste exemptions engine for the user journey
+# Use the waste exemptions engine for the user journey from the local repo
 gem "waste_exemptions_engine",
     git: "https://github.com/DEFRA/waste-exemptions-engine",
-    branch: "main"
+    branch: "RUBY-2976-wex-add-unsubscribe-functionality-to-the-renewal-reminder-emails-in-wex"
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: 3f56b7127405fedbdbff930ca0be55e8f906de7f
-  branch: RUBY-2976-wex-add-unsubscribe-functionality-to-the-renewal-reminder-emails-in-wex
+  revision: 223bdccc5e4b631007505fc414b1530ff3dac517
+  branch: main
   specs:
     waste_exemptions_engine (0.1.0)
       aasm (~> 5.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: b59b6f02127f32c60af545e6abd2284cb6f3899b
-  branch: main
+  revision: 3f56b7127405fedbdbff930ca0be55e8f906de7f
+  branch: RUBY-2976-wex-add-unsubscribe-functionality-to-the-renewal-reminder-emails-in-wex
   specs:
     waste_exemptions_engine (0.1.0)
       aasm (~> 5.5)
@@ -339,7 +339,7 @@ GEM
       rake (>= 0.8.1)
     pg (1.5.4)
     pgreset (0.4)
-    phonelib (0.8.7)
+    phonelib (0.8.8)
     poltergeist (1.18.1)
       capybara (>= 2.1, < 4)
       cliver (~> 0.3.1)
@@ -473,6 +473,8 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    simpleidn (0.2.1)
+      unf (~> 0.1.4)
     spring (4.1.3)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -499,11 +501,15 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     uk_postcode (2.1.8)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.9.1)
     unicode-display_width (2.5.0)
     uniform_notifier (1.16.0)
     uri (0.13.0)
-    validates_email_format_of (1.7.2)
-      i18n
+    validates_email_format_of (1.8.0)
+      i18n (>= 0.8.0)
+      simpleidn
     vcr (6.2.0)
     warden (1.2.9)
       rack (>= 2.0.9)

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -33,6 +33,8 @@ module WasteExemptionsEngine
       joins(:addresses).merge(Address.site.not_nccc)
     }
 
+    scope :opted_in_to_renewal_emails, -> { where(reminder_opt_in: true) }
+
     def active?
       state == "active"
     end

--- a/app/services/renewal_reminder_service.rb
+++ b/app/services/renewal_reminder_service.rb
@@ -19,7 +19,8 @@ class RenewalReminderService < WasteExemptionsEngine::BaseService
       expiry_date: expiry_date,
       magic_link_url: magic_link_url,
       reference: @registration.reference,
-      site_location: site_location
+      site_location: site_location,
+      unsubscribe_link: unsubscribe_link
     }
   end
 
@@ -57,5 +58,9 @@ class RenewalReminderService < WasteExemptionsEngine::BaseService
     else
       displayable_address(address).join(", ")
     end
+  end
+
+  def unsubscribe_link
+    WasteExemptionsEngine::UnsubscribeLinkService.run(registration: @registration)
   end
 end

--- a/app/services/renewal_reminder_service_base.rb
+++ b/app/services/renewal_reminder_service_base.rb
@@ -14,7 +14,7 @@ class RenewalReminderServiceBase < WasteExemptionsEngine::BaseService
       registration.communication_logs.create(
         message_type: "email",
         template_id: "N/A",
-        template_label: "USER OPTED OUT - NO EMAIL SENT",
+        template_label: "USER OPTED OUT - NO RENEWAL REMINDER EMAIL SENT",
         sent_to: registration.contact_email
       )
     end

--- a/app/services/renewal_reminder_service_base.rb
+++ b/app/services/renewal_reminder_service_base.rb
@@ -2,11 +2,21 @@
 
 class RenewalReminderServiceBase < WasteExemptionsEngine::BaseService
   def run
-    expiring_registrations.each do |registration|
+    expiring_registrations_opted_in.each do |registration|
       send_email(registration)
     rescue StandardError => e
       Airbrake.notify e, registration: registration.reference
       Rails.logger.error "Failed to send first renewal email for registration #{registration.reference}"
+    end
+
+    expiring_registrations_opted_out.each do |registration|
+      registration.communication_logs ||= []
+      registration.communication_logs.create(
+        message_type: "email",
+        template_id: "N/A",
+        template_label: "USER OPTED OUT - NO EMAIL SENT",
+        sent_to: registration.contact_email
+      )
     end
   end
 
@@ -20,6 +30,14 @@ class RenewalReminderServiceBase < WasteExemptionsEngine::BaseService
     default_scope.where(
       id: all_active_exemptions_registration_ids
     ).contact_email_present.site_address_is_not_nccc
+  end
+
+  def expiring_registrations_opted_in
+    expiring_registrations.opted_in_to_renewal_emails
+  end
+
+  def expiring_registrations_opted_out
+    expiring_registrations - expiring_registrations_opted_in
   end
 
   def all_active_exemptions_registration_ids

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_22_145717) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_20_151621) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "tsm_system_rows"
@@ -151,10 +151,13 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_22_145717) do
     t.datetime "deregistration_email_sent_at", precision: nil
     t.string "edit_token"
     t.datetime "edit_token_created_at"
+    t.boolean "reminder_opt_in", default: true
+    t.string "unsubscribe_token"
     t.index ["deregistration_email_sent_at"], name: "index_registrations_on_deregistration_email_sent_at"
     t.index ["edit_token"], name: "index_registrations_on_edit_token", unique: true
     t.index ["reference"], name: "index_registrations_on_reference", unique: true
     t.index ["renew_token"], name: "index_registrations_on_renew_token", unique: true
+    t.index ["unsubscribe_token"], name: "index_registrations_on_unsubscribe_token", unique: true
   end
 
   create_table "reports_generated_reports", id: :serial, force: :cascade do |t|

--- a/spec/services/first_renewal_reminder_service_spec.rb
+++ b/spec/services/first_renewal_reminder_service_spec.rb
@@ -94,5 +94,28 @@ RSpec.describe FirstRenewalReminderService do
 
       expect(FirstRenewalReminderEmailService).not_to have_received(:run)
     end
+
+    it "does not send emails to registrations with reminder_opt_in set to false" do
+      registration_with_opt_out = create(
+        :registration,
+        reminder_opt_in: false,
+        registration_exemptions: [
+          build(:registration_exemption, :active, expires_on: 4.weeks.from_now.to_date)
+        ]
+      )
+
+      registration_with_opt_in = create(
+        :registration,
+        reminder_opt_in: true,
+        registration_exemptions: [
+          build(:registration_exemption, :active, expires_on: 4.weeks.from_now.to_date)
+        ]
+      )
+
+      described_class.run
+
+      expect(FirstRenewalReminderEmailService).not_to have_received(:run).with(registration: registration_with_opt_out)
+      expect(FirstRenewalReminderEmailService).to have_received(:run).with(registration: registration_with_opt_in)
+    end
   end
 end


### PR DESCRIPTION
This commit makes the following changes:

1. Adds a new scope `:opted_in_to_renewal_emails` to the `WasteExemptionsEngine::Registration` model, which filters registrations that have opted in to receive renewal reminder emails.

2. Modifies the `RenewalReminderService` to include an `unsubscribe_link` in the email payload and generates the unsubscribe token for the registration.

3. Updates the `RenewalReminderServiceBase` to handle the sending of emails differently based on whether the registration has opted in or out of renewal reminder emails. For registrations that have opted out, it logs the communication without sending an email.

4. Introduces changes to the database schema to include `reminder_opt_in` and `unsubscribe_token` fields to the `registrations` table.

5. Adds tests to the `FirstRenewalReminderServiceSpec` to ensure that emails are not sent to registrations that have opted out of renewal reminders, and that emails are sent to those that have opted in.
