### PR TITLE
Feature/ruby 3745 wex fo record email address of self serve edit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: febc2ac26cc5a03927453145a2c75a12c6cd48be
+  revision: e58979a1c3307a7f0da2a62356da0047e59eb279
   branch: main
   specs:
     waste_exemptions_engine (0.1.0)
@@ -333,7 +333,7 @@ GEM
     mime-types (3.6.2)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0325)
+    mime-types-data (3.2025.0402)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
     minitest (5.25.5)

--- a/app/services/registration_change_history_service.rb
+++ b/app/services/registration_change_history_service.rb
@@ -72,6 +72,12 @@ class RegistrationChangeHistoryService < WasteExemptionsEngine::BaseService
     return "System" unless version.whodunnit
     return "Public user" if version.whodunnit == "public user"
 
-    User.find(version.whodunnit).email
+    identifier?(version.whodunnit) ? User.find(version.whodunnit).email : version.whodunnit
+  end
+
+  def identifier?(whodunnit)
+    true if Integer(whodunnit)
+  rescue StandardError
+    false
   end
 end

--- a/spec/services/analytics/private_beta_page_dwell_times_service_spec.rb
+++ b/spec/services/analytics/private_beta_page_dwell_times_service_spec.rb
@@ -18,7 +18,7 @@ module Analytics
       let(:created_at) { start_date + 1.day }
 
       # Set a fixed time value from which to start measuring page times
-      let(:start_time) { 1.week.ago }
+      let(:start_time) { 1.day.ago }
 
       include_context "with user journeys with timed page views"
 

--- a/spec/services/registration_change_history_service_spec.rb
+++ b/spec/services/registration_change_history_service_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe RegistrationChangeHistoryService do
       expect(service_response.last[:changed_by]).to eq("developer@wex.gov.uk")
     end
 
-    it "displays Changed By corretly when whodunnit is user id" do
+    it "displays Changed By correctly when whodunnit is user id" do
       PaperTrail.request.whodunnit = user.id
       registration.update(contact_first_name: "Jane")
 

--- a/spec/services/registration_change_history_service_spec.rb
+++ b/spec/services/registration_change_history_service_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe RegistrationChangeHistoryService do
       expect(service_response.last[:changed_by]).to eq("developer@wex.gov.uk")
     end
 
-    it "displays Changed By corretly when whodunnit is nil" do
+    it "displays Changed By correctly when whodunnit is nil" do
       PaperTrail.request.whodunnit = nil
       registration.update(contact_first_name: "Jane")
 

--- a/spec/services/registration_change_history_service_spec.rb
+++ b/spec/services/registration_change_history_service_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe RegistrationChangeHistoryService do
       expect(service_response.last[:changed_by]).to eq("System")
     end
 
-    it "displays Changed By corretly when whodunnit is email address" do
+    it "displays Changed By correctly when whodunnit is email address" do
       PaperTrail.request.whodunnit = "developer@wex.gov.uk"
       registration.update(contact_first_name: "Jane")
 

--- a/spec/services/registration_change_history_service_spec.rb
+++ b/spec/services/registration_change_history_service_spec.rb
@@ -91,11 +91,25 @@ RSpec.describe RegistrationChangeHistoryService do
       expect(service_response.last[:changed_by]).to eq("developer@wex.gov.uk")
     end
 
-    it "handles system changes when whodunnit is nil" do
+    it "displays Changed By corretly when whodunnit is nil" do
       PaperTrail.request.whodunnit = nil
       registration.update(contact_first_name: "Jane")
 
       expect(service_response.last[:changed_by]).to eq("System")
+    end
+
+    it "displays Changed By corretly when whodunnit is email address" do
+      PaperTrail.request.whodunnit = "developer@wex.gov.uk"
+      registration.update(contact_first_name: "Jane")
+
+      expect(service_response.last[:changed_by]).to eq("developer@wex.gov.uk")
+    end
+
+    it "displays Changed By corretly when whodunnit is user id" do
+      PaperTrail.request.whodunnit = user.id
+      registration.update(contact_first_name: "Jane")
+
+      expect(service_response.last[:changed_by]).to eq("developer@wex.gov.uk")
     end
 
     it "excludes updated_at and reason_for_change from the changesets" do


### PR DESCRIPTION
Record email address of self-serve edit
https://eaflood.atlassian.net/browse/RUBY-3745
1. Update waste-exemptions-engine to use the latest revision
2. Refactor RegistrationChangeHistoryService to handle different types of whodunnit values