### PR TITLE
[RUBY-2713] Add authorization to RecordReversalsController and fix Accessibility issue

### DIFF
--- a/app/controllers/record_reversals_controller.rb
+++ b/app/controllers/record_reversals_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class RecordReversalsController < ApplicationController
+  before_action :authorize
+
   def index
     find_resource(params[:registration_reference])
     @payments = @resource.account.payments.reverseable.map { |payment| PaymentPresenter.new(payment) }
@@ -34,6 +36,11 @@ class RecordReversalsController < ApplicationController
   end
 
   private
+
+  def authorize
+    resource = find_resource(params[:registration_reference])
+    authorize! :reverse_payment, resource
+  end
 
   def find_resource(reference)
     @resource = WasteExemptionsEngine::Registration.find_by(reference: reference)

--- a/app/views/record_reversals/new.html.erb
+++ b/app/views/record_reversals/new.html.erb
@@ -32,12 +32,10 @@
         </p>
       </div>
 
-      <div class="govuk-form-group">
-        <%= f.label :comments, class: "govuk-label govuk-label--m" do %>
-          <%= t(".reason") %>
-        <% end %>
-        <%= f.text_area :comments, class: "govuk-textarea", rows: 5 %>
-      </div>
+      <%= f.govuk_text_area :comments,
+                           label: { text: t(".reason"), size: "m" },
+                           rows: 5,
+                           link_errors: true %>
 
       <div class="govuk-form-group">
         <%= f.submit t(".reverse_button"), class: "govuk-button", "data-module": "govuk-button" %>

--- a/spec/requests/record_reversals_spec.rb
+++ b/spec/requests/record_reversals_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Record Reversal Forms" do
-  let(:user) { create(:user, :admin_agent) }
+  let(:user) { create(:user, :developer) }
   let(:registration) { create(:registration) }
   let(:payment) do
     create(:payment,
@@ -20,6 +20,11 @@ RSpec.describe "Record Reversal Forms" do
     sign_in(user)
   end
 
+  shared_examples "not permitted" do
+    it { expect(response.code).to eq(WasteExemptionsEngine::ApplicationController::UNSUCCESSFUL_REDIRECTION_CODE.to_s) }
+    it { expect(response.location).to include("/pages/permission") }
+  end
+
   describe "GET /registrations/:reference/record-reversal" do
     context "when the user is signed in" do
       it "renders the index template and returns a 200 status" do
@@ -33,6 +38,16 @@ RSpec.describe "Record Reversal Forms" do
         get registration_record_reversals_path(registration_reference: registration.reference)
 
         expect(response.body).to include("£30")
+      end
+
+      context "when the user does not have permission to access the page" do
+        let(:user) { create(:user, :data_agent) }
+
+        before do
+          get registration_record_reversals_path(registration_reference: registration.reference)
+        end
+
+        it_behaves_like "not permitted"
       end
     end
 
@@ -60,6 +75,16 @@ RSpec.describe "Record Reversal Forms" do
         get new_registration_record_reversal_path(registration_reference: registration.reference, payment_id: payment.id)
 
         expect(response.body).to include("£30")
+      end
+
+      context "when the user does not have permission to access the page" do
+        let(:user) { create(:user, :data_agent) }
+
+        before do
+          get new_registration_record_reversal_path(registration_reference: registration.reference, payment_id: payment.id)
+        end
+
+        it_behaves_like "not permitted"
       end
     end
 
@@ -138,6 +163,16 @@ RSpec.describe "Record Reversal Forms" do
             post registration_record_reversals_path(registration_reference: registration.reference), params: invalid_params
           end.not_to change(WasteExemptionsEngine::Payment, :count)
         end
+      end
+
+      context "when the user does not have permission to access the page" do
+        let(:user) { create(:user, :data_agent) }
+
+        before do
+          post registration_record_reversals_path(registration_reference: registration.reference), params: valid_params
+        end
+
+        it_behaves_like "not permitted"
       end
     end
 


### PR DESCRIPTION
Jira ticket: https://eaflood.atlassian.net/browse/RUBY-2713

- Introduced an `authorize` before_action in `RecordReversalsController` to check user permissions for reversing payments.
- Updated specs to reflect authorization changes, including tests for users without permission.
- Changed test user role from `admin_agent` to `developer` and added shared examples for unauthorized access scenarios.
- Fix accessibility with error link issue