### PR TITLE
Feature/ruby 3298 search order

### DIFF
--- a/app/models/concerns/can_be_searched_like_registration.rb
+++ b/app/models/concerns/can_be_searched_like_registration.rb
@@ -11,6 +11,7 @@ module CanBeSearchedLikeRegistration
                 search_for_operator_address_postcode(term).ids +
                 search_for_person_name(term).ids +
                 search_for_telephone(term).ids)
+        .order(created_at: :desc)
     }
 
     scope :search_registration, lambda { |term|

--- a/lib/tasks/bulk_seed_registration_exemptions.rake
+++ b/lib/tasks/bulk_seed_registration_exemptions.rake
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "factory_bot_rails"
+require "benchmark"
+require "timecop"
+
+desc "Bulk seed registration exemptions for performance test / benchmarking purposes"
+task :bulk_seed_registration_exemptions, %i[reg_count reg_ex_count] => :environment do |_t, args|
+  registration_count = args[:reg_count].to_i
+  puts "Creating #{registration_count} registrations..."
+
+  (1..registration_count).each do |r|
+    reg_type = %i[registration renewing_registration].sample
+
+    creation_date = rand(1_000).days.ago
+    Timecop.freeze(creation_date) do
+      case reg_type
+      when :registration
+        FactoryBot.create(reg_type, submitted_at: creation_date.to_date)
+      else
+        FactoryBot.create(reg_type)
+      end
+    end
+    puts "... #{r}" if (r % 1000).zero?
+  end
+end
+
+desc "benchmark search operation"
+task :benchmark_search, %i[term filter page] => :environment do |_t, args|
+  term = args[:term] || ""
+  model = args[:filter]
+  page = args[:page]
+  puts "Searching with term: \"#{term}\", model: \"#{model}\", page: #{page}\n"
+
+  res = nil
+  Benchmark.bmbm do |x|
+    x.report("search benchmark") do
+      res = SearchService.new.search(term, model, page)
+    end
+  end
+
+  puts "Found #{res.length} matches (NB Kaminari pagination => max 20 at a time)"
+end

--- a/lib/tasks/bulk_seed_registration_exemptions.rake
+++ b/lib/tasks/bulk_seed_registration_exemptions.rake
@@ -7,7 +7,7 @@ require "timecop"
 desc "Bulk seed registration exemptions for performance test / benchmarking purposes"
 task :bulk_seed_registration_exemptions, %i[reg_count reg_ex_count] => :environment do |_t, args|
   registration_count = args[:reg_count].to_i
-  puts "Creating #{registration_count} registrations..."
+  puts "Creating #{registration_count} registrations..." unless Rails.env.test?
 
   (1..registration_count).each do |r|
     reg_type = %i[registration renewing_registration].sample
@@ -30,7 +30,7 @@ task :benchmark_search, %i[term filter page] => :environment do |_t, args|
   term = args[:term] || ""
   model = args[:filter]
   page = args[:page]
-  puts "Searching with term: \"#{term}\", model: \"#{model}\", page: #{page}\n"
+  puts "Searching with term: \"#{term}\", model: \"#{model}\", page: #{page}\n" unless Rails.env.test?
 
   res = nil
   Benchmark.bmbm do |x|
@@ -38,6 +38,4 @@ task :benchmark_search, %i[term filter page] => :environment do |_t, args|
       res = SearchService.new.search(term, model, page)
     end
   end
-
-  puts "Found #{res.length} matches (NB Kaminari pagination => max 20 at a time)"
 end

--- a/spec/lib/tasks/bulk_seed_registration_spec.rb
+++ b/spec/lib/tasks/bulk_seed_registration_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Bulk seed registrations", type: :rake do
     end
   end
 
+  # rubocop:disable RSpec/ExpectOutput
   describe "benchmark_search" do
 
     original_stdout = $stdout
@@ -37,4 +38,5 @@ RSpec.describe "Bulk seed registrations", type: :rake do
       end.not_to raise_error
     end
   end
+  # rubocop:enable RSpec/ExpectOutput
 end

--- a/spec/lib/tasks/bulk_seed_registration_spec.rb
+++ b/spec/lib/tasks/bulk_seed_registration_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Bulk seed registrations", type: :rake do
+  include_context "rake"
+
+  describe "bulk_seed_registration_exemptions" do
+
+    after do
+      Rake::Task["cleanup:transient_registrations"].reenable
+    end
+
+    it "runs without error" do
+      expect do
+        Rake::Task["bulk_seed_registration_exemptions"].invoke(3)
+      end.not_to raise_error
+    end
+
+  end
+end

--- a/spec/lib/tasks/bulk_seed_registration_spec.rb
+++ b/spec/lib/tasks/bulk_seed_registration_spec.rb
@@ -6,9 +6,8 @@ RSpec.describe "Bulk seed registrations", type: :rake do
   include_context "rake"
 
   describe "bulk_seed_registration_exemptions" do
-
     after do
-      Rake::Task["cleanup:transient_registrations"].reenable
+      Rake::Task["bulk_seed_registration_exemptions"].reenable
     end
 
     it "runs without error" do
@@ -16,6 +15,26 @@ RSpec.describe "Bulk seed registrations", type: :rake do
         Rake::Task["bulk_seed_registration_exemptions"].invoke(3)
       end.not_to raise_error
     end
+  end
 
+  describe "benchmark_search" do
+
+    original_stdout = $stdout
+
+    before do
+      # suppress noisy outputs during unit test
+      $stdout = StringIO.new
+    end
+
+    after do
+      $stdout = original_stdout
+      Rake::Task["benchmark_search"].reenable
+    end
+
+    it "runs without error" do
+      expect do
+        Rake::Task["benchmark_search"].invoke("a")
+      end.not_to raise_error
+    end
   end
 end

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -41,6 +41,21 @@ RSpec.describe SearchService do
         it_behaves_like "registration matches and non-matches"
       end
 
+      context "with multiple matches" do
+        let!(:registration_a) { Timecop.freeze(2.days.ago) { create(:registration) } }
+        let!(:registration_b) { Timecop.freeze(1.day.ago) { create(:registration) } }
+        let(:term) { registration.contact_phone }
+
+        before do
+          registration_a.update(contact_phone: registration.contact_phone)
+          registration_b.update(contact_phone: registration.contact_phone)
+        end
+
+        it "reverse-sorts results by created_at" do
+          expect(results.pluck(:id)).to eq [registration.id, registration_b.id, registration_a.id]
+        end
+      end
+
       context "with no matches on any attribute" do
         let(:term) { "this search term does not match any model attribute" }
 


### PR DESCRIPTION
Add a rake task to bulk seed registrations for performance / benchmarking purposes; and sort registration searches by date of registration creation.
https://eaflood.atlassian.net/browse/RUBY-3298