### PR TITLE
Feature/ruby 2705 add a payment page improvements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: ea3c28bb610b2cc6093e465008bf868dfa5cd39f
+  revision: bebb8e10cc2ea7c22716cc7c501dfb9074b94cec
   branch: main
   specs:
     waste_exemptions_engine (0.1.0)
@@ -211,7 +211,7 @@ GEM
       rubocop-rake
       rubocop-rspec
     defra_ruby_template (5.4.1)
-    defra_ruby_validators (2.7.0)
+    defra_ruby_validators (2.7.2)
       activemodel
       i18n
       matrix

--- a/app/forms/add_payment_form.rb
+++ b/app/forms/add_payment_form.rb
@@ -9,12 +9,14 @@ class AddPaymentForm
   validates :payment_type,
             inclusion: { in: %w[bank_transfer missing_card_payment other_payment],
                          message: I18n.t(".payments.errors.payment_type_invalid") }
-  validates :payment_amount, presence: { message: I18n.t(".payments.errors.payment_amount_blank") },
-                             numericality: {
-                               greater_than: 0,
-                               message: I18n.t(".payments.errors.payment_amount_invalid")
-                             }
+
+  validates :payment_amount,
+            "defra_ruby/validators/price": { messages: { blank: I18n.t(".payments.errors.payment_amount_blank"),
+                                                         invalid_format: I18n.t(".payments.errors.payment_amount_invalid") } }
+
   validates :payment_reference, presence: { message: I18n.t(".payments.errors.payment_reference_blank") }
+
+  validates :comments, length: { maximum: 500, message: I18n.t(".payments.errors.comments_too_long") }
 
   validate :validate_payment_date_current_or_past
 

--- a/app/forms/add_payment_form.rb
+++ b/app/forms/add_payment_form.rb
@@ -11,8 +11,10 @@ class AddPaymentForm
                          message: I18n.t(".payments.errors.payment_type_invalid") }
 
   validates :payment_amount,
-            "defra_ruby/validators/price": { messages: { blank: I18n.t(".payments.errors.payment_amount_blank"),
-                                                         invalid_format: I18n.t(".payments.errors.payment_amount_invalid") } }
+            "defra_ruby/validators/price": { messages: {
+              blank: I18n.t(".payments.errors.payment_amount_blank"),
+              invalid_format: I18n.t(".payments.errors.payment_amount_invalid")
+            } }
 
   validates :payment_reference, presence: { message: I18n.t(".payments.errors.payment_reference_blank") }
 

--- a/app/views/payments/new.html.erb
+++ b/app/views/payments/new.html.erb
@@ -31,7 +31,7 @@
             <div class="govuk-radios__item">
               <%= radio_button_tag 'add_payment_form[payment_type]', :missing_card_payment,
                 preselect_missing_card_payment_radio_button?, class: "govuk-radios__input" %>
-              <%= label_tag :payment_type_govpay_payment,
+              <%= label_tag :add_payment_form_payment_type_missing_card_payment,
                 t('.fields.payment_type_labels.govpay_payment'),
                 class: "govuk-label govuk-radios__label" %>
             </div>
@@ -39,7 +39,7 @@
             <div class="govuk-radios__item">
               <%= radio_button_tag 'add_payment_form[payment_type]', :bank_transfer,
                 preselect_bank_transfer_radio_button?, class: "govuk-radios__input" %>
-              <%= label_tag :payment_type_bank_transfer,
+              <%= label_tag :add_payment_form_payment_type_bank_transfer,
                 t('.fields.payment_type_labels.bank_transfer'),
                 class: "govuk-label govuk-radios__label" %>
             </div>
@@ -47,7 +47,7 @@
             <div class="govuk-radios__item">
               <%= radio_button_tag 'add_payment_form[payment_type]', :other_payment,
                 preselect_other_payment_radio_button?, class: "govuk-radios__input" %>
-              <%= label_tag :payment_type_other,
+              <%= label_tag :add_payment_form_payment_type_other_payment,
                 t('.fields.payment_type_labels.other'),
                 class: "govuk-label govuk-radios__label" %>
             </div>

--- a/config/locales/payments.en.yml
+++ b/config/locales/payments.en.yml
@@ -27,4 +27,4 @@ en:
       payment_amount_blank: "You must enter an amount"
       payment_amount_invalid: "You must enter a valid amount"
       payment_reference_blank: "You must enter a payment reference"
-      comments_too_long: "Comments must be 500 characters or fewer"
+      comments_too_long: "Your comment must be no more than 500 characters"

--- a/config/locales/payments.en.yml
+++ b/config/locales/payments.en.yml
@@ -1,7 +1,7 @@
 en:
   payments:
     new:
-      title: "Add a payment"
+      title: "Record a payment"
       heading: "Record a payment for %{registration_reference}"
       submit_button: "Continue"
       fields:
@@ -14,7 +14,7 @@ en:
         payment_reference: "Payment reference"
         payment_amount: "Enter an amount"
         comments: "Comments (optional)"
-        comments_hint: "Enter details of the payment received for this registation."
+        comments_hint: "Enter details of the payment received for this registration"
         payment_date: "Date received"
         payment_date_day: "Day"
         payment_date_month: "Month"
@@ -27,3 +27,4 @@ en:
       payment_amount_blank: "You must enter an amount"
       payment_amount_invalid: "You must enter a valid amount"
       payment_reference_blank: "You must enter a payment reference"
+      comments_too_long: "Comments must be 500 characters or fewer"

--- a/spec/forms/add_payment_form_spec.rb
+++ b/spec/forms/add_payment_form_spec.rb
@@ -75,6 +75,21 @@ RSpec.describe AddPaymentForm, type: :model do
 
         it_behaves_like "form submission fails", :payment_reference
       end
+
+      context "when the comments too long" do
+        before do
+          add_payment_form[:comments] = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nisi sem, efficitur et venenatis \
+          sit amet, dapibus quis erat. Vestibulum velit ligula, luctus at commodo porttitor, viverra et orci. Orci varius natoque penatibus \
+          et magnis dis parturient montes, nascetur ridiculus mus. Donec in lectus quis urna varius convallis a non metus. Duis leo ante, \
+          porttitor in est eget, sodales pellentesque metus. Pellentesque ut viverra nisl. Suspendisse pulvinar efficitur odio at malesuada. \
+          Aenean in sem vel leo placerat feugiat posuere in velit. Phasellus accumsan orci ipsum, non luctus tortor imperdiet in. Integer \
+          ultricies congue lectus sed tristique. Maecenas lectus lectus, aliquam id vehicula eu, dignissim non erat. Donec euismod placerat \
+          eros, nec finibus sem malesuada vitae. Praesent tristique sem auctor sapien pellentesque, vitae congue massa faucibus. Duis tincidunt \
+          mauris a risus efficitur auctor. Fusce non ullamcorper urna, vel rhoncus erat."
+        end
+
+        it_behaves_like "form submission fails", :comments
+      end
     end
 
     context "when the form is valid" do


### PR DESCRIPTION
Improvements for Add a Payment page
https://eaflood.atlassian.net/browse/RUBY-2705
- fixed typo
- fixed payment type radios missing their form label
- added validation for 500 characters max in comments section 
- fixed payment amount validation - more than two decimal points were allowed
- fixed page title not matching H1