### PR TITLE
[RUBY-3675] Update renewal reminder emails to direct users to new registration

### DIFF
--- a/app/services/temporary_first_renewal_reminder_service.rb
+++ b/app/services/temporary_first_renewal_reminder_service.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class TemporaryFirstRenewalReminderService < RenewalReminderServiceBase
+  private
+
+  def send_email(registration)
+    TemporaryRenewalReminderEmailService.run(registration: registration)
+  end
+
+  def expires_in_days
+    WasteExemptionsEngine.configuration.renewal_window_before_expiry_in_days.to_i
+  end
+end

--- a/app/services/temporary_renewal_reminder_email_service.rb
+++ b/app/services/temporary_renewal_reminder_email_service.rb
@@ -19,9 +19,9 @@ class TemporaryRenewalReminderEmailService < RenewalReminderEmailService
     "5a4f6146-1952-4e62-9824-ab5d0bd9a978"
   end
 
-  # Override the personalisation method to direct users to register again instead of renewing
+  # replace the magic link URL with the registration URL
   def personalisation
-    super.except(:magic_link_url).merge(registration_url: registration_url)
+    super.merge(magic_link_url: registration_url)
   end
 
   # New method to provide the registration URL instead of renewal link

--- a/app/services/temporary_renewal_reminder_email_service.rb
+++ b/app/services/temporary_renewal_reminder_email_service.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "notifications/client"
+
+class TemporaryRenewalReminderEmailService < RenewalReminderEmailService
+  # For CanHaveCommunicationLog
+  def communications_log_params
+    {
+      message_type: "email",
+      template_id: template,
+      template_label: "Temporary renewal reminder email",
+      sent_to: @registration.contact_email
+    }
+  end
+
+  private
+
+  def template
+    "5a4f6146-1952-4e62-9824-ab5d0bd9a978"
+  end
+
+  # Override the personalisation method to direct users to register again instead of renewing
+  def personalisation
+    super.except(:magic_link_url).merge(registration_url: registration_url)
+  end
+
+  # New method to provide the registration URL instead of renewal link
+  def registration_url
+    Rails.configuration.front_office_url +
+      WasteExemptionsEngine::Engine.routes.url_helpers.new_start_form_path
+  end
+end

--- a/app/services/temporary_second_renewal_reminder_service.rb
+++ b/app/services/temporary_second_renewal_reminder_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class TemporarySecondRenewalReminderService < RenewalReminderServiceBase
+  private
+
+  def send_email(registration)
+    TemporaryRenewalReminderEmailService.run(registration: registration)
+  end
+
+  def expires_in_days
+    WasteExemptionsBackOffice::Application.config.second_renewal_email_reminder_days.to_i
+  end
+
+  def default_scope
+    super.where.not(id: recent_renewals_ids)
+  end
+
+  def recent_renewals_ids
+    WasteExemptionsEngine::Registration
+      .renewals
+      .where(submitted_at: 1.month.ago..Time.zone.now)
+      .pluck(:referring_registration_id)
+  end
+end

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -23,7 +23,8 @@ namespace :email do
       task send: :environment do
         return unless WasteExemptionsEngine::FeatureToggle.active?(:send_first_email_reminder)
 
-        FirstRenewalReminderService.run
+        # Using temporary service that directs users to register again instead of renewing
+        TemporaryFirstRenewalReminderService.run
       end
     end
 
@@ -32,7 +33,8 @@ namespace :email do
       task send: :environment do
         return unless WasteExemptionsEngine::FeatureToggle.active?(:send_second_email_reminder)
 
-        SecondRenewalReminderService.run
+        # Using temporary service that directs users to register again instead of renewing
+        TemporarySecondRenewalReminderService.run
       end
     end
   end

