### PR TITLE
RUBY-3297: Ability to track report downloads + export download history

### DIFF
--- a/app/controllers/bulk_exports_controller.rb
+++ b/app/controllers/bulk_exports_controller.rb
@@ -21,6 +21,17 @@ class BulkExportsController < ApplicationController
     redirect_to url, allow_other_host: true
   end
 
+  def download_history
+    authorize! :read, Reports::Download
+
+    respond_to do |format|
+      format.csv do
+        timestamp = Time.zone.now.strftime("%Y-%m-%d_%H:%M")
+        send_data Reports::DownloadHistoryExportService.run, filename: "download_history_#{timestamp}.csv"
+      end
+    end
+  end
+
   private
 
   def bucket_name

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -25,6 +25,7 @@ class Ability
     can :change_role, User
     can :activate_or_deactivate, User
     can :read, Reports::DefraQuarterlyStatsService
+    can :read, Reports::Download
 
     permissions_for_super_agent
   end

--- a/app/models/reports/download.rb
+++ b/app/models/reports/download.rb
@@ -4,8 +4,8 @@ module Reports
   class Download < WasteExemptionsEngine::ApplicationRecord
     self.table_name = :reports_downloads
 
-    belongs_to :report, polymorphic: true, optional: false
-
+    validates :report_type, presence: true
+    validates :report_file_name, presence: true
     validates :user_id, presence: true
     validates :downloaded_at, presence: true
   end

--- a/app/models/reports/download.rb
+++ b/app/models/reports/download.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Reports
+  class Download < WasteExemptionsEngine::ApplicationRecord
+    self.table_name = :reports_downloads
+
+    belongs_to :report, polymorphic: true, optional: false
+
+    validates :user_id, presence: true
+    validates :downloaded_at, presence: true
+  end
+end

--- a/app/presenters/bulk_exports_presenter.rb
+++ b/app/presenters/bulk_exports_presenter.rb
@@ -19,6 +19,7 @@ class BulkExportsPresenter
 
   def build_link_data(generated_report)
     {
+      id: generated_report.id,
       url: bucket.presigned_url(generated_report.file_name),
       text: generated_report.data_from_date.to_fs(:month_year)
     }

--- a/app/services/reports/download_history_export_service.rb
+++ b/app/services/reports/download_history_export_service.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Reports
+  class DownloadHistoryExportService < WasteExemptionsEngine::BaseService
+
+    COLUMNS = {
+      report_type: "Report",
+      file_name: "Name",
+      email: "Email",
+      downloaded_at: "Downloaded at"
+    }.freeze
+
+    def run
+      CSV.generate do |csv|
+        csv << COLUMNS.values
+        history_scope.each do |download|
+          csv << present_row(download)
+        end
+      end
+    end
+
+    private
+
+    def history_scope
+      Reports::Download.order(downloaded_at: :desc)
+    end
+
+    def report_name(report_type)
+      type = report_type.gsub(/([a-z])([A-Z])/, '\1_\2').downcase.gsub("::", ".")
+      I18n.t("bulk_exports.#{type}")
+    end
+
+    def present_row(download)
+      [
+        report_name(download.report_type),
+        download.report_file_name,
+        User.find(download.user_id)&.email,
+        download.downloaded_at&.strftime(Time::DATE_FORMATS[:day_month_year_time_slashes])
+      ]
+    end
+  end
+end

--- a/app/services/reports/track_download_service.rb
+++ b/app/services/reports/track_download_service.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Reports
+  class TrackDownloadService < ::WasteExemptionsEngine::BaseService
+    def run(report:, user:)
+      Reports::Download.create!(
+        report: report,
+        user_id: user&.id,
+        downloaded_at: Time.zone.now
+      )
+    end
+  end
+end

--- a/app/services/reports/track_download_service.rb
+++ b/app/services/reports/track_download_service.rb
@@ -4,7 +4,8 @@ module Reports
   class TrackDownloadService < ::WasteExemptionsEngine::BaseService
     def run(report:, user:)
       Reports::Download.create!(
-        report: report,
+        report_type: report.class.name,
+        report_file_name: report.file_name,
         user_id: user&.id,
         downloaded_at: Time.zone.now
       )

