### PR TITLE
Feature/ruby 3296 display registration details

### DIFF
--- a/app/helpers/registrations_helper.rb
+++ b/app/helpers/registrations_helper.rb
@@ -29,7 +29,12 @@ module RegistrationsHelper
   end
 
   def registration_date_range(resource)
-    "(#{resource.created_at.strftime('%-d %B %Y')} to #{resource.expires_on.strftime('%-d %B %Y')})"
+    created_on = resource.created_at.strftime("%-d %B %Y")
+    if resource.respond_to?(:expires_on)
+      "(#{created_on} to #{resource.expires_on.strftime('%-d %B %Y')})"
+    else
+      "(created on #{created_on})"
+    end
   end
 
   def registration_details_link_with_dates(resource)

--- a/app/helpers/registrations_helper.rb
+++ b/app/helpers/registrations_helper.rb
@@ -15,4 +15,26 @@ module RegistrationsHelper
      resource.contact_email,
      resource.contact_position].any?
   end
+
+  def renewal_history(resource)
+    result = [resource]
+    registration_cursor = resource
+
+    while registration_cursor.renewal?
+      registration_cursor = registration_cursor.referring_registration
+      result << registration_cursor
+    end
+
+    result
+  end
+
+  def registration_date_range(resource)
+    "(#{resource.created_at.strftime('%-d %B %Y')} to #{resource.expires_on.strftime('%-d %B %Y')})"
+  end
+
+  def registration_details_link_with_dates(resource)
+    link_text = "#{resource.reference} #{registration_date_range(resource)}"
+
+    link_to link_text, view_link_for(resource), id: "view_#{resource.reference}"
+  end
 end

--- a/app/views/shared/_resource_address.html.erb
+++ b/app/views/shared/_resource_address.html.erb
@@ -36,7 +36,7 @@
         <%= t(".labels.mode") %>
       </p>
       <p class="govuk-body">
-        <%= address.mode %>
+        <%= t(".values.site_location_input_method.#{address.mode}") %>
       </p>
     <% end %>
 
@@ -49,7 +49,7 @@
       </p>
     <% end %>
 
-    <% if address.x.present? %>
+    <% if address.address_type == 'site' && address.x.present? %>
       <p class="govuk-body govuk-!-font-weight-bold">
         <%= t(".labels.x") %>
       </p>
@@ -58,7 +58,7 @@
       </p>
     <% end %>
 
-    <% if address.y.present? %>
+    <% if address.address_type == 'site' && address.y.present? %>
       <p class="govuk-body govuk-!-font-weight-bold">
         <%= t(".labels.y") %>
       </p>
@@ -128,6 +128,26 @@
       <p class="govuk-body">
         <%= address.area %>
       </p>
+    <% end %>
+
+    <% if address.address_type == 'site' %>
+      <% if defined?(on_a_farm) %>
+        <p class="govuk-body govuk-!-font-weight-bold">
+          <%= t(".labels.on_a_farm") %>
+        </p>
+        <p class="govuk-body">
+          <%= t(".values.on_a_farm.#{on_a_farm}") %>
+        </p>
+      <% end %>
+
+      <% if defined?(is_a_farmer) %>
+        <p class="govuk-body govuk-!-font-weight-bold">
+          <%= t(".labels.is_a_farmer") %>
+        </p>
+        <p class="govuk-body">
+          <%= t(".values.is_a_farmer.#{is_a_farmer}") %>
+        </p>
+      <% end %>
     <% end %>
   </dd>
 </div>

--- a/app/views/shared/_resource_address.html.erb
+++ b/app/views/shared/_resource_address.html.erb
@@ -7,7 +7,7 @@
     <% end %>
   </dt>
   <dd class="govuk-summary-list__value">
-  <% if address.address_type == 'site' %>
+  <% if address.site? %>
     <p class="govuk-body govuk-!-font-weight-bold">
       <%= t(".labels.grid_reference") %>
     </p>
@@ -49,7 +49,7 @@
       </p>
     <% end %>
 
-    <% if address.address_type == 'site' && address.x.present? %>
+    <% if address.site? && address.x.present? %>
       <p class="govuk-body govuk-!-font-weight-bold">
         <%= t(".labels.x") %>
       </p>
