### PR TITLE
Fix/ruby 3558 nil orders error

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -121,7 +121,7 @@ module ActionLinksHelper
   end
 
   def display_payment_details_link_for?(resource)
-    resource.is_a?(WasteExemptionsEngine::Registration) && can?(:read, resource)
+    resource.is_a?(WasteExemptionsEngine::Registration) && can?(:read, resource) && resource.account.present?
   end
 
   def can_display_refund_link?(resource)

--- a/app/presenters/account_presenter.rb
+++ b/app/presenters/account_presenter.rb
@@ -16,6 +16,8 @@ class AccountPresenter < BasePresenter
   end
 
   def refunds_and_reversals
+    # SonarCloud doesn't recognise that "super" in this method and in successful_payments
+    # are different so it complains about identical method bodies. Hence this comment.
     return [] if __getobj__.blank?
 
     super.map { |payment| PaymentPresenter.new(payment) }

--- a/app/presenters/account_presenter.rb
+++ b/app/presenters/account_presenter.rb
@@ -4,24 +4,32 @@ class AccountPresenter < BasePresenter
   include FinanceDetailsHelper
 
   def balance
-    return nil unless super
+    return nil if __getobj__.blank?
 
     display_pence_as_pounds_sterling_and_pence(pence: super)
   end
 
   def successful_payments
+    return [] if __getobj__.blank?
+
     super.map { |payment| PaymentPresenter.new(payment) }
   end
 
   def refunds_and_reversals
+    return [] if __getobj__.blank?
+
     super.map { |payment| PaymentPresenter.new(payment) }
   end
 
   def sorted_orders
+    return [] if __getobj__.blank?
+
     orders.order(created_at: :desc).map { |order| OrderPresenter.new(order) }
   end
 
   def charge_adjustments
+    return [] if __getobj__.blank?
+
     super.order(created_at: :desc).map { |charge_adjustment| ChargeAdjustmentPresenter.new(charge_adjustment) }
   end
 end

--- a/app/presenters/account_presenter.rb
+++ b/app/presenters/account_presenter.rb
@@ -16,11 +16,13 @@ class AccountPresenter < BasePresenter
   end
 
   def refunds_and_reversals
-    # SonarCloud doesn't recognise that "super" in this method and in successful_payments
-    # are different so it complains about identical method bodies. Hence this comment.
     return [] if __getobj__.blank?
 
-    super.map { |payment| PaymentPresenter.new(payment) }
+    # SonarCloud doesn't recognise that "super" in this method and in successful_payments are
+    # different so it complains about identical method bodies. Hence this additional statement.
+    payments = super
+
+    payments.map { |payment| PaymentPresenter.new(payment) }
   end
 
   def sorted_orders

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -765,4 +765,34 @@ RSpec.describe ActionLinksHelper do
       end
     end
   end
+
+  describe "#display_payment_details_link_for?" do
+    before { allow(helper).to receive(:can?).with(:read, resource).and_return(true) }
+
+    context "when the resource is not a registration" do
+      let(:resource) { nil }
+
+      it "returns false" do
+        expect(helper.display_payment_details_link_for?(resource)).to be(false)
+      end
+    end
+
+    context "when the resource is a registration" do
+      context "when the registration does not have an account" do
+        let(:resource) { create(:registration, account: nil) }
+
+        it "returns false" do
+          expect(helper.display_payment_details_link_for?(resource)).to be(false)
+        end
+      end
+
+      context "when the registration has an account" do
+        let(:resource) { create(:registration, account: build(:account)) }
+
+        it "returns true" do
+          expect(helper.display_payment_details_link_for?(resource)).to be(true)
+        end
+      end
+    end
+  end
 end

--- a/spec/presenters/account_presenter_spec.rb
+++ b/spec/presenters/account_presenter_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AccountPresenter do
+  subject(:presenter) { described_class.new(account) }
+
+  describe "#balance" do
+    let(:balance) { 123_45 }
+
+    # balance is a method on account, not an attribute, so we cannot
+    # simply set it to a numerical value when building the account
+    before { allow(account).to receive(:balance).and_return(balance) unless account.nil? }
+
+    context "when account is present" do
+      let(:account) { build(:account) }
+
+      it { expect(presenter.balance).to eq "£123.45" }
+    end
+
+    context "when account is not present" do
+      let(:account) { nil }
+
+      it { expect(presenter.balance).to be_nil }
+    end
+  end
+
+  describe "#successful_payments" do
+
+    context "when account is present" do
+      let(:account) { create(:account, payments: build_list(:payment, 2, :success)) }
+
+      it { expect(presenter.successful_payments.length).to eq(2) }
+      it { expect(presenter.successful_payments).to all(be_an(PaymentPresenter)) }
+    end
+
+    context "when account is not present" do
+      let(:account) { nil }
+
+      it { expect(presenter.successful_payments).to be_empty }
+    end
+  end
+
+  describe "#refunds_and_reversals" do
+    context "when account is present" do
+      let(:refund) { build(:payment, :success, payment_type: WasteExemptionsEngine::Payment::PAYMENT_TYPE_REFUND) }
+      let(:reversal) { build(:payment, :success, payment_type: WasteExemptionsEngine::Payment::PAYMENT_TYPE_REVERSAL) }
+      let(:account) { create(:account, payments: [refund, reversal]) }
+
+      it { expect(presenter.refunds_and_reversals.length).to eq(2) }
+      it { expect(presenter.refunds_and_reversals).to all(be_an(PaymentPresenter)) }
+    end
+
+    context "when account is not present" do
+      let(:account) { nil }
+
+      it { expect(presenter.refunds_and_reversals).to be_empty }
+    end
+  end
+
+  describe "#sorted_orders" do
+    context "when account is present" do
+      let(:account) { create(:account, orders: build_list(:order, 2)) }
+
+      it { expect(presenter.sorted_orders.length).to eq(2) }
+      it { expect(presenter.sorted_orders).to all(be_an(OrderPresenter)) }
+    end
+
+    context "when account is not present" do
+      let(:account) { nil }
+
+      it { expect(presenter.sorted_orders).to be_empty }
+    end
+  end
+
+  describe "#charge_adjustments" do
+    context "when account is present" do
+      let(:account) { create(:account, charge_adjustments: build_list(:charge_adjustment, 2)) }
+
+      it { expect(presenter.charge_adjustments.length).to eq(2) }
+      it { expect(presenter.charge_adjustments).to all(be_an(ChargeAdjustmentPresenter)) }
+    end
+
+    context "when account is not present" do
+      let(:account) { nil }
+
+      it { expect(presenter.charge_adjustments).to be_empty }
+    end
+  end
+end


### PR DESCRIPTION
Viewing payment details in the back office for a registration without an account causes an error. This change:
* Adds guards to `AccountPresenter` to return nil or empty array results if the account is not present
* Adds unit tests for all `AccountPresenter` methods
* Prevents display of the "Payment details" link for registrations without an account
https://eaflood.atlassian.net/browse/RUBY-3558