### PR TITLE
RUBY-3589: post qa additions

### DIFF
--- a/app/controllers/send_private_beta_invite_email_controller.rb
+++ b/app/controllers/send_private_beta_invite_email_controller.rb
@@ -31,7 +31,7 @@ class SendPrivateBetaInviteEmailController < ApplicationController
   end
 
   def send_emails
-    beta_participant = WasteExemptionsEngine::BetaParticipant.find_by(email: recipient_email)
+    beta_participant = WasteExemptionsEngine::BetaParticipant.find_by(reg_number: registration.reference)
     if beta_participant.nil?
       beta_participant = WasteExemptionsEngine::BetaParticipant.create(reg_number: registration.reference,
                                                                        email: recipient_email)

--- a/app/services/private_beta_invite_email_service.rb
+++ b/app/services/private_beta_invite_email_service.rb
@@ -29,7 +29,7 @@ class PrivateBetaInviteEmailService < WasteExemptionsEngine::BaseService
     {
       message_type: "email",
       template_id: template,
-      template_label: "Private Beta Invite Email",
+      template_label: "Private beta invite email",
       sent_to: recipient_email
     }
   end
@@ -44,8 +44,21 @@ class PrivateBetaInviteEmailService < WasteExemptionsEngine::BaseService
     @registration.contact_email
   end
 
+  def contact_name
+    "#{@registration.contact_first_name} #{@registration.contact_last_name}"
+  end
+
+  def exemptions
+    relevant_exemptions = @registration.registration_exemptions.order(:exemption_id).select do |re|
+      re.may_expire? || re.expired?
+    end
+    relevant_exemptions.map { |ex| "#{ex.exemption.code} #{ex.exemption.summary}" }
+  end
+
   def personalisation
     {
+      contact_name: contact_name,
+      exemptions: exemptions,
       private_beta_start_url: @beta_participant.private_beta_start_url
     }
   end


### PR DESCRIPTION
Few minor improvements for
https://eaflood.atlassian.net/browse/RUBY-3589
1. invite link is made unique per registration
2. Template name in comms history changed to “Private beta invite email”
3. Added support for contact_name and exemptions fields in PB invite email