### PR TITLE
[RUBY-2704] Fix presenters bug in `RecordRefundsController` and views

### DIFF
--- a/app/controllers/record_refunds_controller.rb
+++ b/app/controllers/record_refunds_controller.rb
@@ -3,12 +3,12 @@
 class RecordRefundsController < ApplicationController
   def index
     find_resource(params[:registration_reference])
-    @payments = @resource.account&.payments&.refundable.map { |payment| PaymentPresenter.new(payment) }
+    @payments = @resource.account.payments.refundable.map { |payment| PaymentPresenter.new(payment) }
   end
 
   def new
     setup_form
-    @payment = @resource.account&.payments&.find_by(id: params[:payment_id])
+    @payment = @resource.account.payments.find_by(id: params[:payment_id])
     @presenter = PaymentPresenter.new(@payment) if @payment
     return if @payment
 
@@ -23,6 +23,7 @@ class RecordRefundsController < ApplicationController
         flash[:success] = I18n.t(".record_refunds.create.success")
         redirect_to registration_payment_details_path(registration_reference: @resource.reference)
       else
+        @presenter = PaymentPresenter.new(@payment)
         render :new
       end
     rescue ActiveRecord::RecordNotFound

--- a/app/controllers/record_refunds_controller.rb
+++ b/app/controllers/record_refunds_controller.rb
@@ -3,12 +3,13 @@
 class RecordRefundsController < ApplicationController
   def index
     find_resource(params[:registration_reference])
-    @payments = @resource.account&.payments&.refundable
+    @payments = @resource.account&.payments&.refundable.map { |payment| PaymentPresenter.new(payment) }
   end
 
   def new
     setup_form
     @payment = @resource.account&.payments&.find_by(id: params[:payment_id])
+    @presenter = PaymentPresenter.new(@payment) if @payment
     return if @payment
 
     redirect_to registration_payment_details_path(registration_reference: @resource.reference)

--- a/app/presenters/payment_presenter.rb
+++ b/app/presenters/payment_presenter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class PaymentPresenter < BasePresenter
+  include ApplicationHelper
   include FinanceDetailsHelper
 
   def payment_type
@@ -13,5 +14,13 @@ class PaymentPresenter < BasePresenter
 
   def payment_amount
     display_pence_as_pounds_sterling_and_pence(pence: super)
+  end
+
+  def maximum_refund_amount
+    display_pence_as_pounds_sterling_and_pence(pence: super)
+  end
+
+  def created_at
+    format_date(super)
   end
 end

--- a/app/views/record_refunds/index.html.erb
+++ b/app/views/record_refunds/index.html.erb
@@ -35,16 +35,16 @@
         <% @payments.each do |payment| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">
-              <%= payment.created_at.to_date.to_formatted_s(:day_month_year_slashes) %>
+              <%= payment.created_at %>
             </td>
             <td class="govuk-table__cell">
               <%= payment.reference %>
             </td>
             <td class="govuk-table__cell">
-              <%= t(".payment_types.#{payment.payment_type}") %>
+              <%= payment.payment_type %>
             </td>
             <td class="govuk-table__cell govuk-table__cell--numeric">
-              £<%= display_pence_as_pounds_and_pence(pence: payment.payment_amount, hide_pence_if_zero: false) %>
+              <%= payment.payment_amount %>
             </td>
             <td class="govuk-table__cell">
               <%= link_to new_registration_record_refund_path(reference: @resource.reference, payment_id: payment.id) do %>

--- a/app/views/record_refunds/new.html.erb
+++ b/app/views/record_refunds/new.html.erb
@@ -16,14 +16,14 @@
       <div class="govuk-form-group">
         <h2 class="govuk-heading-m"><%= t(".payment_type") %></h2>
         <p class="govuk-body">
-          <%= t(".payment_types.#{@payment.payment_type}") %>
+          <%= @presenter.payment_type %>
         </p>
       </div>
 
       <div class="govuk-form-group">
         <h2 class="govuk-heading-m"><%= t(".maximum_refund_amount") %></h2>
         <p class="govuk-body">
-          <%= display_pence_as_pounds_sterling_and_pence(pence: @payment.maximum_refund_amount, hide_pence_if_zero: false)%>
+          <%= @presenter.maximum_refund_amount %>
         </p>
       </div>
 


### PR DESCRIPTION
Bugfix to missing I18n translation and refactoring record refunds flow to use presenters 
- Updated `RecordRefundsController` to use `PaymentPresenter` for payments, ensuring consistent data presentation.
- Modified `PaymentPresenter` to include `ApplicationHelper` and added methods for formatted display of payment attributes.
- Adjusted views to utilize presenter methods for displaying payment details, improving code readability and maintainability.
