### PR TITLE
[RUBY-3013] feat: Add rake task to fix undefined areas for manually added site addresses

### DIFF
--- a/lib/tasks/one_off/undefined_area_fix.rake
+++ b/lib/tasks/one_off/undefined_area_fix.rake
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+namespace :one_off do
+  desc "Fix areas for manually added site addresses (see RUBY-3013)"
+  task undefined_area_fix: :environment do
+    # 1. Find registrations with undefined EA area
+    regs = find_registrations_with_undefined_area
+
+    stats = { regs_count: regs.count, addr_fixed_count: 0, addr_partcode_fixed_count: 0, addr_not_fixed_count: 0 }
+
+    # 2. Find out the number of site addresses that can be fixed by matching cobtact and operator addresses
+    regs.select do |reg|
+      next if reg.site_address.area.present?
+
+      area = find_area_by_postcode(reg.site_address.postcode)
+      if area.present?
+        reg.site_address.update(area: area)
+        stats[:addr_fixed_count] += 1
+        next
+      end
+
+      partcode = reg.site_address.postcode[0..-2]
+      area = find_area_by_postcode(partcode)
+      if area.present?
+        reg.site_address.update(area: area)
+        stats[:addr_partcode_fixed_count] += 1
+        next
+      end
+
+      stats[:addr_not_fixed_count] += 1
+    end
+
+    print_stats(stats)
+  end
+end
+
+def find_registrations_with_undefined_area
+  undefined_reg_site_addresses = WasteExemptionsEngine::Address.where(address_type: 3, mode: 2).where(area: nil)
+  WasteExemptionsEngine::Registration.where("created_at > ?", 3.years.ago)
+                                     .where(id: undefined_reg_site_addresses.pluck(:registration_id))
+end
+
+def find_area_by_postcode(postcode)
+  coords = WasteExemptionsEngine::DetermineEastingAndNorthingService.run(grid_reference: nil, postcode: postcode)
+  if coords.present? && coords[:easting] > 0.0 && coords[:northing] > 0.0
+    area = WasteExemptionsEngine::DetermineAreaService.run(easting: coords[:easting], northing: coords[:northing])
+    return area
+  end
+  nil
+end
+
+def print_stats(stats)
+  return if Rails.env.test?
+
+  puts "Number of regs with undefined EA area: #{stats[:regs_count]}"
+  puts "Number of regs that can be fixed without data manipulations: #{stats[:addr_fixed_count]}"
+  puts "Number of regs that can be fixed by matching postcode (excl. last letter): #{stats[:addr_partcode_fixed_count]}"
+  puts "Number of regs that can't be fixed: #{stats[:addr_not_fixed_count]}"
+end

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  WasteExemptionsEngine::Address.address_types
+  address_types = WasteExemptionsEngine::Address.address_types
+  modes = WasteExemptionsEngine::Address.modes
 
   factory :address, class: "WasteExemptionsEngine::Address" do
     sequence :postcode do |n|
@@ -42,6 +43,36 @@ FactoryBot.define do
       grid_reference { "ST 58337 72855" }
       x { 358_337.0 }
       y { 172_855.0 }
+    end
+
+    trait :operator_address do
+      address_type { address_types[:operator] }
+    end
+
+    trait :contact_address do
+      address_type { address_types[:contact] }
+    end
+
+    trait :site_address do
+      address_type { address_types[:site] }
+    end
+
+    trait :postal do
+      manual
+
+      sequence :postcode do |n|
+        "BS#{n}AA"
+      end
+
+      uprn { Faker::Alphanumeric.unique.alphanumeric(number: 8) }
+      premises { Faker::Address.community }
+      street_address { Faker::Address.street_address }
+      locality { Faker::Address.country }
+      city { Faker::Address.city }
+    end
+
+    trait :manual do
+      mode { modes[:manual] }
     end
 
     trait :site do

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -150,5 +150,13 @@ FactoryBot.define do
     trait :with_valid_mobile_phone_number do
       contact_phone { "07851456789" }
     end
+
+    trait :with_manual_site_address do
+      addresses do
+        [build(:address, :operator_address, :postal),
+         build(:address, :contact_address, :postal),
+         build(:address, :site_address, :manual, :postal)]
+      end
+    end
   end
 end