@@ -58,7 +58,7 @@
       </p>
     <% end %>
 
-    <% if address.address_type == 'site' && address.y.present? %>
+    <% if address.site? && address.y.present? %>
       <p class="govuk-body govuk-!-font-weight-bold">
         <%= t(".labels.y") %>
       </p>
@@ -130,7 +130,7 @@
       </p>
     <% end %>
 
-    <% if address.address_type == 'site' %>
+    <% if address.site? %>
       <% if defined?(on_a_farm) %>
         <p class="govuk-body govuk-!-font-weight-bold">
           <%= t(".labels.on_a_farm") %>

--- a/app/views/shared/_resource_details.html.erb
+++ b/app/views/shared/_resource_details.html.erb
@@ -116,127 +116,11 @@
   <% end %>
 
   </div>
+
   <div class="govuk-column-one-third">
-    <h2 class="govuk-heading-m">
-      <%= t(".subheadings.actions") %>
-      <% if resource.reference.present? %>
-        for <%= resource.reference %>
-      <% end %>
-    </h2>
-    <div class="action-panel govuk-body">
-      <% if display_edit_link_for?(resource) %>
-        <p class="govuk-body">
-          <%= link_to t(".actions.edit"), edit_link_for(resource) %>
-        </p>
-      <% end %>
-
-      <% if display_edit_expiry_date_link_for?(resource) %>
-        <p class="govuk-body">
-          <%= link_to t(".actions.edit_expiry_date"), edit_expiry_date_link_for(resource) %>
-        </p>
-      <% end %>
-
-      <% if display_reset_transient_registrations_link_for?(resource) %>
-        <p class="govuk-body">
-          <%= link_to t(".actions.reset_transient_registrations"), reset_transient_registrations_link_for(resource) %>
-        </p>
-      <% end %>
-
-      <% if display_resume_link_for?(resource) %>
-        <p class="govuk-body">
-          <%= link_to t(".actions.resume"), resume_link_for(resource) %>
-        </p>
-      <% end %>
-
-      <% if display_confirmation_letter_link_for?(resource) %>
-        <p class="govuk-body">
-          <%= link_to t(".actions.resend_confirmation_email"), resend_confirmation_email_path(resource.reference) %>
-        </p>
-        <p class="govuk-body">
-          <%= link_to t(".actions.resend_confirmation_letter"), resend_confirmation_letter_path(resource.reference) %>
-        </p>
-      <% end %>
-
-      <% if display_send_edit_invite_email_link_for?(resource) %>
-        <p class="govuk-body">
-          <%= link_to send_edit_invite_emails_path(resource), id: "send_edit_invite_email_#{resource.reference}" do %>
-            <%= t(".actions.send_edit_invite_email.link_text") %>
-            <span class="govuk-visually-hidden">
-            <%= t(".actions.send_edit_invite_email.visually_hidden_text",
-                  name: result_name_for_visually_hidden_text(resource)) %>
-          </span>
-          <% end %>
-        </p>
-      <% end %>
-
-      <% if display_certificate_link_for?(resource) %>
-        <p class="govuk-body">
-        <%= link_to registration_certificate_path(resource.reference) do %>
-          <%= t(".actions.view_certificate.link_text") %>
-          <span class="govuk-visually-hidden">
-            <%= t(".actions.view_certificate.visually_hidden_text",
-                  name: result_name_for_visually_hidden_text(resource)) %>
-          </span>
-        <% end %>
-        </p>
-      <% end %>
-
-
-      <% if display_already_renewed_text_for?(resource) %>
-        <p class="govuk-body"><%= t(".actions.renew.already_renewed") %></p>
-      <% elsif display_renew_links_for?(resource) %>
-        <p class="govuk-body">
-          <%= link_to ad_privacy_policy_path(renew_registration: resource.reference), id: "renew_#{resource.reference}" do %>
-            <%= t(".actions.renew.link_text") %>
-            <span class="govuk-visually-hidden">
-             <%= t(".actions.renew.visually_hidden_text",
-                   name: result_name_for_visually_hidden_text(resource)) %>
-            </span>
-          <% end %>
-        </p>
-        <p class="govuk-body">
-          <%= link_to resend_renewal_email_path(reference: resource.reference), id: "resend_renew_email_#{resource.reference}" do %>
-            <%= t(".actions.resend_renew_email.link_text") %>
-            <span class="govuk-visually-hidden">
-             <%= t(".actions.resend_renew_email.visually_hidden_text",
-                   name: result_name_for_visually_hidden_text(resource)) %>
-            </span>
-          <% end %>
-        </p>
-        <p class="govuk-body">
-          <%= link_to t(".actions.resend_renewal_letter"), resend_renewal_letter_path(resource.reference) %>
-        </p>
-      <% elsif display_renew_window_closed_text_for?(resource) %>
-        <p class="govuk-body"><%= t(".actions.renew.renew_window_closed") %></p>
-      <% end %>
-
-      <% if display_refresh_registered_company_name_link_for?(resource) %>
-          <%= link_to t(".actions.refresh_companies_house"),
-                        refresh_companies_house_name_path(resource.reference),
-                        method: :patch %>
-      <% end %>
-
-      <% if display_deregister_link_for?(resource) %>
-        <p class="govuk-!-margin-top-6">
-          <%= link_to t(".actions.deregister"), deregister_registrations_form_path(resource) %>
-        </p>
-      <% end %>
-
-      <% if display_communication_logs_link_for?(resource) %>
-        <p class="govuk-body">
-          <%= link_to t(".actions.show_communication_history"), registration_communication_logs_path(resource.reference) %>
-        </p>
-      <% end %>
-
-      <% if display_payment_details_link_for?(resource) %>
-        <p class="govuk-body">
-          <%= link_to t(".actions.payment_details"), registration_payment_details_path(resource.reference) %>
-        </p>
-      <% end %>
-    </div>
+    <%= render("shared/resource_details_actions", resource: @resource) %>
   </div>
 </div>
