### PR TITLE
Chore/ruby 3655 epr export error handling

### DIFF
--- a/app/models/reports/base_serializer.rb
+++ b/app/models/reports/base_serializer.rb
@@ -20,6 +20,12 @@ module Reports
       registration_exemptions_scope.find_in_batches(batch_size: batch_size) do |batch|
         batch.each do |registration_exemption|
           yield parse_registration_exemption(registration_exemption)
+        rescue StandardError => e
+          # Handle parsing errors here so that the serializer can continue with the next object.
+          message = "EPR serializer: Error mapping registration_exemption #{registration_exemption.id}, " \
+                    "registration #{registration_exemption.registration.reference}: #{e}"
+          Rails.logger.error message
+          Airbrake.notify(e, message:)
         end
       end
     end

--- a/app/models/reports/epr_serializer.rb
+++ b/app/models/reports/epr_serializer.rb
@@ -36,8 +36,8 @@ module Reports
     end
 
     def parse_registration_exemption(registration_exemption)
+      presenter = ExemptionEprReportPresenter.new(registration_exemption)
       ATTRIBUTES.map do |attribute|
-        presenter = ExemptionEprReportPresenter.new(registration_exemption)
         presenter.public_send(attribute)
       end
     end

--- a/app/models/reports/monthly_bulk_serializer.rb
+++ b/app/models/reports/monthly_bulk_serializer.rb
@@ -47,8 +47,8 @@ module Reports
     end
 
     def parse_registration_exemption(registration_exemption)
+      presenter = ExemptionBulkReportPresenter.new(registration_exemption)
       ATTRIBUTES.map do |attribute|
-        presenter = ExemptionBulkReportPresenter.new(registration_exemption)
         presenter.public_send(attribute)
       end
     end


### PR DESCRIPTION
Ensure any bad data errors during EPR export are handled at the record level and do not terminate the entire export.
https://eaflood.atlassian.net/browse/RUBY-3665