### PR TITLE
sanity check

### DIFF
--- a/app/controllers/testing_controller.rb
+++ b/app/controllers/testing_controller.rb
@@ -11,11 +11,11 @@ class TestingController < ApplicationController
     # exemptions from params[:exemptions] which is a list of exemption codes
     # e.g. "create_registration/2022-01-01?exemptions=U1&exemptions=U2&exemptions=U3"
     # "testing/create_registration/2022-01-01?exemptions[]=U4&exemptions[]=U5&exemptions[]=U1"
-    if params[:exemptions].present?
-      @registration_exemptions = registration_exemptions_by_codes(params[:exemptions])
-    else
-      @registration_exemptions = registration_exemptions_by_count(3)
-    end
+    @registration_exemptions = if params[:exemptions].present?
+                                 registration_exemptions_by_codes(params[:exemptions])
+                               else
+                                 registration_exemptions_by_count(3)
+                               end
     # https://github.com/thoughtbot/factory_bot/blob/ca810767e70ccd85c7cb63f775bc16f653a97dc8/GETTING_STARTED.md#rails-preloaders-and-rspec
     FactoryBot.reload
 
@@ -25,7 +25,7 @@ class TestingController < ApplicationController
     # Ensure edit_token_created_at is populated
     registration.regenerate_and_timestamp_edit_token
 
-    render :show, locals: { registration: registration, registration_exemptions: @registration_exemptions}
+    render :show, locals: { registration: registration, registration_exemptions: @registration_exemptions }
   end
 
   private
@@ -44,7 +44,9 @@ class TestingController < ApplicationController
     codes.map do |code|
       FactoryBot.build(:registration_exemption,
                        expires_on: @expiry_date,
-                       exemption: selected_exemptions.find { |exemption| exemption.code == code } || FactoryBot.create(:exemption, code: code))
+                       exemption: selected_exemptions.find do |exemption|
+                                    exemption.code == code
+                                  end || FactoryBot.create(:exemption, code: code))
     end
   end
 

--- a/app/controllers/testing_controller.rb
+++ b/app/controllers/testing_controller.rb
@@ -8,27 +8,43 @@ class TestingController < ApplicationController
 
   def create_registration
     @expiry_date = Date.parse(params[:expiry_date])
-
+    # exemptions from params[:exemptions] which is a list of exemption codes
+    # e.g. "create_registration/2022-01-01?exemptions=U1&exemptions=U2&exemptions=U3"
+    # "testing/create_registration/2022-01-01?exemptions[]=U4&exemptions[]=U5&exemptions[]=U1"
+    if params[:exemptions].present?
+      @registration_exemptions = registration_exemptions_by_codes(params[:exemptions])
+    else
+      @registration_exemptions = registration_exemptions_by_count(3)
+    end
     # https://github.com/thoughtbot/factory_bot/blob/ca810767e70ccd85c7cb63f775bc16f653a97dc8/GETTING_STARTED.md#rails-preloaders-and-rspec
     FactoryBot.reload
 
     registration = FactoryBot.create(:registration,
-                                     registration_exemptions: registration_exemptions(3))
+                                     registration_exemptions: registration_exemptions_by_count(3))
 
     # Ensure edit_token_created_at is populated
     registration.regenerate_and_timestamp_edit_token
 
-    render :show, locals: { registration: registration }
+    render :show, locals: { registration: registration, registration_exemptions: @registration_exemptions}
   end
 
   private
 
-  def registration_exemptions(count)
+  def registration_exemptions_by_count(count)
     selected_exemptions = WasteExemptionsEngine::Exemption.first(count)
     (0..count - 1).map do |n|
       FactoryBot.build(:registration_exemption,
                        expires_on: @expiry_date,
                        exemption: selected_exemptions[n] || FactoryBot.create(:exemption))
+    end
+  end
+
+  def registration_exemptions_by_codes(codes)
+    selected_exemptions = WasteExemptionsEngine::Exemption.where(code: codes)
+    codes.map do |code|
+      FactoryBot.build(:registration_exemption,
+                       expires_on: @expiry_date,
+                       exemption: selected_exemptions.find { |exemption| exemption.code == code } || FactoryBot.create(:exemption, code: code))
     end
   end
 

