### PR TITLE
Fix/ruby 3298 jenkins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,6 +109,10 @@ group :development, :test do
 
   # Project uses RSpec as its test framework
   gem "rspec-rails"
+
+  # A gem providing "time travel" and "time freezing" capabilities, making it
+  # dead simple to test time-dependent code.
+  gem "timecop"
 end
 
 group :development do
@@ -137,9 +141,6 @@ group :test do
   gem "capybara"
   # Needed for headless testing with Javascript
   gem "selenium-webdriver"
-  # A gem providing "time travel" and "time freezing" capabilities, making it
-  # dead simple to test time-dependent code.
-  gem "timecop"
   # Mock HTTP requests
   gem "vcr"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -505,7 +505,7 @@ GEM
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     secure_headers (6.7.0)
-    selenium-webdriver (4.24.0)
+    selenium-webdriver (4.25.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_12_151037) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_18_160330) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "tsm_system_rows"
@@ -263,6 +263,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_12_151037) do
     t.boolean "reminder_opt_in", default: true
     t.string "unsubscribe_token"
     t.boolean "charged", default: false
+    t.index ["created_at"], name: "index_registrations_on_created_at"
     t.index ["deregistration_email_sent_at"], name: "index_registrations_on_deregistration_email_sent_at"
     t.index ["edit_token"], name: "index_registrations_on_edit_token", unique: true
     t.index ["reference"], name: "index_registrations_on_reference", unique: true

--- a/lib/tasks/bulk_seed_registration_exemptions.rake
+++ b/lib/tasks/bulk_seed_registration_exemptions.rake
@@ -2,7 +2,8 @@
 
 require "factory_bot_rails"
 require "benchmark"
-require "timecop"
+# Production envs need to be able to parse this file but they won't execute the tasks and won't have timecop installed
+require "timecop" unless Rails.env.production?
 
 desc "Bulk seed registration exemptions for performance test / benchmarking purposes"
 task :bulk_seed_registration_exemptions, %i[reg_count reg_ex_count] => :environment do |_t, args|


### PR DESCRIPTION
Avoid requiring timecop in production (hosted) environments - this was causing Jenkins deployments to fail.
https://eaflood.atlassian.net/browse/RUBY-3298