### PR TITLE
Fix/ruby 3712 wex finance export refunds are missing refund type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: d3847272fdb68f5a21e12a722780da2ed7902252
+  revision: febc2ac26cc5a03927453145a2c75a12c6cd48be
   branch: main
   specs:
     waste_exemptions_engine (0.1.0)
@@ -350,7 +350,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.4)
-    nokogiri (1.18.6)
+    nokogiri (1.18.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notifications-ruby-client (6.2.0)
@@ -439,7 +439,7 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     rbtree3 (0.7.1)
-    rdoc (6.13.0)
+    rdoc (6.13.1)
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
     reline (0.6.0)

--- a/app/presenters/reports/finance_data_report/payment_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/payment_row_presenter.rb
@@ -23,7 +23,9 @@ module Reports
         return unless @secondary_object.payment_type == WasteExemptionsEngine::Payment::PAYMENT_TYPE_REFUND
         return if @secondary_object.associated_payment_id.nil?
 
-        associated_payment = WasteExemptionsEngine::Payment.find(@secondary_object.associated_payment_id)
+        associated_payment = WasteExemptionsEngine::Payment.find_by(id: @secondary_object.associated_payment_id)
+        return if associated_payment.nil?
+
         formatted_payment_type(associated_payment.payment_type, @registration.assistance_mode)
       end
 

--- a/app/presenters/reports/finance_data_report/payment_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/payment_row_presenter.rb
@@ -7,11 +7,7 @@ module Reports
       delegate :reference, to: :@secondary_object
 
       def payment_type
-        if @secondary_object.payment_type == WasteExemptionsEngine::Payment::PAYMENT_TYPE_GOVPAY
-          @registration.assistance_mode == "full" ? "card(moto)" : "card"
-        else
-          @secondary_object.payment_type
-        end
+        formatted_payment_type(@secondary_object.payment_type, @registration.assistance_mode)
       end
 
       def payment_amount
@@ -23,10 +19,26 @@ module Reports
         display_pence_as_pounds_and_pence(pence: @total, hide_pence_if_zero: true)
       end
 
+      def refund_type
+        return unless @secondary_object.payment_type == WasteExemptionsEngine::Payment::PAYMENT_TYPE_REFUND
+        return if @secondary_object.associated_payment_id.nil?
+
+        associated_payment = WasteExemptionsEngine::Payment.find(@secondary_object.associated_payment_id)
+        formatted_payment_type(associated_payment.payment_type, @registration.assistance_mode)
+      end
+
       private
 
       def amount_to_credit
         @secondary_object.payment_amount
+      end
+
+      def formatted_payment_type(payment_type, assistance_mode)
+        if payment_type == WasteExemptionsEngine::Payment::PAYMENT_TYPE_GOVPAY
+          assistance_mode == "full" ? "card(moto)" : "card"
+        else
+          payment_type
+        end
       end
     end
   end

--- a/spec/forms/add_payment_form_spec.rb
+++ b/spec/forms/add_payment_form_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe AddPaymentForm, type: :model do
         expect(payment.payment_type).to eq("bank_transfer")
         expect(payment.payment_amount).to eq(9326)
         expect(payment.payment_status).to eq(WasteExemptionsEngine::Payment::PAYMENT_STATUS_SUCCESS)
-        expect(payment.date_time).to eq(date)
+        expect(payment.date_time.to_date).to eq(date)
         expect(payment.payment_uuid).not_to be_nil
         expect(payment.reference).to eq("1234567890")
         expect(payment.account).to eq(account)

--- a/spec/presenters/reports/finance_data_report/payment_row_presenter_spec.rb
+++ b/spec/presenters/reports/finance_data_report/payment_row_presenter_spec.rb
@@ -61,6 +61,29 @@ module Reports
           expect(presenter.balance).to eq("-40.50")
         end
       end
+
+      describe "#refund_type" do
+        let(:associated_payment) { create(:payment, associated_payment: account.payments.first) }
+
+        before do
+          account.payments << associated_payment
+          account.payments.first.update(payment_type: "refund", associated_payment: associated_payment)
+        end
+
+        it "returns associated payment type" do
+          associated_payment.update(payment_type: "bank_transfer")
+          expect(presenter.refund_type).to eq("bank_transfer")
+        end
+
+        it "returns card when associated payment type is govpay_payment" do
+          expect(presenter.refund_type).to eq("card")
+        end
+
+        it "returns card(moto) when associated payment type is govpay_payment and journey is assisted" do
+          registration.update(assistance_mode: "full")
+          expect(presenter.refund_type).to eq("card(moto)")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Adding missing refund type to finance Data report
https://eaflood.atlassian.net/browse/RUBY-3712