--- a/app/controllers/testing_controller.rb
+++ b/app/controllers/testing_controller.rb
@@ -11,7 +11,7 @@ class TestingController < ApplicationController
     # exemptions from params[:exemptions] which is a list of exemption codes
     # e.g. "create_registration/2022-01-01?exemptions=U1&exemptions=U2&exemptions=U3"
     # "testing/create_registration/2022-01-01?exemptions[]=U4&exemptions[]=U5&exemptions[]=U1"
-    @registration_exemptions = if params[:exemptions].present?
+    registration_exemptions = if params[:exemptions].present?
                                  registration_exemptions_by_codes(params[:exemptions])
                                else
                                  registration_exemptions_by_count(3)
@@ -25,7 +25,7 @@ class TestingController < ApplicationController
     # Ensure edit_token_created_at is populated
     registration.regenerate_and_timestamp_edit_token
 
-    render :show, locals: { registration: registration, registration_exemptions: @registration_exemptions }
+    render :show, locals: { registration: registration, registration_exemptions: registration_exemptions }
   end
 
   private

--- a/app/controllers/testing_controller.rb
+++ b/app/controllers/testing_controller.rb
@@ -11,11 +11,11 @@ class TestingController < ApplicationController
     # exemptions from params[:exemptions] which is a list of exemption codes
     # e.g. "create_registration/2022-01-01?exemptions=U1&exemptions=U2&exemptions=U3"
     # "testing/create_registration/2022-01-01?exemptions[]=U4&exemptions[]=U5&exemptions[]=U1"
-    registration_exemptions = if params[:exemptions].present?
-                                 registration_exemptions_by_codes(params[:exemptions])
-                               else
-                                 registration_exemptions_by_count(3)
-                               end
+    if params[:exemptions].present?
+      registration_exemptions_by_codes(params[:exemptions])
+    else
+      registration_exemptions_by_count(3)
+    end
     # https://github.com/thoughtbot/factory_bot/blob/ca810767e70ccd85c7cb63f775bc16f653a97dc8/GETTING_STARTED.md#rails-preloaders-and-rspec
     FactoryBot.reload
 
@@ -25,7 +25,7 @@ class TestingController < ApplicationController
     # Ensure edit_token_created_at is populated
     registration.regenerate_and_timestamp_edit_token
 
-    render :show, locals: { registration: registration, registration_exemptions: registration_exemptions }
+    render :show, locals: { registration: registration }
   end
 
   private

--- a/app/views/testing/show.html.erb
+++ b/app/views/testing/show.html.erb
@@ -1,2 +1,53 @@
-Created registration: <%= registration.reference %>
-Edit token: <%= registration.edit_token %>
+<% content_for :page_title, "Registration Details" %>
+
+<h1 class="govuk-heading-xl">Test registration created!</h1>
+
+<h2 class="govuk-heading-l">Details</h2>
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Created registration</dt>
+    <dd class="govuk-summary-list__value"><%= registration.reference %></dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Edit token</dt>
+    <dd class="govuk-summary-list__value"><%= registration.edit_token %></dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Renew token</dt>
+    <dd class="govuk-summary-list__value"><%= registration.renew_token %></dd>
+  </div>
+</dl>
+
+<h2 class="govuk-heading-l">Exemptions</h2>
+<p class="govuk-body">This registration includes the following exemptions:</p>
+<dl class="govuk-summary-list">
+  <% registration_exemptions.each do |registration_exemption| %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
+        <span class="govuk-!-font-weight-bold"><%= registration_exemption.exemption.code %></span>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= registration_exemption.exemption.summary %>
+      </dd>
+      <% if registration_exemption.exemption.band.present? %>
+        <dd class="govuk-summary-list__actions">
+          <span class="govuk-tag govuk-tag--blue">
+            <%= registration_exemption.exemption.band.name %>
+          </span>
+        </dd>
+      <% else %>
+        <dd class="govuk-summary-list__actions"></dd>
+      <% end %>
+    </div>
+  <% end %>
+</dl>
+
+<h2 class="govuk-heading-l">Attributes</h2>
+<dl class="govuk-summary-list">
+  <% registration.attributes.each do |key, value| %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key"><%= key.humanize %></dt>
+      <dd class="govuk-summary-list__value"><%= value %></dd>
+    </div>
+  <% end %>
+</dl>

