### PR TITLE
[RUBY-3169] Update schema and add bucket_type to seeds

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_04_170742) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_24_150832) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "tsm_system_rows"
@@ -64,6 +64,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_04_170742) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "band_charge_details", force: :cascade do |t|
+    t.bigint "band_id"
+    t.integer "initial_compliance_charge_amount", default: 0
+    t.integer "additional_compliance_charge_amount", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "bands", force: :cascade do |t|
     t.string "name", null: false
     t.integer "sequence"
@@ -82,6 +90,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_04_170742) do
 
   create_table "buckets", force: :cascade do |t|
     t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "bucket_type"
+    t.index ["bucket_type"], name: "index_buckets_on_bucket_type", unique: true
+    t.index ["name"], name: "index_buckets_on_name", unique: true
+  end
+
+  create_table "charge_details", force: :cascade do |t|
+    t.integer "registration_charge_amount"
+    t.integer "bucket_charge_amount", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -124,6 +142,32 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_04_170742) do
     t.boolean "active"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "order_buckets", force: :cascade do |t|
+    t.bigint "order_id"
+    t.bigint "bucket_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["bucket_id"], name: "index_order_buckets_on_bucket_id"
+    t.index ["order_id"], name: "index_order_buckets_on_order_id"
+  end
+
+  create_table "order_exemptions", force: :cascade do |t|
+    t.bigint "order_id"
+    t.bigint "exemption_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["exemption_id"], name: "index_order_exemptions_on_exemption_id"
+    t.index ["order_id"], name: "index_order_exemptions_on_order_id"
+  end
+
+  create_table "orders", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "order_owner_type"
+    t.bigint "order_owner_id"
+    t.index ["order_owner_type", "order_owner_id"], name: "index_orders_on_order_owner"
   end
 
   create_table "people", id: :serial, force: :cascade do |t|
@@ -297,6 +341,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_04_170742) do
     t.boolean "temp_confirm_exemption_edits"
     t.boolean "temp_confirm_no_exemption_changes"
     t.boolean "temp_check_your_answers_flow"
+    t.string "temp_company_no"
     t.index ["created_at"], name: "index_transient_registrations_on_created_at"
     t.index ["token"], name: "index_transient_registrations_on_token", unique: true
   end
@@ -321,11 +366,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_04_170742) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "role"
     t.boolean "active", default: true
-    t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.inet "current_sign_in_ip"
-    t.inet "last_sign_in_ip"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
@@ -358,6 +398,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_04_170742) do
   add_foreign_key "bucket_exemptions", "buckets"
   add_foreign_key "bucket_exemptions", "exemptions"
   add_foreign_key "exemptions", "bands"
+  add_foreign_key "order_buckets", "buckets"
+  add_foreign_key "order_buckets", "orders"
+  add_foreign_key "order_exemptions", "exemptions"
+  add_foreign_key "order_exemptions", "orders"
   add_foreign_key "people", "registrations"
   add_foreign_key "transient_addresses", "transient_registrations"
   add_foreign_key "transient_people", "transient_registrations"

--- a/db/seeds/charging_schemes.json
+++ b/db/seeds/charging_schemes.json
@@ -1,40 +1,41 @@
 {
   "bands" : [
-    { 
-      "name": "High-risk activity exemptions", 
-      "sequence": 1, 
+    {
+      "name": "High-risk activity exemptions",
+      "sequence": 1,
       "initial_compliance_charge": 40900,
-      "additional_compliance_charge": 7400 
+      "additional_compliance_charge": 7400
     },
-    { 
+    {
       "name": "Medium-risk activity exemptions",
-      "sequence": 2, 
-      "initial_compliance_charge": 20700, 
-      "additional_compliance_charge": 7400 
+      "sequence": 2,
+      "initial_compliance_charge": 20700,
+      "additional_compliance_charge": 7400
     },
-    { 
-      "name": "Lower-risk activity exemptions", 
-      "sequence": 3, 
-      "initial_compliance_charge": 3000, 
-      "additional_compliance_charge": 3000 
+    {
+      "name": "Lower-risk activity exemptions",
+      "sequence": 3,
+      "initial_compliance_charge": 3000,
+      "additional_compliance_charge": 3000
     },
-    { 
-      "name": "Low-risk activity exemptions", 
-      "sequence": 4, 
-      "initial_compliance_charge": 118000, 
-      "additional_compliance_charge": 22100 
+    {
+      "name": "Low-risk activity exemptions",
+      "sequence": 4,
+      "initial_compliance_charge": 118000,
+      "additional_compliance_charge": 22100
     }
   ],
   "charges" : [
-    { 
+    {
       "name": "Registration charge",
-      "charge_type": "registration_charge", 
+      "charge_type": "registration_charge",
       "charge_amount": 4100
     }
   ],
   "buckets" : [
-    { 
-      "name": "Farmer exemptions", 
+    {
+      "name": "Farmer exemptions",
+      "bucket_type": "farmer",
       "initial_compliance_charge": 9000
     }
   ]

--- a/db/seeds/charging_schemes.rb
+++ b/db/seeds/charging_schemes.rb
@@ -49,7 +49,8 @@ def create_charge_if_not_exists(charge_details)
 end
 
 def create_bucket_if_not_exists(bucket_details)
-  WasteExemptionsEngine::Bucket.find_or_create_by(name: bucket_details["name"]) do |rec|
+  WasteExemptionsEngine::Bucket.find_or_create_by(name: bucket_details["name"],
+                                                  bucket_type: bucket_details["bucket_type"]) do |rec|
     rec.initial_compliance_charge = WasteExemptionsEngine::Charge.find_or_create_by!(
       charge_type: "initial_compliance_charge", name: "initial compliance charge for #{bucket_details['name']}"
     ) do |charge|


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-3175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
- Added `band_charge_details`, `charge_details`, `order_buckets`, `order_exemptions`, and `orders` tables to schema.
- Included new fields and indexes in `buckets` and `transient_registrations` tables.
- Removed sign-in tracking fields from `users` table.
- Added foreign key constraints for new associations.
- Updated `charging_schemes.json` to include `bucket_type`