--- a/app/views/bulk_exports/show.html.erb
+++ b/app/views/bulk_exports/show.html.erb
@@ -17,7 +17,7 @@
       <ul class="govuk-list">
         <% @bulk_exports.links.each do |link_data| %>
         <li>
-          <%= link_to link_data[:text], link_data[:url] %>
+          <%= link_to link_data[:text], bulk_export_download_path(link_data[:id]) %>
         </li>
         <% end %>
       </ul>

--- a/app/views/bulk_exports/show.html.erb
+++ b/app/views/bulk_exports/show.html.erb
@@ -5,6 +5,13 @@
     <h1 class="govuk-heading-l">
       <%= t(".heading") %>
     </h1>
+
+    <% if can?(:read, Reports::Download) %>
+    <p class="govuk-body">
+      <%= link_to t(".download_history"), bulk_export_download_history_path(format: :csv) %>
+    </p>
+    <% end %>
+
     <p class="govuk-body">
       <%= @bulk_exports.exported_at_message %>
     </p>

--- a/config/locales/bulk_exports.en.yml
+++ b/config/locales/bulk_exports.en.yml
@@ -5,3 +5,6 @@ en:
       heading: "Data Exports"
       not_yet_exported: "The files have not yet been generated"
       exported_at:  "These files were created at %{export_executed_at}."
+      download_history: "Export download history to CSV"
+    reports:
+      generated_report: "Registration Data Export"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
 
   # Bulk Exports
   get "/data-exports", to: "bulk_exports#show", as: :bulk_exports
+  get "/data-exports/history", to: "bulk_exports#download_history", as: :bulk_export_download_history
   get "/data-exports/:id", to: "bulk_exports#download", as: :bulk_export_download
 
   # Registration management

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
 
   # Bulk Exports
   get "/data-exports", to: "bulk_exports#show", as: :bulk_exports
+  get "/data-exports/:id", to: "bulk_exports#download", as: :bulk_export_download
 
   # Registration management
   resources :registrations, only: :show, param: :reference do

--- a/db/migrate/20240912151037_create_reports_downloads.rb
+++ b/db/migrate/20240912151037_create_reports_downloads.rb
@@ -1,7 +1,9 @@
 class CreateReportsDownloads < ActiveRecord::Migration[7.1]
   def change
     create_table :reports_downloads do |t|
-      t.references :report, polymorphic: true
+      t.string :report_type
+      t.string :report_file_name
+      
       t.string :user_id
       t.datetime :downloaded_at
     end

--- a/db/migrate/20240912151037_create_reports_downloads.rb
+++ b/db/migrate/20240912151037_create_reports_downloads.rb
@@ -1,0 +1,9 @@
+class CreateReportsDownloads < ActiveRecord::Migration[7.1]
+  def change
+    create_table :reports_downloads do |t|
+      t.references :report, polymorphic: true
+      t.string :user_id
+      t.datetime :downloaded_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -272,10 +272,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_12_151037) do
 
   create_table "reports_downloads", force: :cascade do |t|
     t.string "report_type"
-    t.bigint "report_id"
+    t.string "report_file_name"
     t.string "user_id"
     t.datetime "downloaded_at"
-    t.index ["report_type", "report_id"], name: "index_reports_downloads_on_report"
   end
 
   create_table "reports_generated_reports", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_23_131328) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_12_151037) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "tsm_system_rows"
@@ -268,6 +268,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_131328) do
     t.index ["reference"], name: "index_registrations_on_reference", unique: true
     t.index ["renew_token"], name: "index_registrations_on_renew_token", unique: true
     t.index ["unsubscribe_token"], name: "index_registrations_on_unsubscribe_token", unique: true