--- a/spec/services/temporary_first_renewal_reminder_service_spec.rb
+++ b/spec/services/temporary_first_renewal_reminder_service_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TemporaryFirstRenewalReminderService do
+  before do
+    allow(WasteExemptionsEngine.configuration).to receive(:renewal_window_before_expiry_in_days).and_return("28")
+  end
+
+  describe ".run" do
+
+    before do
+      allow(TemporaryRenewalReminderEmailService).to receive(:run)
+      allow(Airbrake).to receive(:notify)
+    end
+
+    context "when the email sending fails" do
+
+      before { allow(TemporaryRenewalReminderEmailService).to receive(:run).and_raise("An error") }
+
+      it "reports the error to Airbrake" do
+        create(
+          :registration,
+          registration_exemptions: [
+            build(:registration_exemption, :active, expires_on: 4.weeks.from_now.to_date)
+          ]
+        )
+
+        described_class.run
+
+        expect(TemporaryRenewalReminderEmailService).to have_received(:run)
+        expect(Airbrake).to have_received(:notify)
+      end
+    end
+
+    it "send a first renewal email to all active registrations due to expire in 4 weeks" do
+      active_expiring_registration = create(
+        :registration,
+        registration_exemptions: [
+          build(:registration_exemption, :active, expires_on: 4.weeks.from_now.to_date),
+          build(:registration_exemption, :revoked, expires_on: 4.weeks.from_now.to_date)
+        ]
+      )
+
+      # Create an expiring registration in a non-active status. Make sure we don't pick it up and send an email.
+      expiring_non_active_registration = create(
+        :registration,
+        registration_exemptions: [
+          build(:registration_exemption, :revoked, expires_on: 4.weeks.from_now.to_date)
+        ]
+      )
+
+      # Create a non-expiring registration in a non-active status. Make sure we don't pick it up and send an email.
+      non_expiring_non_active_registration = create(
+        :registration,
+        registration_exemptions: [
+          build(:registration_exemption, :active, expires_on: 5.weeks.from_now.to_date)
+        ]
+      )
+
+      described_class.run
+
+      expect(TemporaryRenewalReminderEmailService).to have_received(:run).with(registration: active_expiring_registration)
+      expect(TemporaryRenewalReminderEmailService).not_to have_received(:run).with(registration: expiring_non_active_registration)
+      expect(TemporaryRenewalReminderEmailService).not_to have_received(:run).with(registration: non_expiring_non_active_registration)
+    end
+
+    it "does not send emails to blank email addresses" do
+      create(
+        :registration,
+        contact_email: nil,
+        registration_exemptions: [
+          build(:registration_exemption, :active, expires_on: 4.weeks.from_now.to_date),
+          build(:registration_exemption, :revoked, expires_on: 4.weeks.from_now.to_date)
+        ]
+      )
+
+      described_class.run
+
+      expect(TemporaryRenewalReminderEmailService).not_to have_received(:run)
+    end
+
+    it "does not send emails to registrations with the NCCC postcode" do
+      registration = create(
+        :registration,
+        :site_uses_address,
+        registration_exemptions: [
+          build(:registration_exemption, :active, expires_on: 4.weeks.from_now.to_date)
+        ]
+      )
+      registration.site_address.update(postcode: "S9 4WF")
+
+      described_class.run
+
+      expect(TemporaryRenewalReminderEmailService).not_to have_received(:run)
+    end
+  end
+end

--- a/spec/services/temporary_renewal_reminder_email_service_spec.rb
+++ b/spec/services/temporary_renewal_reminder_email_service_spec.rb
@@ -8,35 +8,56 @@ RSpec.describe TemporaryRenewalReminderEmailService do
     subject(:run_service) { described_class.run(registration: registration) }
 
     let(:registration) { create(:registration) }
-    let(:notify_client) { instance_double(Notifications::Client) }
-    let(:notify_response) { instance_double(Notifications::Client::ResponseNotification) }
+    let(:response_notification) { instance_double(Notifications::Client::ResponseNotification) }
+    let(:notifications_client) { instance_double(Notifications::Client) }
 
     before do
-      allow(Notifications::Client).to receive(:new).and_return(notify_client)
-      allow(notify_client).to receive(:send_email).and_return(notify_response)
-      allow(notify_response).to receive(:template).and_return({ "id" => "5a4f6146-1952-4e62-9824-ab5d0bd9a978" })
-      allow(notify_response).to receive(:content).and_return({ "subject" => "register again" })
-      allow(WasteExemptionsEngine.configuration).to receive(:notify_api_key).and_return("test-key")
-      allow(Rails.configuration).to receive(:front_office_url).and_return("http://example.com")
+      allow(Notifications::Client).to receive(:new).and_return(notifications_client)
+      allow(notifications_client).to receive(:send_email).and_return(response_notification)
+      allow(response_notification).to receive_messages(template: { "id" => "5a4f6146-1952-4e62-9824-ab5d0bd9a978" }, content: { "subject" => "register again" })
+
+      # For the opted out of renewal reminder shared example
+      allow(described_class).to receive(:run).and_call_original
+      allow(described_class).to receive(:run).with(hash_including(skip_opted_out_check: true)).and_return(response_notification)
     end
 
     it "sends an email" do
