### PR TITLE
[RUBY-3640] hiding non-farmer exemptions from charge breakdown when non are selected

### DIFF
--- a/app/views/payment_details/index.html.erb
+++ b/app/views/payment_details/index.html.erb
@@ -36,7 +36,9 @@
               <%= order.created_at.strftime("%Y-%m-%d") %>
             </td>
             <td class="govuk-table__cell">
-              <%= order.exemption_codes_excluding_bucket %> <br>
+              <% if order.exemption_codes_excluding_bucket.present? %>
+                <%= order.exemption_codes_excluding_bucket %> <br>
+              <% end %>
               <% if order.bucket.present? %>
                 <%= t(".details_section.charges.bucket_exemptions_label.#{order.bucket.bucket_type}") %> 
                 <%= order.bucket_exemption_codes %> <br>
@@ -45,7 +47,9 @@
               <%= t(".details_section.charges.total_charge_label") %>
             </td>
             <td class="govuk-table__cell govuk-!-text-align-right">
-              <%= display_pence_as_pounds_sterling_and_pence(pence: (order.charge_detail&.total_compliance_charge_amount_excluding_bucket)) %> <br>
+              <% if order.exemption_codes_excluding_bucket.present? %>
+                <%= display_pence_as_pounds_sterling_and_pence(pence: (order.charge_detail&.total_compliance_charge_amount_excluding_bucket)) %> <br>
+              <% end %>
               <% if order.bucket.present? %>
                 <%= display_pence_as_pounds_sterling_and_pence(pence: order.charge_detail&.bucket_charge_amount) %> <br>
               <% end %>


### PR DESCRIPTION
Hiding non-farmer exemptions from charge breakdown when non are selected
https://eaflood.atlassian.net/browse/RUBY-3640