+  end
+
+  create_table "reports_downloads", force: :cascade do |t|
+    t.string "report_type"
+    t.bigint "report_id"
+    t.string "user_id"
+    t.datetime "downloaded_at"
+    t.index ["report_type", "report_id"], name: "index_reports_downloads_on_report"
   end
 
   create_table "reports_generated_reports", id: :serial, force: :cascade do |t|

--- a/spec/factories/reports/download.rb
+++ b/spec/factories/reports/download.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :download, class: "Reports::Download" do
+    report_type { "Reports::GeneratedReport" }
+    report_file_name { "20190601-20190630.csv" }
+    user_id { create(:user).id }
+    downloaded_at { Time.zone.now }
+  end
+end

--- a/spec/models/reports/download_spec.rb
+++ b/spec/models/reports/download_spec.rb
@@ -16,16 +16,14 @@ RSpec.describe Reports::Download do
       expect(download.errors[:downloaded_at]).to include("can't be blank")
     end
 
-    it "validates presence of report" do
+    it "validates presence of report_type" do
       expect(download).not_to be_valid
-      expect(download.errors[:report]).to include("must exist")
+      expect(download.errors[:report_type]).to include("can't be blank")
     end
-  end
 
-  describe "associations" do
-    it "belongs to report" do
-      association = described_class.reflect_on_association(:report)
-      expect(association.macro).to eq(:belongs_to)
+    it "validates presence of report_file_name" do
+      expect(download).not_to be_valid
+      expect(download.errors[:report_file_name]).to include("can't be blank")
     end
   end
 end

--- a/spec/models/reports/download_spec.rb
+++ b/spec/models/reports/download_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Reports::Download do
+  let(:download) { described_class.new(user_id: nil) }
+
+  describe "validations" do
+    it "validates presence of user_id" do
+      expect(download).not_to be_valid
+      expect(download.errors[:user_id]).to include("can't be blank")
+    end
+
+    it "validates presence of downloaded_at" do
+      expect(download).not_to be_valid
+      expect(download.errors[:downloaded_at]).to include("can't be blank")
+    end
+
+    it "validates presence of report" do
+      expect(download).not_to be_valid
+      expect(download.errors[:report]).to include("must exist")
+    end
+  end
+
+  describe "associations" do
+    it "belongs to report" do
+      association = described_class.reflect_on_association(:report)
+      expect(association.macro).to eq(:belongs_to)
+    end
+  end
+end

--- a/spec/requests/bulk_exports_spec.rb
+++ b/spec/requests/bulk_exports_spec.rb
@@ -25,4 +25,20 @@ RSpec.describe "Bulk Exports" do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe "GET /data-exports/:id" do
+    let(:generated_report) { create(:generated_report) }
+    let(:bucket_name) { WasteExemptionsBackOffice::Application.config.bulk_reports_bucket_name }
+    let(:download_link) do
+      bucket = DefraRuby::Aws.get_bucket(bucket_name)
+      bucket.presigned_url(generated_report.file_name)
+    end
+
+    it "redirects to the correct URL and responds with a 302 status code" do
+      get bulk_export_download_path(generated_report)
+
+      expect(response).to redirect_to(download_link)
+      expect(response).to have_http_status(:found)
+    end
+  end
 end

--- a/spec/requests/bulk_exports_spec.rb
+++ b/spec/requests/bulk_exports_spec.rb
@@ -41,4 +41,30 @@ RSpec.describe "Bulk Exports" do
       expect(response).to have_http_status(:found)
     end
   end
+
+  describe "GET /data-exports/download_history.csv" do
+    let(:csv_content) { "Report,Name,Email,Downloaded at\nmonthly,report.csv,test@example.com,01/01/2023 12:00" }
+    let(:service) { instance_double(Reports::DownloadHistoryExportService, run: csv_content) }
+
+    before do
+      allow(Reports::DownloadHistoryExportService).to receive(:new).and_return(service)
+    end
+
+    it "responds with success" do
+      get bulk_export_download_history_path, params: { format: :csv }
+      expect(response).to have_http_status(:success)
+    end
+
+    it "calls the DownloadHistoryExportService" do
+      get bulk_export_download_history_path, params: { format: :csv }
+      expect(Reports::DownloadHistoryExportService).to have_received(:new)
+      expect(service).to have_received(:run)
+    end
+
+    it "returns the correct CSV content" do
+      get bulk_export_download_history_path, params: { format: :csv }
+      expect(response.body).to eq(csv_content)
+      expect(response.header["Content-Type"]).to include("text/csv")
+    end
+  end
 end