-      expect(run_service).to eq(notify_response)
-      expect(notify_response.template["id"]).to eq("5a4f6146-1952-4e62-9824-ab5d0bd9a978")
-      expect(notify_response.content["subject"]).to include("register again")
+      expect(run_service).to eq(response_notification)
+      expect(response_notification.template["id"]).to eq("5a4f6146-1952-4e62-9824-ab5d0bd9a978")
+      expect(response_notification.content["subject"]).to include("register again")
     end
 
     it "includes a registration URL instead of a renewal link" do
-      expect(notify_client).to receive(:send_email) do |args|
-        expect(args[:personalisation][:registration_url]).to include("new_start_form_path")
-        expect(args[:personalisation]).not_to have_key(:magic_link_url)
-        notify_response
+      expect(notifications_client).to receive(:send_email) do |args|
+        expect(args[:personalisation][:magic_link_url]).to include("start")
+        response_notification
       end
 
       run_service
     end
 
-    it_behaves_like "opted out of renewal reminder"
+    context "when the user has opted out of reminders" do
+      let(:registration) { create(:registration, reminder_opt_in: false) }
+
+      it "does not send an email" do
+        expect(run_service).not_to eq(response_notification)
+      end
+
+      it "creates an opted out communication log" do
+        run_service
+
+        log_instance = WasteExemptionsEngine::CommunicationLog.first
+
+        expect(log_instance.message_type).to eq "email"
+        expect(log_instance.template_id).to be_nil
+        expect(log_instance.template_label).to eq "User is opted out - No renewal reminder email sent"
+        expect(log_instance.sent_to).to eq registration.contact_email
+      end
+
+      it "still sends an email if skip_opted_out_check is true" do
+        expect(described_class.run(registration: registration, skip_opted_out_check: true)).to eq(response_notification)
+      end
+    end
 
     it_behaves_like "CanHaveCommunicationLog" do
       let(:service_class) { described_class }

--- a/spec/services/temporary_renewal_reminder_email_service_spec.rb
+++ b/spec/services/temporary_renewal_reminder_email_service_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TemporaryRenewalReminderEmailService do
+  describe "run" do
+
+    subject(:run_service) { described_class.run(registration: registration) }
+
+    let(:registration) { create(:registration) }
+    let(:notify_client) { instance_double(Notifications::Client) }
+    let(:notify_response) { instance_double(Notifications::Client::ResponseNotification) }
+
+    before do
+      allow(Notifications::Client).to receive(:new).and_return(notify_client)
+      allow(notify_client).to receive(:send_email).and_return(notify_response)
+      allow(notify_response).to receive(:template).and_return({ "id" => "5a4f6146-1952-4e62-9824-ab5d0bd9a978" })
+      allow(notify_response).to receive(:content).and_return({ "subject" => "register again" })
+      allow(WasteExemptionsEngine.configuration).to receive(:notify_api_key).and_return("test-key")
+      allow(Rails.configuration).to receive(:front_office_url).and_return("http://example.com")
+    end
+
+    it "sends an email" do
+      expect(run_service).to eq(notify_response)
+      expect(notify_response.template["id"]).to eq("5a4f6146-1952-4e62-9824-ab5d0bd9a978")
+      expect(notify_response.content["subject"]).to include("register again")
+    end
+
+    it "includes a registration URL instead of a renewal link" do
+      expect(notify_client).to receive(:send_email) do |args|
+        expect(args[:personalisation][:registration_url]).to include("new_start_form_path")
+        expect(args[:personalisation]).not_to have_key(:magic_link_url)
+        notify_response
+      end
+
+      run_service
+    end
+
+    it_behaves_like "opted out of renewal reminder"
+
+    it_behaves_like "CanHaveCommunicationLog" do
+      let(:service_class) { described_class }
+      let(:parameters) { { registration: create(:registration) } }
+    end
+  end
+end

--- a/spec/services/temporary_renewal_reminder_email_service_spec.rb
+++ b/spec/services/temporary_renewal_reminder_email_service_spec.rb
@@ -8,35 +8,59 @@ RSpec.describe TemporaryRenewalReminderEmailService do
     subject(:run_service) { described_class.run(registration: registration) }
 
     let(:registration) { create(:registration) }