-
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -259,106 +143,65 @@
 
 <dl class="govuk-summary-list">
   <% if resource.contact_address.present? %>
-    <%= render("shared/resource_address",
-               address: resource.contact_address) %>
+    <%= render("shared/resource_address", address: resource.contact_address) %>
   <% end %>
 
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
-      <%= label_for_business(resource) %>
+      <%= t(".subheadings.business_or_organisation_details") %>
     </dt>
     <dd class="govuk-summary-list__value">
-      <%= resource.operator_name %>
+      <p class="govuk-body govuk-!-font-weight-bold">
+        <%= t(".labels.business_or_organisation_name") %>
+      </p>
+      <p class="govuk-body">
+        <%= resource.operator_name %>
+      </p>
+      <p class="govuk-body govuk-!-font-weight-bold">
+        <%= t(".labels.business_or_organisation_type") %>
+      </p>
+      <p class="govuk-body">
+        <%= t(".values.business_or_organisation_type.#{resource.business_type}") %>
+      </p>
+      <% if resource.company_no.present? %>
+        <p class="govuk-body govuk-!-font-weight-bold">
+          <%= t(".labels.company_no") %>
+        </p>
+        <p class="govuk-body">
+          <%= resource.company_no %>
+        </p>
+      <% end %>
     </dd>
   </div>
 
   <% if resource.operator_address.present? %>
-    <%= render("shared/resource_address",
-             address: resource.operator_address) %>
+    <%= render("shared/resource_address", address: resource.operator_address) %>
   <% end %>
 
   <% if resource.site_address.present? %>
-    <%= render("shared/resource_address",
-              address: resource.site_address) %>
+    <%= render("shared/resource_address", address: resource.site_address,
+                                          on_a_farm: resource.on_a_farm?,
+                                          is_a_farmer: resource.is_a_farmer?) %>
   <% end %>
 </dl>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <details class="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          <%= t(".labels.details") %>