--- a/spec/lib/tasks/one_off/undefined_area_fix_spec.rb
+++ b/spec/lib/tasks/one_off/undefined_area_fix_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "one_off:undefined_area_fix", type: :rake do
+
+  subject(:run_rake_task) { rake_task.invoke }
+
+  include_context "rake"
+
+  let(:rake_task) { Rake::Task["one_off:undefined_area_fix"] }
+
+  let(:reg_with_postcode_that_can_be_found) do
+    reg1 = create(:registration, :site_uses_address, :with_manual_site_address, created_at: 1.year.ago)
+    reg1.site_address.update(postcode: "WA16 0AW", area: nil)
+    reg1
+  end
+
+  let(:reg_with_postcode_that_cannot_be_found) do
+    reg2 = create(:registration, :site_uses_address, :with_manual_site_address, created_at: 1.year.ago)
+    reg2.site_address.update(postcode: "PE33 0NE", area: nil)
+    reg2
+  end
+
+  let(:coords) { { easting: 123.4, northing: 123.5 } }
+
+  # By default Rails prevents multiple invocations of the same Rake task in succession
+  after { rake_task.reenable }
+
+  it { expect { run_rake_task }.not_to raise_error }
+
+  it "updates the area for a registration with a site address postcode that can be found" do
+    allow(WasteExemptionsEngine::DetermineEastingAndNorthingService).to receive(:run).with(grid_reference: nil, postcode: "WA16 0AW").and_return(coords)
+    allow(WasteExemptionsEngine::DetermineAreaService).to receive(:run).and_return("Yorkshire")
+    expect { run_rake_task }.to change { reg_with_postcode_that_can_be_found.site_address.reload.area }.to "Yorkshire"
+  end
+
+  it "updates the area for a registration with a site address postcode that cannot be found" do
+    allow(WasteExemptionsEngine::DetermineEastingAndNorthingService).to receive(:run).with(grid_reference: nil, postcode: "PE33 0NE").and_return(nil)
+    allow(WasteExemptionsEngine::DetermineEastingAndNorthingService).to receive(:run).with(grid_reference: nil, postcode: "PE33 0N").and_return(coords)
+    allow(WasteExemptionsEngine::DetermineAreaService).to receive(:run).and_return("Lincolnshire and Northamptonshire")
+    expect { run_rake_task }.to change { reg_with_postcode_that_cannot_be_found.site_address.reload.area }.to "Lincolnshire and Northamptonshire"
+  end
+end

--- a/spec/lib/tasks/one_off/undefined_area_fix_spec.rb
+++ b/spec/lib/tasks/one_off/undefined_area_fix_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe "one_off:undefined_area_fix", type: :rake do
     reg2
   end
 
+  let(:reg_with_area_defined) do
+    reg1 = create(:registration, :site_uses_address, :with_manual_site_address, created_at: 1.year.ago)
+    reg1.site_address.update(postcode: "WA16 1TS", area: "Yorkshire")
+    reg1
+  end
+
   let(:coords) { { easting: 123.4, northing: 123.5 } }
 
   # By default Rails prevents multiple invocations of the same Rake task in succession
@@ -29,16 +35,20 @@ RSpec.describe "one_off:undefined_area_fix", type: :rake do
 
   it { expect { run_rake_task }.not_to raise_error }
 
-  it "updates the area for a registration with a site address postcode that can be found" do
+  it "defines the area for a registration with a site address postcode that can be found" do
     allow(WasteExemptionsEngine::DetermineEastingAndNorthingService).to receive(:run).with(grid_reference: nil, postcode: "WA16 0AW").and_return(coords)
     allow(WasteExemptionsEngine::DetermineAreaService).to receive(:run).and_return("Yorkshire")
     expect { run_rake_task }.to change { reg_with_postcode_that_can_be_found.site_address.reload.area }.to "Yorkshire"
   end
 
-  it "updates the area for a registration with a site address postcode that cannot be found" do
+  it "defines the area for a registration with a site address postcode that cannot be found" do
     allow(WasteExemptionsEngine::DetermineEastingAndNorthingService).to receive(:run).with(grid_reference: nil, postcode: "PE33 0NE").and_return(nil)
     allow(WasteExemptionsEngine::DetermineEastingAndNorthingService).to receive(:run).with(grid_reference: nil, postcode: "PE33 0N").and_return(coords)
     allow(WasteExemptionsEngine::DetermineAreaService).to receive(:run).and_return("Lincolnshire and Northamptonshire")
     expect { run_rake_task }.to change { reg_with_postcode_that_cannot_be_found.site_address.reload.area }.to "Lincolnshire and Northamptonshire"
+  end
+
+  it "doesn't change the area when area already defined" do
+    expect { run_rake_task }.not_to change { reg_with_area_defined.site_address.reload.area }
   end
 end


### PR DESCRIPTION
This commit adds a new rake task `undefined_area_fix` to fix areas for manually added site addresses. The task finds registrations with undefined EA (Environment Agency) area and attempts to fix them by matching the postcode with the corresponding area. If a match is found, the area is updated for the site address. The task also provides statistics on the number of registrations with undefined EA area and the number of addresses that were fixed or couldn't be fixed.