### PR TITLE
[RUBY-3571] Add `invited_at` timestamp to `BetaParticipant` creation

### DIFF
--- a/app/controllers/beta_start_controller.rb
+++ b/app/controllers/beta_start_controller.rb
@@ -10,6 +10,7 @@ class BetaStartController < ApplicationController
     @registration = WasteExemptionsEngine::Registration.find_by(reference: params[:registration_reference])
     @participant = WasteExemptionsEngine::BetaParticipant.find_or_create_by(
       email: @registration.contact_email,
+      invited_at: Time.current,
       reg_number: @registration.reference
     )
     redirect_to WasteExemptionsEngine::Engine.routes.url_helpers.new_beta_start_form_path(@participant.token)

--- a/spec/requests/beta_start_spec.rb
+++ b/spec/requests/beta_start_spec.rb
@@ -18,12 +18,15 @@ RSpec.describe "Beta Start" do
 
       shared_examples "allows access to beta start" do
         it "creates a new beta participant and redirects to the beta start form" do
-          get request_path
-          expect(WasteExemptionsEngine::BetaParticipant.count).to eq(1)
-          participant = WasteExemptionsEngine::BetaParticipant.last
-          expect(participant.email).to eq(registration.contact_email)
-          path = WasteExemptionsEngine::Engine.routes.url_helpers.new_beta_start_form_path(participant.token)
-          expect(response).to redirect_to(path)
+          Timecop.freeze(Time.current) do
+            get request_path
+            expect(WasteExemptionsEngine::BetaParticipant.count).to eq(1)
+            participant = WasteExemptionsEngine::BetaParticipant.last
+            expect(participant.email).to eq(registration.contact_email)
+            expect(participant.invited_at).to be_within(1.second).of(Time.current)
+            path = WasteExemptionsEngine::Engine.routes.url_helpers.new_beta_start_form_path(participant.token)
+            expect(response).to redirect_to(path)
+          end
         end
       end
 


### PR DESCRIPTION
Updated the `BetaStartController` to include the current time as `invited_at` when creating or finding a `BetaParticipant`. Adjusted the corresponding test in `beta_start_spec.rb` to verify the `invited_at` timestamp is set correctly.
