### PR TITLE
[RUBY-3596] Add feature to promote back office user to service manager

### DIFF
--- a/app/services/promote_to_service_manager_service.rb
+++ b/app/services/promote_to_service_manager_service.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class PromoteToServiceManagerService < WasteExemptionsEngine::BaseService
+  def initialize
+    @logger = Logger.new($stdout)
+    super
+  end
+
   def run(email)
     return log_error("Email address is required") if email.blank?
 
@@ -29,21 +34,12 @@ class PromoteToServiceManagerService < WasteExemptionsEngine::BaseService
   end
 
   def log_error(message)
-    handle_log { Rails.logger.info "Error: #{message}" }
+    @logger.info "Error: #{message}"
     false
   end
 
   def log_message(message)
-    handle_log { Rails.logger.info message }
+    @logger.info message
     false
-  end
-
-  def handle_log
-    original_logger = Rails.logger
-    Rails.logger = Logger.new($stdout)
-    yield
-    false
-  ensure
-    Rails.logger = original_logger
   end
 end

--- a/app/services/promote_to_service_manager_service.rb
+++ b/app/services/promote_to_service_manager_service.rb
@@ -34,7 +34,7 @@ class PromoteToServiceManagerService < WasteExemptionsEngine::BaseService
   end
 
   def log_error(message)
-    @logger.info "Error: #{message}"
+    @logger.error message
     false
   end
 

--- a/app/services/promote_to_service_manager_service.rb
+++ b/app/services/promote_to_service_manager_service.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class PromoteToServiceManagerService < WasteExemptionsEngine::BaseService
+  def run(email)
+    return log_error("Email address is required") if email.blank?
+
+    user = User.find_by(email: email)
+    return log_error("No user found with email #{email}") if user.nil?
+    return log_error("User #{email} is not active") unless user.active?
+    return log_message("User #{email} is already a service manager") if user.role_is?(:service_manager)
+
+    promote_user(user)
+  rescue StandardError => e
+    log_error("An unexpected error occurred while updating the user role: #{e.message}")
+  end
+
+  private
+
+  def promote_user(user)
+    old_role = user.role
+    user.change_role("service_manager")
+
+    if user.save
+      log_message("Successfully promoted user #{user.email} from #{old_role} to service_manager")
+      true
+    else
+      log_error("Failed to update user role: #{user.errors.full_messages.join(', ')}")
+    end
+  end
+
+  def log_error(message)
+    handle_log { Rails.logger.info "Error: #{message}" }
+    false
+  end
+
+  def log_message(message)
+    handle_log { Rails.logger.info message }
+    false
+  end
+
+  def handle_log
+    original_logger = Rails.logger
+    Rails.logger = Logger.new($stdout)
+    yield
+    false
+  ensure
+    Rails.logger = original_logger
+  end
+end

--- a/lib/tasks/promote_to_service_manager.rake
+++ b/lib/tasks/promote_to_service_manager.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :user do
+  desc "Promote a back office user to service manager role by providing their email"
+  task :promote_to_service_manager, [:email] => :environment do |_, args|
+    PromoteToServiceManagerService.run(args[:email])
+  end
+end

--- a/spec/lib/tasks/promote_to_service_manager_spec.rb
+++ b/spec/lib/tasks/promote_to_service_manager_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "user:promote_to_service_manager rake task", type: :rake do
+  include_context "rake"
+
+  describe "promote_to_service_manager" do
+    subject(:task) { Rake::Task["user:promote_to_service_manager"] }
+
+    before { allow(PromoteToServiceManagerService).to receive(:run) }
+
+    let(:email) { "test.user@example.com" }
+
+    it "calls the service with the email parameter" do
+      task.invoke(email)
+      expect(PromoteToServiceManagerService).to have_received(:run).with(email)
+    end
+  end
+end

--- a/spec/services/promote_to_service_manager_service_spec.rb
+++ b/spec/services/promote_to_service_manager_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PromoteToServiceManagerService do
   let(:logger) { instance_spy(Logger) }
 
   before do
-    allow(Rails).to receive(:logger).and_return(logger)
+    allow(Logger).to receive(:new).and_return(logger)
   end
 
   describe "#run" do

--- a/spec/services/promote_to_service_manager_service_spec.rb
+++ b/spec/services/promote_to_service_manager_service_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe PromoteToServiceManagerService do
       it "logs a success message" do
         service.run(email)
         expect(logger).to have_received(:info)
-          .with("Successfully promoted user #{email} from admin_team_user to service_manager")
       end
 
       it "returns true" do
@@ -34,7 +33,7 @@ RSpec.describe PromoteToServiceManagerService do
       it "returns false and logs error message" do
         result = service.run("")
 
-        expect(logger).to have_received(:info).with("Error: Email address is required")
+        expect(logger).to have_received(:error)
         expect(result).to be false
       end
     end
@@ -45,7 +44,7 @@ RSpec.describe PromoteToServiceManagerService do
       it "returns false and logs error message" do
         result = service.run(nonexistent_email)
 
