### PR TITLE
[RUBY-3690] make new registration workflow to start from location page

### DIFF
--- a/app/helpers/ad_privacy_policy_helper.rb
+++ b/app/helpers/ad_privacy_policy_helper.rb
@@ -12,11 +12,9 @@ module AdPrivacyPolicyHelper
   def destination_path(registration = nil)
     if registration.present?
       renew_path(reference: registration.reference)
-    elsif WasteExemptionsEngine::FeatureToggle.active?(:ad_charged_journey_link)
+    else
       transient_registration = WasteExemptionsEngine::NewChargedRegistration.create!
       WasteExemptionsEngine::Engine.routes.url_helpers.new_location_form_path(transient_registration.token)
-    else
-      WasteExemptionsEngine::Engine.routes.url_helpers.new_start_form_path
     end
   end
 end

--- a/spec/helpers/ad_privacy_policy_helper_spec.rb
+++ b/spec/helpers/ad_privacy_policy_helper_spec.rb
@@ -18,34 +18,21 @@ RSpec.describe AdPrivacyPolicyHelper do
     context "when no registration is present" do
       let(:registration) { nil }
 
-      context "when the ad_charged_journey_link feature toggle is not enabled" do
-        before do
-          allow(WasteExemptionsEngine::FeatureToggle).to receive(:active?)
-            .with(:ad_charged_journey_link).and_return(false)
-        end
-
-        it "returns the non-charged new registration start path" do
-          expect(destination_path).to eq WasteExemptionsEngine::Engine.routes.url_helpers.new_start_form_path
-        end
+      before do
+        allow(WasteExemptionsEngine::FeatureToggle).to receive(:active?)
+          .with(:ad_charged_journey_link).and_return(true)
       end
 
-      context "when the ad_charged_journey_link feature toggle is enabled" do
-        before do
-          allow(WasteExemptionsEngine::FeatureToggle).to receive(:active?)
-            .with(:ad_charged_journey_link).and_return(true)
-        end
+      it "creates a new charged registration" do
+        expect { helper.destination_path }.to change(WasteExemptionsEngine::NewChargedRegistration, :count).by(1)
+      end
 
-        it "creates a new charged registration" do
-          expect { helper.destination_path }.to change(WasteExemptionsEngine::NewChargedRegistration, :count).by(1)
-        end
-
-        it "returns the path to the location page" do
-          path = destination_path
-          transient_registration = WasteExemptionsEngine::NewChargedRegistration.last
-          expect(path).to eq WasteExemptionsEngine::Engine
-            .routes.url_helpers
-            .new_location_form_path(transient_registration.token)
-        end
+      it "returns the path to the location page" do
+        path = destination_path
+        transient_registration = WasteExemptionsEngine::NewChargedRegistration.last
+        expect(path).to eq WasteExemptionsEngine::Engine
+          .routes.url_helpers
+          .new_location_form_path(transient_registration.token)
       end
     end
   end

--- a/spec/helpers/ad_privacy_policy_helper_spec.rb
+++ b/spec/helpers/ad_privacy_policy_helper_spec.rb
@@ -18,11 +18,6 @@ RSpec.describe AdPrivacyPolicyHelper do
     context "when no registration is present" do
       let(:registration) { nil }
 
-      before do
-        allow(WasteExemptionsEngine::FeatureToggle).to receive(:active?)
-          .with(:ad_charged_journey_link).and_return(true)
-      end
-
       it "creates a new charged registration" do
         expect { helper.destination_path }.to change(WasteExemptionsEngine::NewChargedRegistration, :count).by(1)
       end


### PR DESCRIPTION
Make back office new registration workflow to start from the location page
https://eaflood.atlassian.net/browse/RUBY-3690