### PR TITLE
[RUBY-3605] Refactor administrable roles service to use consistent spelling for policy adviser

### DIFF
--- a/app/services/administrable_roles_service.rb
+++ b/app/services/administrable_roles_service.rb
@@ -30,7 +30,7 @@ class AdministrableRolesService
        service_manager
        admin_team_user
        admin_team_lead
-       policy_advisor]
+       policy_adviser]
   end
 
   def self.admin_team_lead_administrable_roles
@@ -41,7 +41,7 @@ class AdministrableRolesService
   end
 
   def self.policy_adviser_administrable_roles
-    %w[policy_advisor
+    %w[policy_adviser
        data_viewer]
   end
 end

--- a/spec/services/administrable_roles_service_spec.rb
+++ b/spec/services/administrable_roles_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe AdministrableRolesService do
                                                     service_manager
                                                     admin_team_user
                                                     admin_team_lead
-                                                    policy_advisor])
+                                                    policy_adviser])
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe AdministrableRolesService do
       let(:user) { build(:user, role: "policy_adviser") }
 
       it "returns list of group roles" do
-        expect(described_class.call(user)).to eq(%w[policy_advisor
+        expect(described_class.call(user)).to eq(%w[policy_adviser
                                                     data_viewer])
       end
     end


### PR DESCRIPTION
Fix an issue with being unable to set a policy_advicer role for the user
https://eaflood.atlassian.net/browse/RUBY-3605