### PR TITLE
[RUBY-3644] Stop sending renewal communications to beta participants

### DIFF
--- a/app/services/renewal_reminder_email_service.rb
+++ b/app/services/renewal_reminder_email_service.rb
@@ -34,7 +34,7 @@ class RenewalReminderEmailService < RenewalReminderService
       message_type: "email",
       template_id: nil,
       template_label: "User is opted out - No renewal reminder email sent",
-      sent_to: registration.contact_email
+      sent_to: registration.send(sent_to_method)
     )
   end
 
@@ -44,7 +44,7 @@ class RenewalReminderEmailService < RenewalReminderService
     "email"
   end
 
-  def sent_to
-    @registration.contact_email
+  def sent_to_method
+    :contact_email
   end
 end

--- a/app/services/renewal_reminder_email_service.rb
+++ b/app/services/renewal_reminder_email_service.rb
@@ -34,7 +34,7 @@ class RenewalReminderEmailService < RenewalReminderService
       message_type: "email",
       template_id: nil,
       template_label: "User is opted out - No renewal reminder email sent",
-      sent_to: registration.send(sent_to_method)
+      sent_to: registration.contact_email
     )
   end
 

--- a/app/services/renewal_reminder_email_service.rb
+++ b/app/services/renewal_reminder_email_service.rb
@@ -38,12 +38,13 @@ class RenewalReminderEmailService < RenewalReminderService
     )
   end
 
-  def create_beta_participant_log(registration:)
-    registration.communication_logs.create(
-      message_type: "email",
-      template_id: template,
-      template_label: "beta_participant",
-      sent_to: registration.contact_email
-    )
+  private
+
+  def message_type
+    "email"
+  end
+
+  def sent_to
+    @registration.contact_email
   end
 end

--- a/app/services/renewal_reminder_service.rb
+++ b/app/services/renewal_reminder_service.rb
@@ -73,7 +73,7 @@ class RenewalReminderService < WasteExemptionsEngine::BaseService
       message_type: message_type,
       template_id: nil,
       template_label: "Beta participant - No renewal reminder sent",
-      sent_to: sent_to
+      sent_to: registration.send(sent_to_method)
     )
   end
 end

--- a/app/services/renewal_reminder_service.rb
+++ b/app/services/renewal_reminder_service.rb
@@ -63,4 +63,17 @@ class RenewalReminderService < WasteExemptionsEngine::BaseService
   def unsubscribe_link
     WasteExemptionsEngine::UnsubscribeLinkService.run(registration: @registration)
   end
+
+  def message_type
+    raise NotImplementedError
+  end
+
+  def create_beta_participant_log(registration:)
+    registration.communication_logs.create(
+      message_type: message_type,
+      template_id: nil,
+      template_label: "Beta participant - No renewal reminder sent",
+      sent_to: sent_to
+    )
+  end
 end

--- a/app/services/renewal_reminder_text_service.rb
+++ b/app/services/renewal_reminder_text_service.rb
@@ -23,12 +23,13 @@ class RenewalReminderTextService < RenewalReminderService
     )
   end
 
-  def create_beta_participant_log(registration:)
-    registration.communication_logs.create(
-      message_type: "text",
-      template_id: template,
-      template_label: "beta_participant",
-      sent_to: registration.contact_phone
-    )
+  private
+
+  def message_type
+    "text"
+  end
+
+  def sent_to
+    @registration.contact_phone
   end
 end

--- a/app/services/renewal_reminder_text_service.rb
+++ b/app/services/renewal_reminder_text_service.rb
@@ -7,6 +7,11 @@ class RenewalReminderTextService < RenewalReminderService
   def run(registration:)
     return unless registration.valid_mobile_phone_number?
 
+    if WasteExemptionsEngine::BetaParticipant.exists?(reg_number: registration.reference)
+      create_beta_participant_log(registration:)
+      return
+    end
+
     @registration = registration
 
     client = Notifications::Client.new(WasteExemptionsEngine.configuration.notify_api_key)
@@ -15,6 +20,15 @@ class RenewalReminderTextService < RenewalReminderService
       phone_number: @registration.contact_phone,
       template_id: template,
       personalisation: personalisation
+    )
+  end
+
+  def create_beta_participant_log(registration:)
+    registration.communication_logs.create(
+      message_type: "text",
+      template_id: template,
+      template_label: "beta_participant",
+      sent_to: registration.contact_phone
     )
   end
 end

--- a/app/services/renewal_reminder_text_service.rb
+++ b/app/services/renewal_reminder_text_service.rb
@@ -29,7 +29,7 @@ class RenewalReminderTextService < RenewalReminderService
     "text"
   end
 
-  def sent_to
-    @registration.contact_phone
+  def sent_to_method
+    :contact_phone
   end
 end

--- a/spec/services/first_renewal_reminder_email_service_spec.rb
+++ b/spec/services/first_renewal_reminder_email_service_spec.rb
@@ -19,6 +19,29 @@ RSpec.describe FirstRenewalReminderEmailService do
 
     it_behaves_like "opted out of renewal reminder"
 