-        </span>
-      </summary>
-
-      <div class="govuk-details__text">
-        <% unless resource.on_a_farm.nil? %>
-          <p class="govuk-body govuk-!-font-weight-bold">
-            <%= t(".labels.on_a_farm") %>
-          </p>
-          <p class="govuk-body">
-            <%= t(".values.on_a_farm.#{resource.on_a_farm}") %>
-          </p>
-        <% end %>
-
-        <% unless resource.is_a_farmer.nil? %>
-          <p class="govuk-body govuk-!-font-weight-bold">
-            <%= t(".labels.is_a_farmer") %>
-          </p>
-          <p class="govuk-body">
-            <%= t(".values.is_a_farmer.#{resource.is_a_farmer}") %>
-          </p>
-        <% end %>
-
-        <% if resource.business_type.present? %>
-          <p class="govuk-body govuk-!-font-weight-bold">
-            <%= t(".labels.business_type") %>
-          </p>
-          <p class="govuk-body">
-            <%= t(".values.business_type.#{resource.business_type}") %>
-          </p>
-        <% end %>
-
-        <% if resource.location.present? %>
-          <p class="govuk-body govuk-!-font-weight-bold">
-            <%= t(".labels.location") %>
-          </p>
-          <p class="govuk-body">
-            <%= t(".values.location.#{resource.location}") %>
-          </p>
-        <% end %>
-
-        <% if resource.company_no.present? %>
-          <p class="govuk-body govuk-!-font-weight-bold">
-            <%= t(".labels.company_no") %>
-          </p>
-          <p class="govuk-body">
-            <%= resource.company_no %>
-          </p>
-        <% end %>
-
-        <% if resource.respond_to?(:assistance_mode) %>
-          <p class="govuk-body govuk-!-font-weight-bold">
-            <%= t(".labels.assistance_mode") %>
-          </p>
-          <p class="govuk-body">
-            <%= t(".values.assistance_mode.#{resource.assistance_mode || "none"}") %>
-          </p>
-        <% end %>
-
-        <% if resource.renewal? %>
-          <p class="govuk-body govuk-!-font-weight-bold">
-            <%= t(".labels.renewed_from") %>
-          </p>
-          <p class="govuk-body">
-            <%= link_to resource.referring_registration.reference, view_link_for(resource.referring_registration), id: "view_#{resource.referring_registration.reference}" %>
-          </p>
-        <% end %>
-      </div>
-    </details>
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      <%= t(".subheadings.renewal_history") %>
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body">
+        <%= "#{resource.reference} #{registration_date_range(resource)} #{t(".this_registration")}" %>
+      </p>
+      <% renewal_history(resource).each do |registration| %>
+        <p>
+          <%= registration_details_link_with_dates(registration) %>
+        <p>
+      <% end %>
+    </div>
   </div>
-</div>
+</dl>
 
 <% if resource.people.present? %>
   <div class="govuk-grid-row">

