### PR TITLE
[RUBY-2713] Add titles to 'Record a refund' and 'Reverse a payment' forms in locales

### DIFF
--- a/app/models/waste_exemptions_engine/payment.rb
+++ b/app/models/waste_exemptions_engine/payment.rb
@@ -16,6 +16,7 @@ module WasteExemptionsEngine
         .success
         .where.not(payment_type: PAYMENT_TYPE_GOVPAY)
         .where.not(id: Payment.where.not(associated_payment_id: nil).select(:associated_payment_id))
+        .order(date_time: :desc)
     }
 
     def maximum_refund_amount

--- a/app/views/record_refunds/new.html.erb
+++ b/app/views/record_refunds/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t(".title", reference: @resource.reference) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render("waste_exemptions_engine/shared/back", back_path: registration_record_refunds_path(registration_reference: @resource.reference)) %>

--- a/app/views/record_reversals/new.html.erb
+++ b/app/views/record_reversals/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t(".title", reference: @resource.reference) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render("waste_exemptions_engine/shared/back", back_path: registration_record_reversals_path(registration_reference: @resource.reference)) %>

--- a/config/locales/forms/record_refunds.en.yml
+++ b/config/locales/forms/record_refunds.en.yml
@@ -17,7 +17,7 @@ en:
         other_payment: "Other payment"
     new:
       heading: "Record a refund for %{reference}"
-      title: "Record a refund"
+      title: "Record a refund for %{reference}"
       payment_type: "Payment type"
       payment_types:
         govpay_payment: Govpay

--- a/config/locales/forms/record_refunds.en.yml
+++ b/config/locales/forms/record_refunds.en.yml
@@ -17,6 +17,7 @@ en:
         other_payment: "Other payment"
     new:
       heading: "Record a refund for %{reference}"
+      title: "Record a refund"
       payment_type: "Payment type"
       payment_types:
         govpay_payment: Govpay

--- a/config/locales/forms/record_reversals.en.yml
+++ b/config/locales/forms/record_reversals.en.yml
@@ -17,6 +17,7 @@ en:
         other_payment: "Other payment"
     new:
       heading: "Reverse a payment for %{reference}"
+      title: "Reverse a payment"
       payment_type: "Payment type"
       amount_to_reverse: "Amount to reverse"
       reason: "Reason"

--- a/config/locales/forms/record_reversals.en.yml
+++ b/config/locales/forms/record_reversals.en.yml
@@ -17,7 +17,7 @@ en:
         other_payment: "Other payment"
     new:
       heading: "Reverse a payment for %{reference}"
-      title: "Reverse a payment"
+      title: "Reverse a payment for %{reference}"
       payment_type: "Payment type"
       amount_to_reverse: "Amount to reverse"
       reason: "Reason"


### PR DESCRIPTION
Added 'title' fields to the 'Record a refund' and 'Reverse a payment' forms in the English locale files to provide clear headings for these forms.