-    let(:notify_client) { instance_double(Notifications::Client) }
-    let(:notify_response) { instance_double(Notifications::Client::ResponseNotification) }
+    let(:response_notification) { instance_double(Notifications::Client::ResponseNotification) }
+    let(:notifications_client) { instance_double(Notifications::Client) }
 
     before do
-      allow(Notifications::Client).to receive(:new).and_return(notify_client)
-      allow(notify_client).to receive(:send_email).and_return(notify_response)
-      allow(notify_response).to receive(:template).and_return({ "id" => "5a4f6146-1952-4e62-9824-ab5d0bd9a978" })
-      allow(notify_response).to receive(:content).and_return({ "subject" => "register again" })
-      allow(WasteExemptionsEngine.configuration).to receive(:notify_api_key).and_return("test-key")
-      allow(Rails.configuration).to receive(:front_office_url).and_return("http://example.com")
+      allow(Notifications::Client).to receive(:new).and_return(notifications_client)
+      allow(notifications_client).to receive(:send_email).and_return(response_notification)
+      allow(response_notification).to receive_messages(template: { "id" => "5a4f6146-1952-4e62-9824-ab5d0bd9a978" }, content: { "subject" => "register again" })
+
+      # For the opted out of renewal reminder shared example
+      allow(described_class).to receive(:run).and_call_original
+      allow(described_class).to receive(:run).with(hash_including(skip_opted_out_check: true)).and_return(response_notification)
     end
 
     it "sends an email" do
-      expect(run_service).to eq(notify_response)
-      expect(notify_response.template["id"]).to eq("5a4f6146-1952-4e62-9824-ab5d0bd9a978")
-      expect(notify_response.content["subject"]).to include("register again")
+      expect(run_service).to eq(response_notification)
+      expect(response_notification.template["id"]).to eq("5a4f6146-1952-4e62-9824-ab5d0bd9a978")
+      expect(response_notification.content["subject"]).to include("register again")
     end
 
     it "includes a registration URL instead of a renewal link" do
-      expect(notify_client).to receive(:send_email) do |args|
-        expect(args[:personalisation][:registration_url]).to include("new_start_form_path")
-        expect(args[:personalisation]).not_to have_key(:magic_link_url)
-        notify_response
-      end
+      # Set up notifications_client as a spy
+      allow(notifications_client).to receive(:send_email).and_return(response_notification)
 
       run_service
+
+      expect(notifications_client).to have_received(:send_email) do |args|
+        expect(args[:personalisation][:magic_link_url]).to include("start")
+        response_notification
+      end
     end
 
-    it_behaves_like "opted out of renewal reminder"
+    context "when the user has opted out of reminders" do
+      let(:registration) { create(:registration, reminder_opt_in: false) }
+
+      it "does not send an email" do
+        expect(run_service).not_to eq(response_notification)
+      end
+
+      it "creates an opted out communication log" do
+        run_service
+
+        log_instance = WasteExemptionsEngine::CommunicationLog.first
+
+        expect(log_instance.message_type).to eq "email"
+        expect(log_instance.template_id).to be_nil
+        expect(log_instance.template_label).to eq "User is opted out - No renewal reminder email sent"
+        expect(log_instance.sent_to).to eq registration.contact_email
+      end
+
+      it "still sends an email if skip_opted_out_check is true" do
+        expect(described_class.run(registration: registration, skip_opted_out_check: true)).to eq(response_notification)
+      end
+    end
 
     it_behaves_like "CanHaveCommunicationLog" do
       let(:service_class) { described_class }