--- a/app/views/shared/_resource_details_actions.html.erb
+++ b/app/views/shared/_resource_details_actions.html.erb
@@ -1,0 +1,117 @@
+<h2 class="govuk-heading-m">
+  <%= t(".subheadings.actions") %>
+  <% if resource.reference.present? %>
+    for <%= resource.reference %>
+  <% end %>
+</h2>
+
+<div class="action-panel govuk-body">
+  <% if display_edit_link_for?(resource) %>
+    <p class="govuk-body">
+      <%= link_to t(".actions.edit"), edit_link_for(resource) %>
+    </p>
+  <% end %>
+
+  <% if display_edit_expiry_date_link_for?(resource) %>
+    <p class="govuk-body">
+      <%= link_to t(".actions.edit_expiry_date"), edit_expiry_date_link_for(resource) %>
+    </p>
+  <% end %>
+
+  <% if display_reset_transient_registrations_link_for?(resource) %>
+    <p class="govuk-body">
+      <%= link_to t(".actions.reset_transient_registrations"), reset_transient_registrations_link_for(resource) %>
+    </p>
+  <% end %>
+
+  <% if display_resume_link_for?(resource) %>
+    <p class="govuk-body">
+      <%= link_to t(".actions.resume"), resume_link_for(resource) %>
+    </p>
+  <% end %>
+
+  <% if display_confirmation_letter_link_for?(resource) %>
+    <p class="govuk-body">
+      <%= link_to t(".actions.resend_confirmation_email"), resend_confirmation_email_path(resource.reference) %>
+    </p>
+    <p class="govuk-body">
+      <%= link_to t(".actions.resend_confirmation_letter"), resend_confirmation_letter_path(resource.reference) %>
+    </p>
+  <% end %>
+
+  <% if display_send_edit_invite_email_link_for?(resource) %>
+    <p class="govuk-body">
+      <%= link_to send_edit_invite_emails_path(resource), id: "send_edit_invite_email_#{resource.reference}" do %>
+        <%= t(".actions.send_edit_invite_email.link_text") %>
+        <span class="govuk-visually-hidden">
+          <%= t(".actions.send_edit_invite_email.visually_hidden_text",
+                name: result_name_for_visually_hidden_text(resource)) %>
+        </span>
+      <% end %>
+    </p>
+  <% end %>
+
+  <% if display_certificate_link_for?(resource) %>
+    <p class="govuk-body">
+      <%= link_to registration_certificate_path(resource.reference) do %>
+        <%= t(".actions.view_certificate.link_text") %>
+        <span class="govuk-visually-hidden">
+          <%= t(".actions.view_certificate.visually_hidden_text",
+                name: result_name_for_visually_hidden_text(resource)) %>
+        </span>
+      <% end %>
+    </p>
+  <% end %>
+
+  <% if display_already_renewed_text_for?(resource) %>
+    <p class="govuk-body"><%= t(".actions.renew.already_renewed") %></p>
+  <% elsif display_renew_links_for?(resource) %>
+    <p class="govuk-body">
+      <%= link_to ad_privacy_policy_path(renew_registration: resource.reference), id: "renew_#{resource.reference}" do %>
+        <%= t(".actions.renew.link_text") %>
+        <span class="govuk-visually-hidden">
+          <%= t(".actions.renew.visually_hidden_text",
+                name: result_name_for_visually_hidden_text(resource)) %>
+        </span>
+      <% end %>
+    </p>
+    <p class="govuk-body">
+      <%= link_to resend_renewal_email_path(reference: resource.reference), id: "resend_renew_email_#{resource.reference}" do %>
+        <%= t(".actions.resend_renew_email.link_text") %>
+        <span class="govuk-visually-hidden">
+          <%= t(".actions.resend_renew_email.visually_hidden_text",
+                name: result_name_for_visually_hidden_text(resource)) %>
+        </span>
+      <% end %>
+    </p>
+    <p class="govuk-body">
+      <%= link_to t(".actions.resend_renewal_letter"), resend_renewal_letter_path(resource.reference) %>
+    </p>
+  <% elsif display_renew_window_closed_text_for?(resource) %>
+    <p class="govuk-body"><%= t(".actions.renew.renew_window_closed") %></p>
+  <% end %>
+
+  <% if display_refresh_registered_company_name_link_for?(resource) %>
+    <%= link_to t(".actions.refresh_companies_house"),
+                  refresh_companies_house_name_path(resource.reference),
+                  method: :patch %>
+  <% end %>
+
+  <% if display_deregister_link_for?(resource) %>
+    <p class="govuk-!-margin-top-6">
+      <%= link_to t(".actions.deregister"), deregister_registrations_form_path(resource) %>
+    </p>
+  <% end %>
+
+  <% if display_communication_logs_link_for?(resource) %>
+    <p class="govuk-body">
+      <%= link_to t(".actions.show_communication_history"), registration_communication_logs_path(resource.reference) %>
+    </p>
+  <% end %>
+
+  <% if display_payment_details_link_for?(resource) %>
+    <p class="govuk-body">
+      <%= link_to t(".actions.payment_details"), registration_payment_details_path(resource.reference) %>
+    </p>
+  <% end %>
+</div>

--- a/config/locales/partials/resource_address.en.yml
+++ b/config/locales/partials/resource_address.en.yml
@@ -4,10 +4,10 @@ en:
       heading:
         unknown: Unknown address
         contact: Contact address
-        operator: Address
+        operator: Business or organisation address
         site: Site location
       labels:
-        mode: Mode
+        mode: Site location input method
         grid_reference: Site grid reference
         address:
           contact: Address
@@ -23,3 +23,16 @@ en:
         source_data_type: Source data type
         country_iso: Country ISO
         area: Area
