### PR TITLE
[RUBY-3658] Fix balance calculation in finance data report presenters

### DIFF
--- a/app/models/reports/finance_data_report/data_serializer.rb
+++ b/app/models/reports/finance_data_report/data_serializer.rb
@@ -64,7 +64,7 @@ module Reports
           order_rows.concat(charge_adjustment_row(registration, charge_adjustment).compact)
         end
         # payment rows
-        registration.account.payments.map do |payment|
+        registration.account.payments.order(date_time: :asc).map do |payment|
           order_rows.concat(payment_row(registration, payment).compact)
         end
         order_rows

--- a/app/presenters/reports/finance_data_report/additional_compliance_charge_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/additional_compliance_charge_row_presenter.rb
@@ -23,7 +23,7 @@ module Reports
       end
 
       def balance
-        @total += @secondary_object.additional_compliance_charge_amount
+        @total -= @secondary_object.additional_compliance_charge_amount
         display_pence_as_pounds_and_pence(pence: @total,
                                           hide_pence_if_zero: true)
       end

--- a/app/presenters/reports/finance_data_report/charge_adjustment_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/charge_adjustment_row_presenter.rb
@@ -12,7 +12,7 @@ module Reports
       end
 
       def balance
-        @total += charge_adjustment_amount
+        @total -= charge_adjustment_amount
         display_pence_as_pounds_and_pence(pence: @total,
                                           hide_pence_if_zero: true)
       end

--- a/app/presenters/reports/finance_data_report/farm_compliance_charge_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/farm_compliance_charge_row_presenter.rb
@@ -18,7 +18,7 @@ module Reports
       end
 
       def balance
-        @total += @secondary_object.bucket_charge_amount
+        @total -= @secondary_object.bucket_charge_amount
         display_pence_as_pounds_and_pence(pence: @total,
                                           hide_pence_if_zero: true)
       end

--- a/app/presenters/reports/finance_data_report/initial_compliance_charge_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/initial_compliance_charge_row_presenter.rb
@@ -23,7 +23,7 @@ module Reports
       end
 
       def balance
-        @total += @secondary_object.initial_compliance_charge_amount
+        @total -= @secondary_object.initial_compliance_charge_amount
         display_pence_as_pounds_and_pence(pence: @total,
                                           hide_pence_if_zero: true)
       end

--- a/app/presenters/reports/finance_data_report/payment_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/payment_row_presenter.rb
@@ -15,23 +15,18 @@ module Reports
       end
 
       def payment_amount
-        display_pence_as_pounds_and_pence(pence: amount_to_deduct, hide_pence_if_zero: true)
+        display_pence_as_pounds_and_pence(pence: amount_to_credit, hide_pence_if_zero: true)
       end
 
       def balance
-        @total -= amount_to_deduct
+        @total += amount_to_credit
         display_pence_as_pounds_and_pence(pence: @total, hide_pence_if_zero: true)
       end
 
       private
 
-      def amount_to_deduct
-        if [WasteExemptionsEngine::Payment::PAYMENT_TYPE_REFUND,
-            WasteExemptionsEngine::Payment::PAYMENT_TYPE_REVERSAL].include?(@secondary_object.payment_type)
-          -@secondary_object.payment_amount
-        else
-          @secondary_object.payment_amount
-        end
+      def amount_to_credit
+        @secondary_object.payment_amount
       end
     end
   end

--- a/app/presenters/reports/finance_data_report/registration_charge_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/registration_charge_row_presenter.rb
@@ -12,7 +12,7 @@ module Reports
       end
 
       def balance
-        @total += @secondary_object.registration_charge_amount
+        @total -= @secondary_object.registration_charge_amount
         display_pence_as_pounds_and_pence(pence: @total,
                                           hide_pence_if_zero: true)
       end

--- a/spec/presenters/reports/finance_data_report/additional_compliance_charge_row_presenter_spec.rb
+++ b/spec/presenters/reports/finance_data_report/additional_compliance_charge_row_presenter_spec.rb
@@ -16,7 +16,7 @@ module Reports
       end
 
       let(:registration) { build(:registration, reference: "REG123", submitted_at: Time.zone.now, account: account) }
-      let(:presenter) { described_class.new(registration: registration, secondary_object: band_charge_detail, total: 1150) }
+      let(:presenter) { described_class.new(registration: registration, secondary_object: band_charge_detail, total: -1150) }
 
       describe "#charge_type" do
         it "returns 'compliance_additional'" do
@@ -59,7 +59,7 @@ module Reports
 
       describe "#balance" do
         it "returns the formatted balance amount" do
-          expect(presenter.balance).to eq("31.50")
+          expect(presenter.balance).to eq("-31.50")
         end
       end
     end

--- a/spec/presenters/reports/finance_data_report/charge_adjustment_row_presenter_spec.rb
+++ b/spec/presenters/reports/finance_data_report/charge_adjustment_row_presenter_spec.rb
@@ -7,7 +7,7 @@ module Reports
     RSpec.describe ChargeAdjustmentRowPresenter do
       let(:charge_adjustment) { build(:charge_adjustment, amount: 1550, adjustment_type: "decrease") }
       let(:registration) { build(:registration, reference: "REG123", submitted_at: Time.zone.now) }
-      let(:presenter) { described_class.new(registration: registration, secondary_object: charge_adjustment, total: 3050) }
+      let(:presenter) { described_class.new(registration: registration, secondary_object: charge_adjustment, total: -3050) }
 
       describe "#charge_type" do
         it "returns 'charge_adjust'" do
@@ -28,12 +28,12 @@ module Reports
 
       describe "#balance" do
         it "returns the formatted balance amount, calculated as the previous balance minus the charge adjustment amount" do
