### PR TITLE
Fix/ruby 3292 renewal journey stats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,6 @@ jobs:
       # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
       - name: Run unit tests
         run: |
-          bundle exec rails test
           bundle exec rspec
           sed -i 's/\/home\/runner\/work\/waste-exemptions-back-office\/waste-exemptions-back-office\//\/github\/workspace\//g' coverage/coverage.json
 

--- a/Gemfile
+++ b/Gemfile
@@ -134,8 +134,8 @@ group :test do
   gem "simplecov", "~> 0.22.0", require: false
   # Integration testing tool
   gem "capybara"
-  # Needed for headless testing with Javascript or pages that ref external sites
-  gem "poltergeist"
+  # Needed for headless testing with Javascript
+  gem "selenium-webdriver"
   # A gem providing "time travel" and "time freezing" capabilities, making it
   # dead simple to test time-dependent code.
   gem "timecop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,8 +104,8 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     airbrake (13.0.4)
       airbrake-ruby (~> 6.0)
     airbrake-ruby (6.2.2)
@@ -167,7 +167,6 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     chronic (0.10.2)
-    cliver (0.3.2)
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
@@ -308,6 +307,7 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
+    logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -321,7 +321,7 @@ GEM
     method_source (1.1.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.0820)
+    mime-types-data (3.2024.0903)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
     minitest (5.25.1)
@@ -363,10 +363,6 @@ GEM
     pg (1.5.7)
     pgreset (0.4)
     phonelib (0.9.1)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     protocol-hpack (1.4.3)
     protocol-http (0.26.4)
     protocol-http1 (0.19.1)
@@ -382,7 +378,7 @@ GEM
       pry (>= 0.13, < 0.15)
     psych (5.1.2)
       stringio
-    public_suffix (5.0.5)
+    public_suffix (6.0.1)
     racc (1.8.1)
     rack (2.2.9)
     rack-session (1.0.2)