+        on_a_farm: On a farm?
+        is_a_farmer: Is a farmer?
+      values:
+        site_location_input_method:
+          auto: Grid reference
+          manual: Manual
+          lookup: Lookup
+        on_a_farm:
+          "true": "Yes"
+          "false": "No"
+        is_a_farmer:
+          "true": "Yes"
+          "false": "No"

--- a/config/locales/partials/resource_address.en.yml
+++ b/config/locales/partials/resource_address.en.yml
@@ -27,6 +27,7 @@ en:
         is_a_farmer: Is a farmer?
       values:
         site_location_input_method:
+          unknown_mode: Unknown
           auto: Grid reference
           manual: Manual
           lookup: Lookup

--- a/config/locales/partials/resource_details.en.yml
+++ b/config/locales/partials/resource_details.en.yml
@@ -4,22 +4,21 @@ en:
       subheadings:
         applicant: Applicant details
         contact: Contact details
-        farm: Farm details
+        business_or_organisation_details: Business or organisation
         exemptions: Exemptions
+        renewal_history: Renewal history
         actions: Actions
         current_balance: Current balance
       labels:
         workflow_state: Workflow state
         reference: Reference
-        location: Location
         applicant_first_name: Applicant first name
         applicant_last_name: Applicant last name
         applicant_phone: Applicant phone
         applicant_email: Applicant email
-        business_type: Business type
-        details: Reporting information
+        business_or_organisation_name: Name
+        business_or_organisation_type: Business type
         renewed_from: Renewed from
-        operator_name: Operator name
         people: Partners
         company_no: Company number
         contact_first_name: Contact first name
@@ -27,62 +26,23 @@ en:
         contact_position: Contact position
         contact_phone: Contact phone
         contact_email: Contact email
-        on_a_farm: On a farm?
-        is_a_farmer: Is a farmer?
-        assistance_mode: Assistance mode
+        assistance_mode: Registration method
         submitted_at: Submitted at
         amount: Amount
       values:
-        business_type:
+        business_or_organisation_type:
           charity: Charity or trust
           limitedCompany: Limited company
           limitedLiabilityPartnership: Limited liability partnership
           localAuthority: Local authority or public body
           partnership: Partnership
           soleTrader: Individual or sole trader
-        is_a_farmer:
-          "true": "Yes"
-          "false": "No"
-        location:
-          england: England
-          northern_ireland: Northern Ireland
-          scotland: Scotland
-          wales: Wales
-        on_a_farm:
-          "true": "Yes"
-          "false": "No"
         assistance_mode:
-          admin_intervention: Admin intervention
           full: Fully assisted
           partial: Partially assisted
-          none: Unassisted
-      actions:
-        edit: Edit
-        edit_expiry_date: Set a new expiry date
-        deregister: Deregister
-        show_communication_history: Show communication history
-        resume: Resume
-        resend_confirmation_email: Resend confirmation email
-        resend_confirmation_letter: Resend confirmation letter
-        refresh_companies_house: Refresh Companies House information
-        reset_transient_registrations: Reset transient registrations
-        renew:
-          link_text: Start renewal
-          visually_hidden_text: "of %{name}"
-          renew_window_closed: Renewal period closed
-          already_renewed: Already renewed
-        resend_renew_email:
-          link_text: Resend renewal email
-          visually_hidden_text: "of %{name}"
-        resend_renewal_letter: Resend renewal letter
-        send_edit_invite_email:
-          link_text: Send edit invite email
-          visually_hidden_text: "send edit invite email for %{name}"
-        view_certificate:
-          link_text: View certificate
-          visually_hidden_text: "of %{name}"
-        payment_details: Payment details
+          none: Self-Serve
       no_applicant_data: No applicant details
       no_contact_data: No contact details
       no_exemptions: No exemptions
       no_people: No people
+      this_registration: (this registration)

