### PR TITLE
[RUBY-2749] Add deregistration details page, and enhance styles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,9 @@ jobs:
           bundle exec rubocop --format progress --format json --out rubocop-result.json
 
       # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
-      # folder mounted as `/github/workspace`. The problem is when the .resultset.json file is generated it will
+      # folder mounted as `/github/workspace`. The problem is when the coverage.json file is generated it will
       # reference the code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use
-      # sed to update the references in .resultset.json
+      # sed to update the references in coverage.json
       # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
       - name: Run unit tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           bundle exec rails test
           bundle exec rspec
-          sed -i 's/\/home\/runner\/work\/waste-exemptions-back-office\/waste-exemptions-back-office\//\/github\/workspace\//g' coverage/.resultset.json
+          sed -i 's/\/home\/runner\/work\/waste-exemptions-back-office\/waste-exemptions-back-office\//\/github\/workspace\//g' coverage/coverage.json
 
       - name: Analyze with SonarCloud
         uses: sonarsource/sonarcloud-github-action@master

--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem "sucker_punch", "~> 3.2"
 # Use the waste exemptions engine for the user journey from the local repo
 gem "waste_exemptions_engine",
     git: "https://github.com/DEFRA/waste-exemptions-engine",
-    branch: "main"
+    branch: "RUBY-2749-wex-bo-add-deregistration-details-to-a-registration"
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.

--- a/Gemfile
+++ b/Gemfile
@@ -125,7 +125,7 @@ group :test do
   gem "faker"
   # Generates a test coverage report on every `bundle exec rspec` call. We use
   # the output to feed CodeClimate's stats and analysis
-  gem "simplecov", require: false
+  gem "simplecov", "~> 0.22.0", require: false
   # Integration testing tool
   gem "capybara"
   # Needed for headless testing with Javascript or pages that ref external sites

--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem "sucker_punch", "~> 3.2"
 # Use the waste exemptions engine for the user journey from the local repo
 gem "waste_exemptions_engine",
     git: "https://github.com/DEFRA/waste-exemptions-engine",