--- a/app/views/testing/show.html.erb
+++ b/app/views/testing/show.html.erb
@@ -21,7 +21,7 @@
 <h2 class="govuk-heading-l">Exemptions</h2>
 <p class="govuk-body">This registration includes the following exemptions:</p>
 <dl class="govuk-summary-list">
-  <% registration_exemptions.each do |registration_exemption| %>
+  <% registration.registration_exemptions.each do |registration_exemption| %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
         <span class="govuk-!-font-weight-bold"><%= registration_exemption.exemption.code %></span>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -366,6 +366,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_24_150832) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "role"
     t.boolean "active", default: true
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/requests/testing_spec.rb
+++ b/spec/requests/testing_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe "Testing" do
 
   before { sign_in(user) }
 
+  after do
+    allow(ENV).to receive(:fetch).with("AIRBRAKE_ENV_NAME", any_args).and_call_original
+    allow(Rails.env).to receive(:test?).and_call_original
+  end
+
   describe "/create_registration" do
     let(:expiry_date) { 2.days.from_now.strftime("%Y-%m-%d") }
 

--- a/spec/requests/testing_spec.rb
+++ b/spec/requests/testing_spec.rb
@@ -3,7 +3,6 @@
 require "rails_helper"
 
 RSpec.describe "Testing" do
-
   let(:user) { create(:user) }
 
   before { sign_in(user) }
@@ -16,6 +15,36 @@ RSpec.describe "Testing" do
 
       it "creates a registration" do
         expect { get "/testing/create_registration/#{expiry_date}" }.to change(WasteExemptionsEngine::Registration, :count).by(1)
+      end
+
+      it "creates a registration with default exemptions when no exemptions are specified" do
+        get "/testing/create_registration/#{expiry_date}"
+        expect(response).to have_http_status(:success)
+        registration = WasteExemptionsEngine::Registration.last
+        expect(registration.registration_exemptions.count).to eq(3)
+      end
+
+      it "creates a registration with specified exemptions" do
+        exemption_codes = %w[U1 U2 U3]
+        get "/testing/create_registration/#{expiry_date}", params: { exemptions: exemption_codes }
+        expect(response).to have_http_status(:success)
+        registration = WasteExemptionsEngine::Registration.last
+        expect(registration.registration_exemptions.count).to eq(3)
+        expect(registration.registration_exemptions.map { |re| re.exemption.code }).to match_array(exemption_codes)
+      end
+
+      it "sets the expiry date correctly" do
+        get "/testing/create_registration/#{expiry_date}"
+        expect(response).to have_http_status(:success)
+        registration = WasteExemptionsEngine::Registration.last
+        expect(registration.registration_exemptions.first.expires_on).to eq(Date.parse(expiry_date))
+      end
+
+      it "populates the edit_token_created_at" do
+        get "/testing/create_registration/#{expiry_date}"
+        expect(response).to have_http_status(:success)
+        registration = WasteExemptionsEngine::Registration.last
+        expect(registration.edit_token_created_at).to be_present
       end
     end
 


### PR DESCRIPTION
- [RUBY-3268] Add exemption handling and improve registration details display
- [RUBY-3268] Refactor `TestingController` and enhance test coverage
- [RUBY-3268] Refactor `TestingController#create_registration` to use local variable `registration_exemptions` instead of instance variable.
- [RUBY-3268] rubocop fixes
- ReSonarCloud
- Re-add missing devise schema attributes
- Remove ENV/env? mocking after specs


[RUBY-3268]: https://eaflood.atlassian.net/browse/RUBY-3268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUBY-3268]: https://eaflood.atlassian.net/browse/RUBY-3268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUBY-3268]: https://eaflood.atlassian.net/browse/RUBY-3268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUBY-3268]: https://eaflood.atlassian.net/browse/RUBY-3268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