--- a/config/locales/partials/resource_details_actions.en.yml
+++ b/config/locales/partials/resource_details_actions.en.yml
@@ -1,0 +1,31 @@
+en:
+  shared:
+    resource_details_actions:
+      subheadings:
+        actions: Actions
+      actions:
+        edit: Edit
+        edit_expiry_date: Set a new expiry date
+        deregister: Deregister
+        show_communication_history: Show communication history
+        resume: Resume
+        resend_confirmation_email: Resend confirmation email
+        resend_confirmation_letter: Resend confirmation letter
+        refresh_companies_house: Refresh Companies House information
+        reset_transient_registrations: Reset transient registrations
+        renew:
+          link_text: Start renewal
+          visually_hidden_text: "of %{name}"
+          renew_window_closed: Renewal period closed
+          already_renewed: Already renewed
+        resend_renew_email:
+          link_text: Resend renewal email
+          visually_hidden_text: "of %{name}"
+        resend_renewal_letter: Resend renewal letter
+        send_edit_invite_email:
+          link_text: Send edit invite email
+          visually_hidden_text: "send edit invite email for %{name}"
+        view_certificate:
+          link_text: View certificate
+          visually_hidden_text: "of %{name}"
+        payment_details: Payment details

--- a/spec/helpers/registrations_helper_spec.rb
+++ b/spec/helpers/registrations_helper_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe RegistrationsHelper do
   let(:resource) { build(:new_registration) }
 
-  describe "applicant_data_present?" do
+  describe "#applicant_data_present?" do
     context "when the resource has data in at least one relevant field" do
       before { resource.applicant_first_name = "Foo" }
 
@@ -28,7 +28,7 @@ RSpec.describe RegistrationsHelper do
     end
   end
 
-  describe "contact_data_present?" do
+  describe "#contact_data_present?" do
     context "when the resource has data in at least one relevant field" do
       before { resource.contact_first_name = "Foo" }
 
@@ -49,6 +49,43 @@ RSpec.describe RegistrationsHelper do
       it "returns true" do
         expect(helper.contact_data_present?(resource)).to be(false)
       end
+    end
+  end
+
+  describe "#renewal_history" do
+    let(:original_registration) { create(:registration) }
+    let(:previous_registration) { create(:registration, referring_registration: original_registration) }
+    let(:current_registration) { create(:registration, referring_registration: previous_registration) }
+
+    it "returns an array of registrations in reverse chronological order" do
+      expect(helper.renewal_history(current_registration)).to eq [
+        current_registration,
+        previous_registration,
+        original_registration
+      ]
+    end
+  end
+
+  describe "#registration_date_range" do
+    let(:registration) { create(:registration) }
+
+    it do
+      expect(helper.registration_date_range(registration))
+        .to eq "(#{registration.created_at.strftime('%-d %B %Y')} to #{registration.expires_on.strftime('%-d %B %Y')})"
+    end
+  end
+
+  describe "#registration_details_link_with_dates" do
+    subject(:link_response) { helper.registration_details_link_with_dates(registration) }
+
+    let(:registration) { create(:registration) }
+
+    it "returns a link to the details page for the registration" do
+      expect(link_response).to match(%r{href="/registrations/#{registration.reference}"})
+    end
+
+    it "includes the date range for the registration" do
+      expect(link_response).to include(helper.registration_date_range(registration))
     end
   end
 end

--- a/spec/helpers/registrations_helper_spec.rb
+++ b/spec/helpers/registrations_helper_spec.rb
@@ -67,11 +67,22 @@ RSpec.describe RegistrationsHelper do
   end
 
   describe "#registration_date_range" do
-    let(:registration) { create(:registration) }
+    context "with a registration" do
+      let(:registration) { create(:registration) }
 
-    it do
-      expect(helper.registration_date_range(registration))
-        .to eq "(#{registration.created_at.strftime('%-d %B %Y')} to #{registration.expires_on.strftime('%-d %B %Y')})"
+      it do
+        expect(helper.registration_date_range(registration))
+          .to eq "(#{registration.created_at.strftime('%-d %B %Y')} to #{registration.expires_on.strftime('%-d %B %Y')})"
+      end
+    end
+
+    context "with a new_registration" do
+      let(:registration) { create(:new_registration) }
+
+      it do
+        expect(helper.registration_date_range(registration))
+          .to eq "(created on #{registration.created_at.strftime('%-d %B %Y')})"
+      end
     end
   end
 


### PR DESCRIPTION
This change reorganises content on the registration details page and adds a renewal history section.
https://eaflood.atlassian.net/browse/RUBY-3296