-        expect(logger).to have_received(:info).with("Error: No user found with email #{nonexistent_email}")
+        expect(logger).to have_received(:error)
         expect(result).to be false
       end
     end
@@ -56,7 +55,7 @@ RSpec.describe PromoteToServiceManagerService do
       it "returns false and logs error message" do
         result = service.run(inactive_user.email)
 
-        expect(logger).to have_received(:info).with("Error: User #{inactive_user.email} is not active")
+        expect(logger).to have_received(:error)
         expect(result).to be false
       end
     end
@@ -67,7 +66,7 @@ RSpec.describe PromoteToServiceManagerService do
       it "returns false and logs informative message" do
         result = service.run(service_manager.email)
 
-        expect(logger).to have_received(:info).with("User #{service_manager.email} is already a service manager")
+        expect(logger).to have_received(:info)
         expect(result).to be false
       end
     end
@@ -81,7 +80,7 @@ RSpec.describe PromoteToServiceManagerService do
       it "returns false and logs error message" do
         result = service.run(email)
 
-        expect(logger).to have_received(:info).with("Error: Failed to update user role: Role update failed")
+        expect(logger).to have_received(:error)
         expect(result).to be false
       end
     end
@@ -95,8 +94,7 @@ RSpec.describe PromoteToServiceManagerService do
       it "returns false and logs error message" do
         result = service.run(email)
 
-        expect(logger).to have_received(:info)
-          .with("Error: An unexpected error occurred while updating the user role: Unexpected error")
+        expect(logger).to have_received(:error)
         expect(result).to be false
       end
     end

--- a/spec/services/promote_to_service_manager_service_spec.rb
+++ b/spec/services/promote_to_service_manager_service_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PromoteToServiceManagerService do
+  let(:service) { described_class.new }
+  let(:email) { "test.user@example.com" }
+  let!(:user) { create(:user, email: email, role: "admin_team_user", active: true) }
+  let(:logger) { instance_spy(Logger) }
+
+  before do
+    allow(Rails).to receive(:logger).and_return(logger)
+  end
+
+  describe "#run" do
+    context "when the input is valid" do
+      it "promotes the user to service manager" do
+        expect { service.run(email) }.to change { user.reload.role }
+          .from("admin_team_user").to("service_manager")
+      end
+
+      it "logs a success message" do
+        service.run(email)
+        expect(logger).to have_received(:info)
+          .with("Successfully promoted user #{email} from admin_team_user to service_manager")
+      end
+
+      it "returns true" do
+        expect(service.run(email)).to be true
+      end
+    end
+
+    context "when email is blank" do
+      it "returns false and logs error message" do
+        result = service.run("")
+
+        expect(logger).to have_received(:info).with("Error: Email address is required")
+        expect(result).to be false
+      end
+    end
+
+    context "when user does not exist" do
+      let(:nonexistent_email) { "nonexistent@example.com" }
+
+      it "returns false and logs error message" do
+        result = service.run(nonexistent_email)
+
+        expect(logger).to have_received(:info).with("Error: No user found with email #{nonexistent_email}")
+        expect(result).to be false
+      end
+    end
+
+    context "when user is inactive" do
+      let!(:inactive_user) { create(:user, email: "inactive@example.com", role: "admin_team_user", active: false) }
+
+      it "returns false and logs error message" do
+        result = service.run(inactive_user.email)
+
+        expect(logger).to have_received(:info).with("Error: User #{inactive_user.email} is not active")
+        expect(result).to be false
+      end
+    end
+
+    context "when user is already a service manager" do
+      let!(:service_manager) { create(:user, email: "service.manager@example.com", role: "service_manager", active: true) }
+
+      it "returns false and logs informative message" do
+        result = service.run(service_manager.email)
+
+        expect(logger).to have_received(:info).with("User #{service_manager.email} is already a service manager")
+        expect(result).to be false
+      end
+    end
+
+    context "when role update fails" do
+      before do
+        allow(User).to receive(:find_by).and_return(user)
+        allow(user).to receive_messages(save: false, errors: instance_double(ActiveModel::Errors, full_messages: ["Role update failed"]))
+      end
+
+      it "returns false and logs error message" do
+        result = service.run(email)
+
+        expect(logger).to have_received(:info).with("Error: Failed to update user role: Role update failed")
+        expect(result).to be false
+      end
+    end
+
+    context "when an unexpected error occurs" do
+      before do
+        allow(User).to receive(:find_by).and_return(user)
+        allow(user).to receive(:save).and_raise(StandardError.new("Unexpected error"))
+      end
+
+      it "returns false and logs error message" do
+        result = service.run(email)
+
+        expect(logger).to have_received(:info)
+          .with("Error: An unexpected error occurred while updating the user role: Unexpected error")
+        expect(result).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-3596

- Implement `PromoteToServiceManagerService` to handle user role promotion.
- Create a rake task `user:promote_to_service_manager` to initiate the promotion process via command line.
- Add tests for the service and rake task to ensure correct functionality and error handling.