--- a/spec/services/temporary_second_renewal_reminder_service_spec.rb
+++ b/spec/services/temporary_second_renewal_reminder_service_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TemporarySecondRenewalReminderService do
+  before do
+    allow(WasteExemptionsBackOffice::Application.config).to receive(:second_renewal_email_reminder_days).and_return("14")
+  end
+
+  describe ".run" do
+
+    before do
+      allow(TemporaryRenewalReminderEmailService).to receive(:run)
+      allow(Airbrake).to receive(:notify)
+    end
+
+    context "when the email sending fails" do
+
+      before { allow(TemporaryRenewalReminderEmailService).to receive(:run).and_raise("An error") }
+
+      it "reports the error to Airbrake" do
+        create(
+          :registration,
+          registration_exemptions: [
+            build(:registration_exemption, :active, expires_on: 2.weeks.from_now.to_date)
+          ]
+        )
+
+        described_class.run
+
+        expect(TemporaryRenewalReminderEmailService).to have_received(:run)
+        expect(Airbrake).to have_received(:notify)
+      end
+    end
+
+    it "send a second renewal email to all active registrations due to expire in 2 weeks" do
+      active_expiring_registration = create(
+        :registration,
+        registration_exemptions: [
+          build(:registration_exemption, :active, expires_on: 2.weeks.from_now.to_date),
+          build(:registration_exemption, :revoked, expires_on: 2.weeks.from_now.to_date)
+        ]
+      )
+
+      # Create an expiring registration in a non-active status. Make sure we don't pick it up and send an email.
+      expiring_non_active_registration = create(
+        :registration,
+        registration_exemptions: [
+          build(:registration_exemption, :revoked, expires_on: 2.weeks.from_now.to_date)
+        ]
+      )
+
+      # Create a non-expiring registration in a non-active status. Make sure we don't pick it up and send an email.
+      non_expiring_non_active_registration = create(
+        :registration,
+        registration_exemptions: [
+          build(:registration_exemption, :active, expires_on: 3.weeks.from_now.to_date)
+        ]
+      )
+
+      described_class.run
+
+      expect(TemporaryRenewalReminderEmailService).to have_received(:run).with(registration: active_expiring_registration)
+      expect(TemporaryRenewalReminderEmailService).not_to have_received(:run).with(registration: expiring_non_active_registration)
+      expect(TemporaryRenewalReminderEmailService).not_to have_received(:run).with(registration: non_expiring_non_active_registration)
+    end
+
+    it "does not send emails to blank email addresses" do
+      create(
+        :registration,
+        contact_email: nil,
+        registration_exemptions: [
+          build(:registration_exemption, :active, expires_on: 2.weeks.from_now.to_date),
+          build(:registration_exemption, :revoked, expires_on: 2.weeks.from_now.to_date)
+        ]
+      )
+
+      described_class.run
+
+      expect(TemporaryRenewalReminderEmailService).not_to have_received(:run)
+    end
+
+    it "does not send emails to registrations with the NCCC postcode" do
+      registration = create(
+        :registration,
+        :site_uses_address,
+        registration_exemptions: [
+          build(:registration_exemption, :active, expires_on: 2.weeks.from_now.to_date)
+        ]
+      )
+      registration.site_address.update(postcode: "S9 4WF")
+
+      described_class.run
+
+      expect(TemporaryRenewalReminderEmailService).not_to have_received(:run)
+    end
+
+    it "does not send emails to registrations that have been renewed in the last month" do
+      active_expiring_registration = create(
+        :registration,
+        registration_exemptions: [
+          build(:registration_exemption, :active, expires_on: 2.weeks.from_now.to_date)
+        ]
+      )
+
+      create(:registration, :has_been_renewed, referring_registration: active_expiring_registration)
+
+      described_class.run
+
+      expect(TemporaryRenewalReminderEmailService).not_to have_received(:run)
+    end
+  end
+end

--- a/spec/services/temporary_second_renewal_reminder_service_spec.rb
+++ b/spec/services/temporary_second_renewal_reminder_service_spec.rb
@@ -103,7 +103,19 @@ RSpec.describe TemporarySecondRenewalReminderService do
         ]
       )
 
-      create(:registration, :has_been_renewed, referring_registration: active_expiring_registration)
+      # Create a renewal registration manually instead of using the :has_been_renewed trait
+      create(
+        :registration,
+        submitted_at: 2.weeks.ago,
+        referring_registration_id: active_expiring_registration.id,
+        registration_exemptions: [
+          build(:registration_exemption, :active)
+        ]
+      )
+
+      allow(WasteExemptionsEngine::Registration).to receive(:renewals).and_return(
+        WasteExemptionsEngine::Registration.where(referring_registration_id: active_expiring_registration.id)
+      )
 
       described_class.run
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-3675

- Introduced `TemporaryFirstRenewalReminderService` and `TemporarySecondRenewalReminderService` classes, extending `RenewalReminderServiceBase`, to handle sending of renewal reminder emails that direct users to register again instead of renewing.