-          expect(presenter.balance).to eq("15")
+          expect(presenter.balance).to eq("-15")
         end
 
         it "returns the formatted balance amount, calculated as the previous balance plus the charge adjustment amount" do
           charge_adjustment.adjustment_type = "increase"
-          expect(presenter.balance).to eq("46")
+          expect(presenter.balance).to eq("-46")
         end
       end
     end

--- a/spec/presenters/reports/finance_data_report/farm_compliance_charge_row_presenter_spec.rb
+++ b/spec/presenters/reports/finance_data_report/farm_compliance_charge_row_presenter_spec.rb
@@ -9,7 +9,7 @@ module Reports
       let(:order) { build(:order, :with_exemptions, bucket: bucket) }
       let(:charge_detail) { build(:charge_detail, order: order, registration_charge_amount: 3150, bucket_charge_amount: 8850) }
       let(:registration) { build(:registration, reference: "REG123", submitted_at: Time.zone.now) }
-      let(:presenter) { described_class.new(registration: registration, secondary_object: charge_detail, total: 1000) }
+      let(:presenter) { described_class.new(registration: registration, secondary_object: charge_detail, total: -1000) }
 
       before do
         bucket.exemptions << order.exemptions.last
@@ -35,7 +35,7 @@ module Reports
 
       describe "#balance" do
         it "returns the formatted balance amount" do
-          expect(presenter.balance).to eq("98.50")
+          expect(presenter.balance).to eq("-98.50")
         end
       end
     end

--- a/spec/presenters/reports/finance_data_report/initial_compliance_charge_row_presenter_spec.rb
+++ b/spec/presenters/reports/finance_data_report/initial_compliance_charge_row_presenter_spec.rb
@@ -16,7 +16,7 @@ module Reports
       end
 
       let(:registration) { build(:registration, reference: "REG123", submitted_at: Time.zone.now, account: account) }
-      let(:presenter) { described_class.new(registration: registration, secondary_object: band_charge_detail, total: 1000) }
+      let(:presenter) { described_class.new(registration: registration, secondary_object: band_charge_detail, total: -1000) }
 
       describe "#charge_type" do
         it "returns 'compliance_initial'" do
@@ -62,7 +62,7 @@ module Reports
 
       describe "#balance" do
         it "returns the formatted balance amount" do
-          expect(presenter.balance).to eq("20")
+          expect(presenter.balance).to eq("-20")
         end
       end
     end

--- a/spec/presenters/reports/finance_data_report/payment_row_presenter_spec.rb
+++ b/spec/presenters/reports/finance_data_report/payment_row_presenter_spec.rb
@@ -9,7 +9,7 @@ module Reports
       let(:order) { build(:order, :with_exemptions, :with_charge_detail, order_owner: account) }
 
       let(:registration) { build(:registration, reference: "REG123", submitted_at: Time.zone.now, account: account) }
-      let(:presenter) { described_class.new(registration: registration, secondary_object: account.payments.first, total: 3050) }
+      let(:presenter) { described_class.new(registration: registration, secondary_object: account.payments.first, total: -3050) }
 
       describe "#payment_type" do
         it "returns payment type" do
@@ -40,12 +40,12 @@ module Reports
         end
 
         it "shows the negative amount when payment type is refund" do
-          account.payments.first.update(payment_type: "refund")
+          account.payments.first.update(payment_type: "refund", payment_amount: -1000)
           expect(presenter.payment_amount).to eq("-10")
         end
 
         it "shows the negative amount when payment type is reversal" do
-          account.payments.first.update(payment_type: "reversal")
+          account.payments.first.update(payment_type: "reversal", payment_amount: -1000)
           expect(presenter.payment_amount).to eq("-10")
         end
       end
@@ -53,12 +53,12 @@ module Reports
       describe "#balance" do
         it "returns the formatted balance amount, calculated as the previous balance minus amount paid" do
           account.payments.first.update(payment_type: "bank_transfer")
-          expect(presenter.balance).to eq("20.50")
+          expect(presenter.balance).to eq("-20.50")
         end
 
         it "returns the formatted balance amount, calculated as the previous balance plus the amount refunded" do
-          account.payments.first.update(payment_type: "refund")
-          expect(presenter.balance).to eq("40.50")
+          account.payments.first.update(payment_type: "refund", payment_amount: -1000)
+          expect(presenter.balance).to eq("-40.50")
         end
       end
     end

--- a/spec/presenters/reports/finance_data_report/registration_charge_row_presenter_spec.rb
+++ b/spec/presenters/reports/finance_data_report/registration_charge_row_presenter_spec.rb
@@ -7,7 +7,7 @@ module Reports
     RSpec.describe RegistrationChargeRowPresenter do
       let(:charge_detail) { build(:charge_detail, registration_charge_amount: 3150) }
       let(:registration) { build(:registration, reference: "REG123", submitted_at: Time.zone.now) }
-      let(:presenter) { described_class.new(registration: registration, secondary_object: charge_detail, total: 1000) }
+      let(:presenter) { described_class.new(registration: registration, secondary_object: charge_detail, total: -1000) }
 
       describe "#charge_type" do
         it "returns 'registration'" do
@@ -23,7 +23,7 @@ module Reports
 
       describe "#balance" do
         it "returns the formatted balance amount" do
-          expect(presenter.balance).to eq("41.50")
+          expect(presenter.balance).to eq("-41.50")
         end
       end
     end


### PR DESCRIPTION
Some minor fixes for Finance Data export:
- The balance should show as negative when the registration is in debt
- A reversal should debit the registration (the same amount as been credited by the payment)
- A refund should debit the registration

https://eaflood.atlassian.net/browse/RUBY-3658