-    branch: "RUBY-2749-wex-bo-add-deregistration-details-to-a-registration"
+    branch: "main"
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: de65e8c379aa04aab83de480176e4a8932fd3bfa
-  branch: main
+  revision: 7ccc6b1f2c39899c30f7070e9079e5065079e0be
+  branch: RUBY-2749-wex-bo-add-deregistration-details-to-a-registration
   specs:
     waste_exemptions_engine (0.1.0)
       aasm (~> 5.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: 7ccc6b1f2c39899c30f7070e9079e5065079e0be
-  branch: RUBY-2749-wex-bo-add-deregistration-details-to-a-registration
+  revision: e4eaa94e4316cf62f7612206c64b750b8cbb1ad7
+  branch: main
   specs:
     waste_exemptions_engine (0.1.0)
       aasm (~> 5.5)
@@ -506,7 +506,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    simpleidn (0.2.1)
+    simpleidn (0.2.2)
       unf (~> 0.1.4)
     spring (4.2.0)
     spring-commands-rspec (1.0.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -608,7 +608,7 @@ DEPENDENCIES
   rubyzip
   sassc-rails
   secure_headers (~> 6.5)
-  simplecov
+  simplecov (~> 0.22.0)
   spring
   spring-commands-rspec
   sucker_punch (~> 3.2)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,3 +9,7 @@
 .float-right {
   float: right;
 }
+
+.govuk-table__caption--m {
+  text-align: left;
+}

--- a/app/controllers/deregistrations_controller.rb
+++ b/app/controllers/deregistrations_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class DeregistrationsController < ApplicationController
+  helper ActionLinksHelper
+
+  def show
+    find_resource(params[:reference])
+    authorize
+  end
+
+  private
+
+  def find_resource(reference)
+    @resource = WasteExemptionsEngine::Registration.find_by(reference: reference)
+  end
+
+  def authorize
+    authorize! :read, @resource
+  end
+end

--- a/app/models/waste_exemptions_engine/registration_exemption.rb
+++ b/app/models/waste_exemptions_engine/registration_exemption.rb
@@ -44,5 +44,15 @@ module WasteExemptionsEngine
       # timestamp is first updated.
       saved_change_to_deregistered_at?
     end
+
+    def deregistered_by
+      # As versions are only saved when deregistere_at is changed, so we know the
+      # version that exists will have the email of the user who deregistered it
+      deregistration_version = versions.where(event: "update").last
+
+      return if deregistration_version.blank?
+
+      deregistration_version.whodunnit
+    end
   end
 end

--- a/app/views/deregistrations/show.html.erb
+++ b/app/views/deregistrations/show.html.erb
@@ -1,0 +1,49 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render("waste_exemptions_engine/shared/back", back_path: registration_path(@resource.reference), back_link_label: t(".back_link_label")) %>
+    <table class="govuk-table">
+      <%#align table caption to the left%>
+      <caption class="govuk-table__caption--m"><%= t('.title', reference: @resource.reference) %></caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col"><%= t('.headers.exemption') %></th>
+          <th class="govuk-table__header" scope="col"><%= t('.headers.deregistered_on') %></th>
+          <th class="govuk-table__header" scope="col"><%= t('.headers.reason') %></th>
+          <th class="govuk-table__header" scope="col"><%= t('.headers.status') %></th>
+          <th class="govuk-table__header" scope="col"><%= t('.headers.deregistered_by') %></th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @resource.registration_exemptions.deregistered.each do |re| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= re.exemption.code %> &mdash; <%= re.exemption.summary %></td>
+            <td class="govuk-table__cell date-nowrap">
+              <% if re.deregistered_at.present? %>
+                <%= re.deregistered_at.to_formatted_s(:day_month_year) %>
+              <% end %>
+            </td>
+            <td class="govuk-table__cell date-nowrap">
+              <% if re.deregistration_message.present? %>
+                <%= re.deregistration_message %>
+              <% else %>
+                <%= t('.deregistered_via_self_serve_reason') %>
+              <% end %>
+            </td>
+            <td class="govuk-table__cell">
+              <% if re.state.present? %>
+                <span class="<%= "status-tag-#{re.state}" %>"><%= re.state %></span>
+              <% end %>
+            </td>
+            <td class="govuk-table__cell">
+              <% if re.deregistered_by.present? %>
+                <%= re.deregistered_by %>
+              <% else %>
+                <%= t('.deregistered_by_self') %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/shared/_resource_exemptions_list.html.erb
+++ b/app/views/shared/_resource_exemptions_list.html.erb
@@ -36,6 +36,13 @@
               exemption <%= re.exemption.code %> &mdash; <%= re.exemption.summary %>
             </span>
           </a>
+        <% elsif %w[ceased revoked].include? re.state %>
+          <a class="govuk-link" href="<%= deregistration_path(re.registration.reference) %>">
+            Details
+            <span class="govuk-visually-hidden">
+              exemption <%= re.exemption.code %> &mdash; <%= re.exemption.summary %>
+            </span>
+          </a>
         <% end %>
       </td>
     </tr>

--- a/config/locales/deregistrations.en.yml
+++ b/config/locales/deregistrations.en.yml
@@ -1,0 +1,14 @@
+en:
+  deregistrations:
+    show:
+      title: "Deregistration details"
+      table_caption: "Deregistration details %{reference}"
+      headers:
+        exemption: "Exemption"
+        deregistered_on: "Deregistered on"
+        reason: "Reason"
+        status: "Status"
+        deregistered_by: "Deregistered by"
+      deregistered_by_self: "Self-serve"
+      deregistered_via_self_serve_reason: "Deregistered via self-serve"
+      back_link_label: "Back to main details"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,8 @@ Rails.application.routes.draw do
     get "communication_logs", to: "communication_logs#index", as: :communication_logs
   end
 
+  resources :deregistrations, only: :show, param: :reference
+
   get "/registrations/:id/modify_expiry_date", to: "modify_expiry_date#new", as: :modify_expiry_date_form
   post "/registrations/:id/modify_expiry_date", to: "modify_expiry_date#update", as: :modify_expiry_date
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_20_151621) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_20_151621) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "tsm_system_rows"
@@ -151,9 +151,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_20_151621) do
     t.datetime "deregistration_email_sent_at", precision: nil
     t.string "edit_token"
     t.datetime "edit_token_created_at"