+    context "when registration is a beta participant" do
+      before do
+        create(:beta_participant, reg_number: registration.reference)
+      end
+
+      it "does not send an email" do
+        VCR.use_cassette("first_renewal_reminder_email_beta_participant") do
+          response = run_service
+          expect(response).to be_nil
+        end
+      end
+
+      it "creates a communication log for beta participant" do
+        VCR.use_cassette("first_renewal_reminder_email_beta_participant") do
+          run_service
+          log = registration.communication_logs.last
+          expect(log.message_type).to eq("email")
+          expect(log.template_label).to eq("beta_participant")
+          expect(log.sent_to).to eq(registration.contact_email)
+        end
+      end
+    end
+
     it_behaves_like "CanHaveCommunicationLog" do
       let(:service_class) { described_class }
       let(:parameters) { { registration: create(:registration) } }

--- a/spec/services/first_renewal_reminder_email_service_spec.rb
+++ b/spec/services/first_renewal_reminder_email_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe FirstRenewalReminderEmailService do
           run_service
           log = registration.communication_logs.last
           expect(log.message_type).to eq("email")
-          expect(log.template_label).to eq("beta_participant")
+          expect(log.template_label).to eq("Beta participant - No renewal reminder sent")
           expect(log.sent_to).to eq(registration.contact_email)
         end
       end

--- a/spec/services/renewal_reminder_text_service_spec.rb
+++ b/spec/services/renewal_reminder_text_service_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe RenewalReminderTextService do
         renewal_reminder_text_service.run(registration: registration)
         log = registration.communication_logs.last
         expect(log.message_type).to eq("text")
-        expect(log.template_label).to eq("beta_participant")
+        expect(log.template_label).to eq("Beta participant - No renewal reminder sent")
         expect(log.sent_to).to eq(registration.contact_phone)
       end
     end

--- a/spec/services/renewal_reminder_text_service_spec.rb
+++ b/spec/services/renewal_reminder_text_service_spec.rb
@@ -34,5 +34,24 @@ RSpec.describe RenewalReminderTextService do
         expect(notifications_client_instance).to have_received(:send_sms)
       end
     end
+
+    context "when registration is a beta participant" do
+      before do
+        create(:beta_participant, reg_number: registration.reference)
+      end
+
+      it "does not send a text message" do
+        renewal_reminder_text_service.run(registration: registration)
+        expect(notifications_client_instance).not_to have_received(:send_sms)
+      end
+
+      it "creates a communication log for beta participant" do
+        renewal_reminder_text_service.run(registration: registration)
+        log = registration.communication_logs.last
+        expect(log.message_type).to eq("text")
+        expect(log.template_label).to eq("beta_participant")
+        expect(log.sent_to).to eq(registration.contact_phone)
+      end
+    end
   end
 end

--- a/spec/services/second_renewal_reminder_email_service_spec.rb
+++ b/spec/services/second_renewal_reminder_email_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe SecondRenewalReminderEmailService do
           run_service
           log = registration.communication_logs.last
           expect(log.message_type).to eq("email")
-          expect(log.template_label).to eq("beta_participant")
+          expect(log.template_label).to eq("Beta participant - No renewal reminder sent")
           expect(log.sent_to).to eq(registration.contact_email)
         end
       end

--- a/spec/services/second_renewal_reminder_email_service_spec.rb
+++ b/spec/services/second_renewal_reminder_email_service_spec.rb
@@ -24,6 +24,29 @@ RSpec.describe SecondRenewalReminderEmailService do
 
     it_behaves_like "opted out of renewal reminder"
 
+    context "when registration is a beta participant" do
+      before do
+        create(:beta_participant, reg_number: registration.reference)
+      end
+
+      it "does not send an email" do
+        VCR.use_cassette("second_renewal_reminder_email_beta_participant") do
+          response = run_service
+          expect(response).to be_nil
+        end
+      end
+
+      it "creates a communication log for beta participant" do
+        VCR.use_cassette("second_renewal_reminder_email_beta_participant") do
+          run_service
+          log = registration.communication_logs.last
+          expect(log.message_type).to eq("email")
+          expect(log.template_label).to eq("beta_participant")
+          expect(log.sent_to).to eq(registration.contact_email)
+        end
+      end
+    end
+
     it_behaves_like "CanHaveCommunicationLog" do
       let(:service_class) { described_class }
       let(:parameters) { { registration: create(:registration) } }


### PR DESCRIPTION
[RUBY-3644] Stop sending renewal communications to beta participants

- Updated `RenewalReminderEmailService` and `RenewalReminderTextService` to check if a registration is a beta participant and skip sending emails or texts if true.
- Added `create_beta_participant_log` method to log communication attempts for beta participants.

https://eaflood.atlassian.net/browse/RUBY-3644

[RUBY-3644]: https://eaflood.atlassian.net/browse/RUBY-3644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