### PR TITLE
Update error message for refund amount validation

### DIFF
--- a/config/locales/forms/record_refunds.en.yml
+++ b/config/locales/forms/record_refunds.en.yml
@@ -42,8 +42,8 @@ en:
             amount:
               blank: "Enter the amount to refund"
               greater_than: "Refund amount must be greater than zero"
-              exceeds_payment_amount: "Refund amount must not exceed the maximum refund amount (amount exceeds payment amount)"
-              exceeds_balance: "Refund amount must not exceed maximum refund amount (amount exceeds balance)"
+              exceeds_payment_amount: "Refund amount must not exceed the maximum refund amount"
+              exceeds_balance: "Refund amount must not exceed maximum refund amount"
             comments:
               blank: "Enter a reason for the refund"
             payment:

--- a/config/locales/forms/record_refunds.en.yml
+++ b/config/locales/forms/record_refunds.en.yml
@@ -42,7 +42,7 @@ en:
             amount:
               blank: "Enter the amount to refund"
               greater_than: "Refund amount must be greater than zero"
-              exceeds_payment_amount: "Refund amount must not exceed the payment amount (amount exceeds payment amount)"
+              exceeds_payment_amount: "Refund amount must not exceed the maximum refund amount (amount exceeds payment amount)"
               exceeds_balance: "Refund amount must not exceed maximum refund amount (amount exceeds balance)"
             comments:
               blank: "Enter a reason for the refund"

--- a/spec/forms/record_refund_form_spec.rb
+++ b/spec/forms/record_refund_form_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe RecordRefundForm do
       it "returns false if amount is higher than the payment amount" do
         params = { amount: "35.00", comments: "Refund", payment_id: payment.id }
         expect(form.submit(params)).to be false
-        expect(form.errors[:amount]).to include("Refund amount must not exceed the payment amount (amount exceeds payment amount)")
+        expect(form.errors[:amount]).to include("Refund amount must not exceed the maximum refund amount (amount exceeds payment amount)")
       end
     end
 

--- a/spec/forms/record_refund_form_spec.rb
+++ b/spec/forms/record_refund_form_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe RecordRefundForm do
       it "returns false when amount exceeds balance" do
         params = { amount: "50.00", comments: "Refund", payment_id: payment.id }
         expect(form.submit(params)).to be false
-        expect(form.errors[:amount]).to include("Refund amount must not exceed maximum refund amount (amount exceeds balance)")
+        expect(form.errors[:amount]).to include("Refund amount must not exceed maximum refund amount")
       end
 
       it "returns false when amount is zero" do
@@ -94,7 +94,7 @@ RSpec.describe RecordRefundForm do
       it "returns false if amount is higher than the payment amount" do
         params = { amount: "35.00", comments: "Refund", payment_id: payment.id }
         expect(form.submit(params)).to be false
-        expect(form.errors[:amount]).to include("Refund amount must not exceed the maximum refund amount (amount exceeds payment amount)")
+        expect(form.errors[:amount]).to include("Refund amount must not exceed the maximum refund amount")
       end
     end
 


### PR DESCRIPTION
Clarified the error message for when the refund amount exceeds the allowable maximum, changing "payment amount" to "maximum refund amount" for better understanding.