-    t.boolean "reminder_opt_in", default: true
+    t.boolean "reminder_opt_in"
     t.string "unsubscribe_token"
     t.index ["deregistration_email_sent_at"], name: "index_registrations_on_deregistration_email_sent_at"
+    t.index ["edit_token"], name: "index_registrations_on_edit_token", unique: true
     t.index ["reference"], name: "index_registrations_on_reference", unique: true
     t.index ["renew_token"], name: "index_registrations_on_renew_token", unique: true
     t.index ["unsubscribe_token"], name: "index_registrations_on_unsubscribe_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_20_151621) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_20_151621) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "tsm_system_rows"
@@ -151,10 +151,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_20_151621) do
     t.datetime "deregistration_email_sent_at", precision: nil
     t.string "edit_token"
     t.datetime "edit_token_created_at"
-    t.boolean "reminder_opt_in"
+    t.boolean "reminder_opt_in", default: true
     t.string "unsubscribe_token"
     t.index ["deregistration_email_sent_at"], name: "index_registrations_on_deregistration_email_sent_at"
-    t.index ["edit_token"], name: "index_registrations_on_edit_token", unique: true
     t.index ["reference"], name: "index_registrations_on_reference", unique: true
     t.index ["renew_token"], name: "index_registrations_on_renew_token", unique: true
     t.index ["unsubscribe_token"], name: "index_registrations_on_unsubscribe_token", unique: true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -26,5 +26,5 @@ sonar.tests=./spec
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
 
-sonar.ruby.coverage.reportPath=coverage/.resultset.json
+sonar.ruby.coverage.reportPaths=coverage/coverage.json
 sonar.ruby.rubocop.reportPaths=rubocop-result.json

--- a/spec/requests/deregistrations_spec.rb
+++ b/spec/requests/deregistrations_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Deregistrations" do
   let(:registration) { create(:registration) }
 
-  describe "GET /deregistrations/:reference" do
+  describe "GET #show" do
     context "when a user is signed in" do
       before do
         sign_in(create(:user))

--- a/spec/requests/deregistrations_spec.rb
+++ b/spec/requests/deregistrations_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Deregistrations" do
+  let(:registration) { create(:registration) }
+
+  describe "GET /deregistrations/:reference" do
+    context "when a user is signed in" do
+      before do
+        sign_in(create(:user))
+      end
+
+      it "renders the show template and includes the correct reference" do
+        get "/deregistrations/#{registration.reference}"
+
+        expect(response).to render_template(:show)
+        expect(response.body).to include(registration.reference)
+      end
+
+      it "includes the correct back link" do
+        get "/deregistrations/#{registration.reference}"
+
+        expect(response.body).to include("Back to main details")
+        expect(response.body).to include(registration_path(registration.reference))
+      end
+    end
+
+    context "when a valid user is not signed in" do
+      before { sign_out(create(:user)) }
+
+      it "redirects to the sign-in page" do
+        get "/registrations/#{registration.id}"
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/support/simplecov.rb
+++ b/spec/support/simplecov.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 require "simplecov"
+require "simplecov_json_formatter"
+
+SimpleCov.formatters = [
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::JSONFormatter
+]
 
 # We start it with the rails param to ensure it includes coverage for all code
 # started by the rails app, and not just the files touched by our unit tests.


### PR DESCRIPTION
- Introduce DeregistrationsController with a show action to display deregistration details.
- Extend RegistrationExemption model with a deregistered_by method to track the user who performed the deregistration.
- Create a new view for showing deregistration details in deregistrations/show.html.erb.
- Update the resource exemptions list partial to include links to the new deregistration details page for ceased or revoked exemptions.
- Add localization entries for deregistration details in config/locales/deregistrations.en.yml.
- Include a new route for deregistrations show action.
- Add tests for the deregistered_by method in registration_exemption_spec.rb to ensure proper functionality.
- Add styling for .govuk-table__caption--m in application.scss to align the table caption to the left.

This commit introduces the ability to view deregistration details for exemptions and includes necessary model, view, controller, and styling changes to support this feature. It also ensures that the Gemfile points to the correct feature branch for the waste_exemptions_engine gem.