@@ -447,16 +443,16 @@ GEM
       strscan
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.1)
+    rspec-expectations (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-rails (6.1.4)
-      actionpack (>= 6.1)
-      activesupport (>= 6.1)
-      railties (>= 6.1)
+    rspec-rails (7.0.1)
+      actionpack (>= 7.0)
+      activesupport (>= 7.0)
+      railties (>= 7.0)
       rspec-core (~> 3.13)
       rspec-expectations (~> 3.13)
       rspec-mocks (~> 3.13)
@@ -479,10 +475,10 @@ GEM
       rubocop (~> 1.41)
     rubocop-factory_bot (2.26.1)
       rubocop (~> 1.61)
-    rubocop-rails (2.25.1)
+    rubocop-rails (2.26.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
-      rubocop (>= 1.33.0, < 2.0)
+      rubocop (>= 1.52.0, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
@@ -505,6 +501,12 @@ GEM
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     secure_headers (6.7.0)
+    selenium-webdriver (4.24.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -558,6 +560,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
+    websocket (1.2.11)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -602,7 +605,6 @@ DEPENDENCIES
   passenger (~> 6.0, != 6.0.23)
   pg
   pgreset
-  poltergeist
   pry-byebug
   rack (~> 2)
   rails-controller-testing
@@ -614,6 +616,7 @@ DEPENDENCIES
   rubyzip
   sassc-rails
   secure_headers (~> 6.5)
+  selenium-webdriver
   simplecov (~> 0.22.0)
   spring
   spring-commands-rspec

--- a/app/controllers/exemptions_controller.rb
+++ b/app/controllers/exemptions_controller.rb
@@ -14,7 +14,7 @@ class ExemptionsController < ApplicationController
       redirect_to exemptions_path
     else
       load_records
-      flash[:error] = I18n.t("exemptions.messages.failed_to_update")
+      flash.now[:error] = I18n.t("exemptions.messages.failed_to_update")
       render :index
     end
   end

--- a/app/controllers/reset_transient_registrations_controller.rb
+++ b/app/controllers/reset_transient_registrations_controller.rb
@@ -13,11 +13,11 @@ class ResetTransientRegistrationsController < ApplicationController
     if reset_transient_registrations_form.submit
       successful_redirection = WasteExemptionsEngine::ApplicationController::SUCCESSFUL_REDIRECTION_CODE
       redirect_to registration_path(reference: registration.reference), status: successful_redirection
-      flash[:message] = t("reset_transient_registrations.flash.successful_reset")
+      flash.now[:message] = t("reset_transient_registrations.flash.successful_reset")
     else
       unsuccessful_redirection = WasteExemptionsEngine::ApplicationController::UNSUCCESSFUL_REDIRECTION_CODE
       redirect_to registration_path(reference: registration.reference), status: unsuccessful_redirection
-      flash[:error] = t("reset_transient_registrations.flash.no_transient_registrations")
+      flash.now[:error] = t("reset_transient_registrations.flash.no_transient_registrations")
     end
   end
 

--- a/app/models/user_journey.rb
+++ b/app/models/user_journey.rb
@@ -3,10 +3,16 @@
 # module WasteExemptionsEngine
 #   module Analytics
 class UserJourney < WasteExemptionsEngine::Analytics::UserJourney
-  # include ActiveModel
-  # self.table_name = "analytics_user_journeys"
 
   # These scopes and helpers are used only for presentation of aggregate stats in the back-office.
+
+  START_CUTOFF_PAGES = %w[
+    location_form
+    edit_exemptions_form
+    front_office_edit_form
+    confirm_renewal_form
+    renew_without_changes_form
+  ].freeze
 
   scope :registrations, -> { where(journey_type: "NewRegistration") }
   scope :renewals, -> { where(journey_type: "RenewingRegistration") }
@@ -73,6 +79,4 @@ class UserJourney < WasteExemptionsEngine::Analytics::UserJourney
 
     durations.sum / durations.size
   end
-  # end
-  # end
 end

--- a/app/models/user_journey.rb
+++ b/app/models/user_journey.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# module WasteExemptionsEngine
+#   module Analytics
+class UserJourney < WasteExemptionsEngine::Analytics::UserJourney
+  # include ActiveModel
+  # self.table_name = "analytics_user_journeys"
+
+  # These scopes and helpers are used only for presentation of aggregate stats in the back-office.
+
+  scope :registrations, -> { where(journey_type: "NewRegistration") }
+  scope :renewals, -> { where(journey_type: "RenewingRegistration") }
+  scope :only_types, ->(journey_types) { where(journey_type: journey_types) }
+  scope :started_digital, -> { where(started_route: "DIGITAL") }
+  scope :started_assisted_digital, -> { where(started_route: "ASSISTED_DIGITAL") }
+  scope :incomplete, -> { where(completed_at: nil) }
+  scope :completed, -> { where.not(completed_at: nil) }
+  scope :completed_digital, -> { where(completed_route: "DIGITAL") }
+  scope :completed_assisted_digital, -> { where(completed_route: "ASSISTED_DIGITAL") }
+
+  # rubocop:disable Metrics/BlockLength
+  scope :passed_start_cutoff_page, lambda {
+    # Subquery to check for the existence of the START_CUTOFF_PAGES in any PageView for the UserJourney
+    start_cutoff_page_subquery = <<-SQL
+          EXISTS (
+            SELECT 1
+            FROM analytics_page_views
+            WHERE
+              analytics_page_views.user_journey_id = analytics_user_journeys.id
+              AND analytics_page_views.page IN ('#{START_CUTOFF_PAGES.join("', '")}')
+          )
+    SQL
+
+    # Subquery to find the last PageView for each UserJourney
+    last_page_not_cutoff_subquery = <<-SQL
+          NOT EXISTS (
+            SELECT 1
+            FROM analytics_page_views as last_pages
+            WHERE
+              last_pages.user_journey_id = analytics_user_journeys.id
+              AND last_pages.id = (
+                SELECT id
+                FROM analytics_page_views
+                WHERE analytics_page_views.user_journey_id = last_pages.user_journey_id
+                ORDER BY created_at DESC
+                LIMIT 1
+              )
+              AND last_pages.page IN ('#{START_CUTOFF_PAGES.join("', '")}')
+          )
+    SQL
+
+    where(start_cutoff_page_subquery).where(last_page_not_cutoff_subquery)
+  }
+  # rubocop:enable Metrics/BlockLength
+
+  scope :date_range, lambda { |start_date, end_date|
+    where("created_at >= :start AND created_at <= :end",
+          start: start_date.beginning_of_day, end: end_date.end_of_day)
+      .or(
+        where(
+          "completed_at IS NOT NULL AND completed_at >= :start AND completed_at <= :end AND created_at >= :start",
+          start: start_date.beginning_of_day, end: end_date.end_of_day
+        )
+      )
+  }
+
+  def self.minimum_created_at
+    minimum(:created_at)
+  end
+
+  def self.average_duration(user_journey_scope)
+    durations = user_journey_scope.pluck(Arel.sql("EXTRACT(EPOCH FROM (updated_at - created_at))"))
+    return 0 if durations.empty?
+
+    durations.sum / durations.size
+  end
+  # end
+  # end
+end

--- a/app/models/user_journey.rb
+++ b/app/models/user_journey.rb
@@ -21,7 +21,7 @@ class UserJourney < WasteExemptionsEngine::Analytics::UserJourney
   # rubocop:disable Metrics/BlockLength
   scope :passed_start_cutoff_page, lambda {
     # Subquery to check for the existence of the START_CUTOFF_PAGES in any PageView for the UserJourney
-    start_cutoff_page_subquery = <<-SQL
+    start_cutoff_page_subquery = <<-SQL.squish
           EXISTS (
             SELECT 1
             FROM analytics_page_views
@@ -32,7 +32,7 @@ class UserJourney < WasteExemptionsEngine::Analytics::UserJourney
     SQL
 
     # Subquery to find the last PageView for each UserJourney
-    last_page_not_cutoff_subquery = <<-SQL
+    last_page_not_cutoff_subquery = <<-SQL.squish
           NOT EXISTS (
             SELECT 1
             FROM analytics_page_views as last_pages
@@ -54,8 +54,7 @@ class UserJourney < WasteExemptionsEngine::Analytics::UserJourney
   # rubocop:enable Metrics/BlockLength
 
   scope :date_range, lambda { |start_date, end_date|
-    where("created_at >= :start AND created_at <= :end",
-          start: start_date.beginning_of_day, end: end_date.end_of_day)
+    where(created_at: start_date.beginning_of_day..end_date.end_of_day)
       .or(
         where(
           "completed_at IS NOT NULL AND completed_at >= :start AND completed_at <= :end AND created_at >= :start",

--- a/app/services/analytics/aggregated_analytics_service.rb
+++ b/app/services/analytics/aggregated_analytics_service.rb
@@ -24,7 +24,7 @@ module Analytics
     private
 
     def default_start_date
-      WasteExemptionsEngine::Analytics::UserJourney.minimum_created_at&.to_date.presence || Time.zone.today
+      UserJourney.minimum_created_at&.to_date.presence || Time.zone.today
     end
 
     def front_office_started
@@ -66,11 +66,11 @@ module Analytics
     end
 
     def journey_base_scope
-      WasteExemptionsEngine::Analytics::UserJourney.only_types(%w[
-                                                                 NewRegistration
-                                                                 RenewingRegistration
-                                                                 FrontOfficeEditRegistration
-                                                               ]).date_range(start_date, end_date)
+      UserJourney.only_types(%w[
+                               NewRegistration
+                               RenewingRegistration
+                               FrontOfficeEditRegistration
+                             ]).date_range(start_date, end_date)
     end
 
     def total_journeys_abandoned

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,7 +38,7 @@ module WasteExemptionsBackOffice
     config.time_zone = "London"
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.{rb,yml}")]
+    config.i18n.load_path += Rails.root.glob("config/locales/**/*.{rb,yml}")
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     # config.active_record.raise_in_transactional_callbacks = true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_24_150832) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_23_131328) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "tsm_system_rows"
+
+  create_table "accounts", force: :cascade do |t|
+    t.bigint "registration_id", null: false
+    t.integer "balance", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["registration_id"], name: "index_accounts_on_registration_id"
+  end
 
   create_table "addresses", id: :serial, force: :cascade do |t|
     t.integer "address_type", default: 0
@@ -70,6 +78,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_24_150832) do
     t.integer "additional_compliance_charge_amount", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "charge_detail_id"
+    t.index ["charge_detail_id"], name: "index_band_charge_details_on_charge_detail_id"
   end
 
   create_table "bands", force: :cascade do |t|
@@ -102,6 +112,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_24_150832) do
     t.integer "bucket_charge_amount", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "order_id"
+    t.integer "total_charge_amount"
+    t.index ["order_id"], name: "index_charge_details_on_order_id"
   end
 
   create_table "charges", force: :cascade do |t|
@@ -167,7 +180,23 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_24_150832) do
     t.datetime "updated_at", null: false
     t.string "order_owner_type"
     t.bigint "order_owner_id"
+    t.string "order_uuid"
     t.index ["order_owner_type", "order_owner_id"], name: "index_orders_on_order_owner"
+  end
+
+  create_table "payments", force: :cascade do |t|
+    t.string "payment_type"
+    t.integer "payment_amount"
+    t.string "payment_status"
+    t.bigint "order_id"
+    t.datetime "date_time"
+    t.string "govpay_id"
+    t.string "refunded_payment_govpay_id"
+    t.boolean "moto_payment", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "payment_uuid"
+    t.index ["order_id"], name: "index_payments_on_order_id"
   end
 
   create_table "people", id: :serial, force: :cascade do |t|
@@ -233,6 +262,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_24_150832) do
     t.datetime "edit_token_created_at"
     t.boolean "reminder_opt_in", default: true
     t.string "unsubscribe_token"
+    t.boolean "charged", default: false
     t.index ["deregistration_email_sent_at"], name: "index_registrations_on_deregistration_email_sent_at"
     t.index ["edit_token"], name: "index_registrations_on_edit_token", unique: true
     t.index ["reference"], name: "index_registrations_on_reference", unique: true
@@ -342,6 +372,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_24_150832) do
     t.boolean "temp_confirm_no_exemption_changes"
     t.boolean "temp_check_your_answers_flow"
     t.string "temp_company_no"
+    t.string "temp_payment_method"
     t.index ["created_at"], name: "index_transient_registrations_on_created_at"
     t.index ["token"], name: "index_transient_registrations_on_token", unique: true
   end
@@ -398,15 +429,19 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_24_150832) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  add_foreign_key "accounts", "registrations"
   add_foreign_key "addresses", "registrations"
   add_foreign_key "analytics_page_views", "analytics_user_journeys", column: "user_journey_id"
+  add_foreign_key "band_charge_details", "charge_details"
   add_foreign_key "bucket_exemptions", "buckets"
   add_foreign_key "bucket_exemptions", "exemptions"
+  add_foreign_key "charge_details", "orders"
   add_foreign_key "exemptions", "bands"
   add_foreign_key "order_buckets", "buckets"
   add_foreign_key "order_buckets", "orders"
   add_foreign_key "order_exemptions", "exemptions"
   add_foreign_key "order_exemptions", "orders"
+  add_foreign_key "payments", "orders"
   add_foreign_key "people", "registrations"
   add_foreign_key "transient_addresses", "transient_registrations"
   add_foreign_key "transient_people", "transient_registrations"

--- a/lib/tasks/one_off/delete_outdated_edit_transient_registrations.rake
+++ b/lib/tasks/one_off/delete_outdated_edit_transient_registrations.rake
@@ -23,27 +23,27 @@ namespace :one_off do
            "transient addresses / transient people"
     end
   end
+end
 
-  def delete_associated_records(outdated_registration_ids)
-    WasteExemptionsEngine::TransientAddress
-      .where(transient_registration_id: outdated_registration_ids)
-      .destroy_all
+def delete_associated_records(outdated_registration_ids)
+  WasteExemptionsEngine::TransientAddress
+    .where(transient_registration_id: outdated_registration_ids)
+    .destroy_all
 
-    WasteExemptionsEngine::TransientPerson
-      .where(transient_registration_id: outdated_registration_ids)
-      .destroy_all
+  WasteExemptionsEngine::TransientPerson
+    .where(transient_registration_id: outdated_registration_ids)
+    .destroy_all
 
-    WasteExemptionsEngine::TransientRegistrationExemption
-      .where(transient_registration_id: outdated_registration_ids)
-      .destroy_all
-  end
+  WasteExemptionsEngine::TransientRegistrationExemption
+    .where(transient_registration_id: outdated_registration_ids)
+    .destroy_all
+end
 
-  def delete_transient_registrations(outdated_registration_ids)
-    sql = <<-SQL.squish
-      DELETE FROM transient_registrations
-      WHERE id IN (#{outdated_registration_ids.join(', ')});
-    SQL
+def delete_transient_registrations(outdated_registration_ids)
+  sql = <<-SQL.squish
+    DELETE FROM transient_registrations
+    WHERE id IN (#{outdated_registration_ids.join(', ')});
+  SQL
 
-    ActiveRecord::Base.connection.execute(sql)
-  end
+  ActiveRecord::Base.connection.execute(sql)
 end

--- a/spec/factories/analytics/user_journey.rb
+++ b/spec/factories/analytics/user_journey.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :user_journey, class: "WasteExemptionsEngine::Analytics::UserJourney" do
+  factory :user_journey, class: "UserJourney" do
     journey_type { "NewRegistration" }
     token { SecureRandom.hex(20) }
     started_route { "DIGITAL" }

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -25,10 +25,14 @@ RSpec.describe "Dashboard" do
       end
 
       it "strips tab character within the search terms and returns search results" do
-        reference_with_tabs = "WEX00	0001"
+        wex_reference = "WEX00	0001"
 
         expect(page).to have_field("term")
-        fill_in "term", with: reference_with_tabs
+
+        # Unlike the other examples, we can't use Capybara 'fill_in' here because it emulates keyboard
+        # input so the tab character embedded in the string would cause it to tab to the next field.
+        page.execute_script "$(\"#term\").val(\"#{wex_reference}\")"
+
         expect(page).to have_button("Search")
         click_on "Search"
 
@@ -37,10 +41,10 @@ RSpec.describe "Dashboard" do
       end
 
       it "strips ampersand character within the search terms and returns search results" do
-        reference_with_tabs = "WEX&000001"
+        wex_reference = "WEX&000001"
 
         expect(page).to have_field("term")
-        fill_in "term", with: reference_with_tabs
+        fill_in "term", with: wex_reference
         expect(page).to have_button("Search")
         click_on "Search"
 
@@ -49,10 +53,10 @@ RSpec.describe "Dashboard" do
       end
 
       it "strips double quote character within the search terms and returns search results" do
-        reference_with_tabs = "WEX\"000001"
+        wex_reference = "WEX\"000001"
 
         expect(page).to have_field("term")
-        fill_in "term", with: reference_with_tabs
+        fill_in "term", with: wex_reference
         expect(page).to have_button("Search")
         click_on "Search"
 
@@ -61,10 +65,10 @@ RSpec.describe "Dashboard" do
       end
 
       it "strips single quote character within the search terms and returns search results" do
-        reference_with_tabs = "WEX'000001"
+        wex_reference = "WEX'000001"
 
         expect(page).to have_field("term")
-        fill_in "term", with: reference_with_tabs
+        fill_in "term", with: wex_reference
         expect(page).to have_button("Search")
         click_on "Search"
 
@@ -73,10 +77,10 @@ RSpec.describe "Dashboard" do
       end
 
       it "strips less-than character within the search terms and returns search results" do
-        reference_with_tabs = "WEX<000001"
+        wex_reference = "WEX<000001"
 
         expect(page).to have_field("term")
-        fill_in "term", with: reference_with_tabs
+        fill_in "term", with: wex_reference
         expect(page).to have_button("Search")
         click_on "Search"
 
@@ -85,10 +89,10 @@ RSpec.describe "Dashboard" do
       end
 
       it "strips greater-than character within the search terms and returns search results" do
-        reference_with_tabs = "WEX>000001"
+        wex_reference = "WEX>000001"
 
         expect(page).to have_field("term")
-        fill_in "term", with: reference_with_tabs
+        fill_in "term", with: wex_reference
         expect(page).to have_button("Search")
         click_on "Search"
 
@@ -97,10 +101,10 @@ RSpec.describe "Dashboard" do
       end
 
       it "strips forward slash character within the search terms and returns search results" do
-        reference_with_tabs = "WEX/000001"
+        wex_reference = "WEX/000001"
 
         expect(page).to have_field("term")
-        fill_in "term", with: reference_with_tabs
+        fill_in "term", with: wex_reference
         expect(page).to have_button("Search")
         click_on "Search"
 

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Dashboard" do
         expect(page).to have_text("WEX000001")
       end
 
-      it "strips ampersant character within the search terms and returns search results" do
+      it "strips ampersand character within the search terms and returns search results" do
         reference_with_tabs = "WEX&000001"
 
         expect(page).to have_field("term")

--- a/spec/models/user_journey_spec.rb
+++ b/spec/models/user_journey_spec.rb
@@ -1,0 +1,246 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# module WasteExemptionsEngine
+#   module Analytics
+
+RSpec.describe UserJourney do
+
+  # rubocop:disable RSpec/IndexedLet
+  let(:count1) { Faker::Number.between(from: 1, to: 5) }
+  let(:count2) { Faker::Number.between(from: 1, to: 5) }
+  let(:count3) { Faker::Number.between(from: 1, to: 5) }
+  # rubocop:enable RSpec/IndexedLet
+
+  describe "journey type scopes" do
+    before do
+      create_list(:user_journey, count1, :registration)
+      create_list(:user_journey, count2, :renewal)
+      create_list(:user_journey, count3, journey_type: "Foo")
+    end
+
+    it { expect(described_class.registrations.length).to eq count1 }
+    it { expect(described_class.renewals.length).to eq count2 }
+    it { expect(described_class.only_types(%w[NewRegistration]).length).to eq count1 }
+    it { expect(described_class.only_types(%w[RenewingRegistration]).length).to eq count2 }
+    it { expect(described_class.only_types(%w[NewRegistration RenewingRegistration]).length).to eq count1 + count2 }
+  end
+
+  describe "start route scopes" do
+    before do
+      create_list(:user_journey, count1, :started_digital)
+      create_list(:user_journey, count2, :started_assisted_digital)
+    end
+
+    it { expect(described_class.started_digital.length).to eq count1 }
+    it { expect(described_class.started_assisted_digital.length).to eq count2 }
+  end
+
+  describe "passed_start_cutoff_page" do
+    describe "with location_form being a cutoff page" do
+      let!(:journey_initial_page_only) { create(:user_journey, visited_pages: %w[start_form]) }
+      let!(:journey_to_location_page) { create(:user_journey, visited_pages: %w[start_form location_form]) }
+      let!(:journey_past_location_page) { create(:user_journey, visited_pages: %w[start_form location_form business_type_form]) }
+
+      it { expect(described_class.passed_start_cutoff_page).not_to include(journey_initial_page_only) }
+      it { expect(described_class.passed_start_cutoff_page).not_to include(journey_to_location_page) }
+      it { expect(described_class.passed_start_cutoff_page).to include(journey_past_location_page) }
+    end
+
+    describe "with edit_exemptions_form being a cutoff page" do
+      let!(:journey_initial_page_only) { create(:user_journey, visited_pages: %w[renewal_start_form]) }
+      let!(:journey_to_edit_exemptions_page) { create(:user_journey, visited_pages: %w[renewal_start_form edit_exemptions_form]) }
+      let!(:journey_past_edit_exemptions_page) { create(:user_journey, visited_pages: %w[renewal_start_form edit_exemptions_form deregistration_complete_no_change_form]) }
+
+      it { expect(described_class.passed_start_cutoff_page).not_to include(journey_initial_page_only) }
+      it { expect(described_class.passed_start_cutoff_page).not_to include(journey_to_edit_exemptions_page) }
+      it { expect(described_class.passed_start_cutoff_page).to include(journey_past_edit_exemptions_page) }
+    end
+
+    describe "with front_office_edit_form being a cutoff page" do
+      let!(:journey_initial_page_only) { create(:user_journey, visited_pages: %w[start_form]) }
+      let!(:journey_to_front_office_edit_page) { create(:user_journey, visited_pages: %w[start_form front_office_edit_form]) }
+      let!(:journey_past_front_office_edit_page) { create(:user_journey, visited_pages: %w[start_form front_office_edit_form contact_name_form]) }
+
+      it { expect(described_class.passed_start_cutoff_page).not_to include(journey_initial_page_only) }
+      it { expect(described_class.passed_start_cutoff_page).not_to include(journey_to_front_office_edit_page) }
+      it { expect(described_class.passed_start_cutoff_page).to include(journey_past_front_office_edit_page) }
+    end
+
+    describe "with confirm_renewal_form being a cutoff page" do
+      let!(:journey_initial_page_only) { create(:user_journey, visited_pages: %w[renewal_start_form]) }
+      let!(:journey_to_confirm_renewal_page) { create(:user_journey, visited_pages: %w[renewal_start_form confirm_renewal_form]) }
+      let!(:journey_past_confirm_renewal_page) { create(:user_journey, visited_pages: %w[renewal_start_form confirm_renewal_form declaration_form]) }
+
+      it { expect(described_class.passed_start_cutoff_page).not_to include(journey_initial_page_only) }
+      it { expect(described_class.passed_start_cutoff_page).not_to include(journey_to_confirm_renewal_page) }
+      it { expect(described_class.passed_start_cutoff_page).to include(journey_past_confirm_renewal_page) }
+    end
+  end
+
+  describe "completion scopes" do
+    before do
+      create_list(:user_journey, count1, :completed_digital)
+      create_list(:user_journey, count2, :completed_assisted_digital)
+      create_list(:user_journey, count3, completed_at: nil)
+    end
+
+    it { expect(described_class.completed_digital.length).to eq count1 }
+    it { expect(described_class.completed_assisted_digital.length).to eq count2 }
+    it { expect(described_class.completed.length).to eq count1 + count2 }
+    it { expect(described_class.incomplete.length).to eq count3 }
+  end
+
+  describe ".date_range" do
+    subject(:date_range_query_results) { described_class.date_range(start_date, end_date) }
+
+    let(:start_date) { 10.days.ago.midnight }
+    let(:end_date) { Time.zone.today.midnight }
+
+    context "with journeys started before the range" do
+      let!(:journey_started_before_range) { Timecop.freeze(start_date - 2.days) { create(:user_journey, completed_at: start_date - 1.day) } }
+
+      it "does not include journeys started before the range" do
+        expect(date_range_query_results).not_to include(journey_started_before_range)
+      end
+    end
+
+    context "with journeys starting at the range start" do
+      let!(:journey_started_at_range_start) { Timecop.freeze(start_date) { create(:user_journey, completed_at: start_date + 1.day) } }
+
+      it "includes journeys started at the range start" do
+        expect(date_range_query_results).to include(journey_started_at_range_start)
+      end
+    end
+
+    context "with journeys starting before the range end" do
+      let!(:journey_started_before_range_end) { Timecop.freeze(end_date - 1.day) { create(:user_journey, completed_at: end_date) } }
+
+      it "includes journeys started before the range end" do
+        expect(date_range_query_results).to include(journey_started_before_range_end)
+      end
+    end
+
+    context "with journeys starting after the range" do
+      let!(:journey_started_after_range) { Timecop.freeze(end_date + 1.day) { create(:user_journey) } }
+
+      it "does not include journeys started after the range" do
+        expect(date_range_query_results).not_to include(journey_started_after_range)
+      end
+    end
+
+    context "with journeys completed after the range" do
+      let!(:journey_completed_after_range) { Timecop.freeze(start_date - 2.days) { create(:user_journey, completed_at: end_date + 1.day) } }
+
+      it "does not include journeys completed after the range" do
+        expect(date_range_query_results).not_to include(journey_completed_after_range)
+      end
+    end
+
+    context "with ongoing journeys started in the range" do
+      let!(:ongoing_journey_started_in_range) { Timecop.freeze(start_date + 1.day) { create(:user_journey, completed_at: nil) } }
+
+      it "includes ongoing journeys started in the range" do
+        expect(date_range_query_results).to include(ongoing_journey_started_in_range)
+      end
+    end
+
+    context "with ongoing journeys started before the range" do
+      let!(:ongoing_journey_started_before_range) { Timecop.freeze(start_date - 3.days) { create(:user_journey, completed_at: nil) } }
+
+      it "does not include ongoing journeys started before the range" do
+        expect(date_range_query_results).not_to include(ongoing_journey_started_before_range)
+      end
+    end
+
+    context "with journeys started before and ended within the range" do
+      let!(:journey_started_before_and_ended_within_range) { Timecop.freeze(start_date - 1.day) { create(:user_journey, completed_at: end_date) } }
+
+      it "does not include journeys started before and ended within the range" do
+        expect(date_range_query_results).not_to include(journey_started_before_and_ended_within_range)
+      end
+    end
+  end
+
+  describe "#complete_journey" do
+    let(:transient_registration) { create(:new_registration) }
+    let(:journey) { Timecop.freeze(1.hour.ago) { create(:user_journey, token: transient_registration.token) } }
+    let(:completion_time) { Time.zone.now }
+
+    before do
+      allow(WasteExemptionsEngine.configuration).to receive(:host_is_back_office?).and_return(false)
+      Timecop.freeze(completion_time) { journey.complete_journey(transient_registration) }
+    end
+
+    it "updates the completed_at attribute on completion" do
+      expect(journey.completed_at).to be_within(1.second).of(completion_time)
+    end
+
+    it "sets the completed_route to 'DIGITAL' on completion" do
+      expect(journey.completed_route).to eq "DIGITAL"
+    end
+
+    it "updates registration data with attributes from the transient registration on completion" do
+      expected_attributes = transient_registration.attributes.slice("business_type", "type")
+      expect(journey.registration_data).to include(expected_attributes)
+    end
+  end
+
+  describe ".average_session_duration" do
+    let(:transient_registration_a) { create(:new_registration) }
+    let(:transient_registration_b) { create(:new_registration) }
+
+    let!(:journey_a) { Timecop.freeze(6.hours.ago) { create(:user_journey, token: transient_registration_a.token) } }
+    let!(:journey_b) { Timecop.freeze(4.hours.ago) { create(:user_journey, token: transient_registration_b.token) } }
+    let!(:journey_c) { Timecop.freeze(1.hour.ago) { create(:user_journey) } }
+
+    before do
+      journey_a.complete_journey(transient_registration_a)
+      journey_b.complete_journey(transient_registration_b)
+      # simulate a non-completion update:
+      journey_c.update(registration_data: { foo: :bar })
+    end
+
+    it "returns the average duration across all user journeys" do
+      total_duration = [
+        journey_a.completed_at.to_time - journey_a.created_at.to_time,
+        journey_b.completed_at.to_time - journey_b.created_at.to_time,
+        journey_c.updated_at.to_time - journey_c.created_at.to_time
+      ].sum
+
+      expect(described_class.average_duration(described_class.all)).to be_within(0.1.seconds).of(total_duration / 3)
+    end
+
+    context "with completed registrations only" do
+      it "returns the average duration across completed journeys only" do
+        total_duration = [
+          journey_a.completed_at.to_time - journey_a.created_at.to_time,
+          journey_b.completed_at.to_time - journey_b.created_at.to_time
+        ].sum
+
+        expect(described_class.average_duration(described_class.completed)).to be_within(0.1.seconds).of(total_duration / 2)
+      end
+    end
+
+    context "with incomplete registrations only" do
+      it "returns the average duration across incomplete journeys only" do
+        duration = journey_c.updated_at.to_time - journey_c.created_at.to_time
+        expect(described_class.average_duration(described_class.incomplete)).to eq duration
+      end
+    end
+  end
+
+  describe ".minimum_created_at" do
+    # rubocop:disable RSpec/LetSetup
+    let!(:earliest_created_journey) { create(:user_journey, created_at: 5.days.ago) }
+    let!(:latest_created_journey) { create(:user_journey, created_at: 1.day.ago) }
+    # rubocop:enable RSpec/LetSetup
+
+    it "returns the earliest created user journey" do
+      expect(described_class.minimum_created_at).to be_within(1.second).of(earliest_created_journey.created_at)
+    end
+  end
+  #   end
+  # end
+end

--- a/spec/models/user_journey_spec.rb
+++ b/spec/models/user_journey_spec.rb
@@ -77,6 +77,17 @@ RSpec.describe UserJourney do
       it { expect(described_class.passed_start_cutoff_page).not_to include(journey_to_confirm_renewal_page) }
       it { expect(described_class.passed_start_cutoff_page).to include(journey_past_confirm_renewal_page) }
     end
+
+    # This spec is to ensure that legacy journeys before the renaming of renew_without_changes_form re also counted
+    describe "with renew_without_changes_form being a cutoff page" do
+      let!(:journey_initial_page_only) { create(:user_journey, visited_pages: %w[renewal_start_form]) }
+      let!(:journey_to_renew_without_changes) { create(:user_journey, visited_pages: %w[renewal_start_form renew_without_changes_form]) }
+      let!(:journey_past_renew_without_changes) { create(:user_journey, visited_pages: %w[renewal_start_form renew_without_changes_form declaration_form]) }
+
+      it { expect(described_class.passed_start_cutoff_page).not_to include(journey_initial_page_only) }
+      it { expect(described_class.passed_start_cutoff_page).not_to include(journey_to_renew_without_changes) }
+      it { expect(described_class.passed_start_cutoff_page).to include(journey_past_renew_without_changes) }
+    end
   end
 
   describe "completion scopes" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,8 +9,13 @@ require File.expand_path("../config/environment", __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
-require "capybara/poltergeist"
-Capybara.javascript_driver = :poltergeist
+
+# Use Selenium Chrome driver in headless mode. Poltergeist has issues loading JS.
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome,
+                                      options: Selenium::WebDriver::Chrome::Options.new(args: %w[headless disable-gpu]))
+end
+Capybara.javascript_driver = :chrome
 Capybara.server = :webrick
 
 # Checks for pending migrations and applies them before tests are run.

--- a/spec/requests/exemptions_spec.rb
+++ b/spec/requests/exemptions_spec.rb
@@ -5,15 +5,18 @@ require "rails_helper"
 RSpec.describe "Exemptions Controller" do
   let(:user) { create(:user, :super_agent) }
 
-  before do
-    sign_in(user)
+  let!(:exemptions) { create_list(:exemption, 3) }
+  let!(:bands) { create_list(:band, 2) }
+  let!(:buckets) do
+    [
+      create(:bucket, bucket_type: "farmer"),
+      create(:bucket, bucket_type: "charity")
+    ]
   end
 
-  describe "GET /exemptions" do
-    let!(:exemptions) { create_list(:exemption, 3) }
-    let!(:bands) { create_list(:band, 2) }
-    let!(:buckets) { create_list(:bucket, 2) }
+  before { sign_in(user) }
 
+  describe "GET /exemptions" do
     it "responds to the GET request with a 200 status code and renders the appropriate template" do
       get exemptions_path
 
@@ -26,10 +29,6 @@ RSpec.describe "Exemptions Controller" do
   end
 
   describe "PUT /exemptions" do
-    let!(:exemptions) { create_list(:exemption, 3) }
-    let!(:bands) { create_list(:band, 2) }
-    let!(:buckets) { create_list(:bucket, 2) }
-
     context "when the update is successful" do
       let(:request_params) do
         {


### PR DESCRIPTION
This change:
- Moves back-office-specific user journey analytics logic from the engine to the back-office
- Resolves an issue where a hard exit in a rake task (only in the test env) was causing rspec to skip many unit tests, locally and in CI
- Fixes some failing tests which relied on Javascript, partly by replacing Poltergeist with Selenium Chrome
- Addresses an issue where visits to the legacy `renew_without_changes_form` were not being included in user journey statistics calculations
https://eaflood.atlassian.net/browse/RUBY-3291