--- a/spec/services/reports/download_history_export_service_spec.rb
+++ b/spec/services/reports/download_history_export_service_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "csv"
+
+module Reports
+  RSpec.describe DownloadHistoryExportService do
+    describe ".run" do
+      let!(:user) { create(:user, email: "test@example.com") }
+      let!(:report) { create(:generated_report) }
+      let!(:download) { create(:download, report_type: report.class.name, report_file_name: report.file_name, user_id: user.id, downloaded_at: Time.zone.now) }
+      let(:service) { described_class.new }
+
+      it "generates a CSV with the correct headers and data" do
+        csv_content = service.run
+        csv = CSV.parse(csv_content, headers: true)
+
+        expect(csv.headers).to eq(["Report", "Name", "Email", "Downloaded at"])
+        expect(csv[0]["Report"]).to eq("Registration Data Export")
+        expect(csv[0]["Name"]).to eq(download.report_file_name)
+        expect(csv[0]["Email"]).to eq(user.email)
+        expect(csv[0]["Downloaded at"]).to eq(download.downloaded_at.strftime(Time::DATE_FORMATS[:day_month_year_time_slashes]))
+      end
+    end
+  end
+end

--- a/spec/services/reports/track_download_service_spec.rb
+++ b/spec/services/reports/track_download_service_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Reports
+  RSpec.describe TrackDownloadService do
+    describe ".run" do
+      let(:report) { create(:generated_report) }
+      let(:user) { create(:user) }
+      let(:service) { described_class.new }
+
+      it "creates a download record with the correct attributes" do
+        expect do
+          service.run(report: report, user: user)
+        end.to change(Reports::Download, :count).by(1)
+
+        download = Reports::Download.last
+        expect(download.report).to eq(report)
+        expect(download.user_id.to_i).to eq(user.id)
+        expect(download.downloaded_at).to be_within(1.second).of(Time.zone.now)
+      end
+
+      it "raises an error when user is nil" do
+        expect do
+          service.run(report: report, user: nil)
+        end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: User can't be blank")
+      end
+    end
+  end
+end

--- a/spec/services/reports/track_download_service_spec.rb
+++ b/spec/services/reports/track_download_service_spec.rb
@@ -15,7 +15,8 @@ module Reports
         end.to change(Reports::Download, :count).by(1)
 
         download = Reports::Download.last
-        expect(download.report).to eq(report)
+        expect(download.report_type).to eq(report.class.name)
+        expect(download.report_file_name).to eq(report.file_name)
         expect(download.user_id.to_i).to eq(user.id)
         expect(download.downloaded_at).to be_within(1.second).of(Time.zone.now)
       end

--- a/spec/support/shared_examples/abilities/system_examples.rb
+++ b/spec/support/shared_examples/abilities/system_examples.rb
@@ -20,4 +20,8 @@ RSpec.shared_examples "system examples" do
   it "is able to view DEFRA quarterly reports" do
     expect(subject).to be_able_to(:read, Reports::DefraQuarterlyStatsService)
   end
+
+  it "is able to view reports download history" do
+    expect(subject).to be_able_to(:read, Reports::Download)
+  end
 end


### PR DESCRIPTION
WEX - Track who uses BO data export + export download history
1. model with details of who and when downloaded report + service to save that model
2. new endpoint with ability to download report and call tracking service
3. direct report link replaced with a link to download endpoint 
4. added ability to export download history into CSV

https://eaflood.atlassian.net/browse/RUBY-3297