### PR TITLE
[RUBY-3571] Add `invited_at` timestamp to BetaParticipant creation

### DIFF
--- a/app/controllers/beta_start_controller.rb
+++ b/app/controllers/beta_start_controller.rb
@@ -8,10 +8,15 @@ class BetaStartController < ApplicationController
     return unless ensure_private_beta_active
 
     @registration = WasteExemptionsEngine::Registration.find_by(reference: params[:registration_reference])
-    @participant = WasteExemptionsEngine::BetaParticipant.find_or_create_by!(
-      email: @registration.contact_email,
+    @participant = WasteExemptionsEngine::BetaParticipant.find_or_initialize_by(
       reg_number: @registration.reference
-    ) { |participant| participant.invited_at = Time.current } # executed if creation is needed
+    )
+
+    if @participant.new_record?
+      @participant.email = @registration.contact_email
+      @participant.invited_at = Time.current
+      @participant.save!
+    end
 
     redirect_to WasteExemptionsEngine::Engine.routes.url_helpers.new_beta_start_form_path(@participant.token)
   end

--- a/app/controllers/beta_start_controller.rb
+++ b/app/controllers/beta_start_controller.rb
@@ -8,7 +8,7 @@ class BetaStartController < ApplicationController
     return unless ensure_private_beta_active
 
     @registration = WasteExemptionsEngine::Registration.find_by(reference: params[:registration_reference])
-    @participant = WasteExemptionsEngine::BetaParticipant.find_or_create_by(
+    @participant = WasteExemptionsEngine::BetaParticipant.find_or_create_by!(
       email: @registration.contact_email,
       reg_number: @registration.reference
     ) { |participant| participant.invited_at = Time.current } # executed if creation is needed

--- a/app/controllers/beta_start_controller.rb
+++ b/app/controllers/beta_start_controller.rb
@@ -11,7 +11,8 @@ class BetaStartController < ApplicationController
     @participant = WasteExemptionsEngine::BetaParticipant.find_or_create_by(
       email: @registration.contact_email,
       reg_number: @registration.reference
-    )
+    ) { |participant| participant.invited_at = Time.current } # executed if creation is needed
+
     redirect_to WasteExemptionsEngine::Engine.routes.url_helpers.new_beta_start_form_path(@participant.token)
   end
 

--- a/spec/requests/beta_start_spec.rb
+++ b/spec/requests/beta_start_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe "Beta Start" do
       let(:feature_active) { true }
 
       shared_examples "allows access to beta start" do
+        context "when the beta participant already exists" do
+          let!(:participant) { create(:beta_participant, email: registration.contact_email, reg_number: registration.reference) }
+
+          it "redirects to the beta start form" do
+            get request_path
+            path = WasteExemptionsEngine::Engine.routes.url_helpers.new_beta_start_form_path(participant.token)
+            expect(response).to redirect_to(path)
+          end
+        end
+
         it "creates a new beta participant and redirects to the beta start form" do
           get request_path
           expect(WasteExemptionsEngine::BetaParticipant.count).to eq(1)


### PR DESCRIPTION
- Updated `BetaStartController` to set `invited_at` to the current time when a new `BetaParticipant` is created.
- Enhanced tests in `beta_start_spec.rb` to cover scenarios where a beta participant already exists and ensure proper redirection.
