### PR TITLE
Fix/ruby 3559 3607 private beta resource flash

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -4,13 +4,7 @@ class RegistrationsController < ApplicationController
   helper ActionLinksHelper
 
   def show
-    resource = find_resource(params[:reference])
-
-    if view_context.private_beta_participant?(resource)
-      flash[:message] = I18n.t("registrations.show.private_beta_banner")
-    end
-
-    resource
+    find_resource(params[:reference])
   end
 
   private

--- a/app/views/new_registrations/show.html.erb
+++ b/app/views/new_registrations/show.html.erb
@@ -1,6 +1,19 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render("waste_exemptions_engine/shared/back", back_path: root_path, back_link_label: t(".back_link_label")) %>
+    <%= render("shared/message", message: flash[:message]) if flash[:message].present? %>
+    <%= render("shared/error", error: flash[:error], details: flash[:error_details]) if flash[:error].present? %>
+
+    <% if private_beta_participant?(@resource) %>
+      <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header"></div>
+        <div class="govuk-notification-banner__content">
+          <h3 class="govuk-notification-banner__heading">
+            <%= I18n.t("registrations.show.private_beta_banner") %>
+          </h3>
+        </div>
+      </div>
+    <% end %>
 
     <h1 class="govuk-heading-l">
       <%= t(".heading") %>

--- a/app/views/new_registrations/show.html.erb
+++ b/app/views/new_registrations/show.html.erb
@@ -8,7 +8,7 @@
       <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
         <div class="govuk-notification-banner__header"></div>
         <div class="govuk-notification-banner__content">
-          <h3 class="govuk-notification-banner__heading">
+          <h3 class="govuk-notification-banner__heading" id="private_beta_banner_text">
             <%= I18n.t("registrations.show.private_beta_banner") %>
           </h3>
         </div>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -4,6 +4,17 @@
     <%= render("shared/message", message: flash[:message]) if flash[:message].present? %>
     <%= render("shared/error", error: flash[:error], details: flash[:error_details]) if flash[:error].present? %>
 
+    <% if private_beta_participant?(@resource) %>
+      <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header"></div>
+        <div class="govuk-notification-banner__content">
+          <h3 class="govuk-notification-banner__heading">
+            <%= I18n.t("registrations.show.private_beta_banner") %>
+          </h3>
+        </div>
+      </div>
+    <% end %>%
+
     <h1 class="govuk-heading-l">
       <%= t(".heading", reference: @resource.reference) %>
     </h1>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -13,7 +13,7 @@
           </h3>
         </div>
       </div>
-    <% end %>%
+    <% end %>
 
     <h1 class="govuk-heading-l">
       <%= t(".heading", reference: @resource.reference) %>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -8,7 +8,7 @@
       <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
         <div class="govuk-notification-banner__header"></div>
         <div class="govuk-notification-banner__content">
-          <h3 class="govuk-notification-banner__heading">
+          <h3 class="govuk-notification-banner__heading" id="private_beta_banner_text">
             <%= I18n.t("registrations.show.private_beta_banner") %>
           </h3>
         </div>


### PR DESCRIPTION
This change adds the private beta banner to the new_registrations view and adds an id to the banner text to support automated testing.
https://eaflood.atlassian.net/browse/RUBY-3559
https://eaflood.atlassian.net/browse/RUBY-3607