### PR TITLE
Refactor the way reason_for_change is shown in RegistrationChangeHistoryService

### DIFF
--- a/app/services/registration_change_history_service.rb
+++ b/app/services/registration_change_history_service.rb
@@ -65,7 +65,7 @@ class RegistrationChangeHistoryService < WasteExemptionsEngine::BaseService
   end
 
   def reason_for_change(version)
-    version.changeset[:reason_for_change]&.last || nil
+    (version.next.present? ? version.next.reify.reason_for_change : version.item.reason_for_change) || nil
   end
 
   def changed_by(version)

--- a/spec/services/registration_change_history_service_spec.rb
+++ b/spec/services/registration_change_history_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RegistrationChangeHistoryService do
       # Create versions with changes
 
       # 2nd version
-      registration.update(contact_first_name: "Johnny", contact_last_name: "Smiths", contact_position: "Manager")
+      registration.update(contact_first_name: "Johnny", contact_last_name: "Smiths", contact_position: "Manager", reason_for_change: "Fixing the typo in name")
       # 3rd version
       registration.update(contact_first_name: "John", contact_last_name: "Smith", contact_position: "Senior Manager", reason_for_change: "Fixing the typo in name")
     end
@@ -85,6 +85,11 @@ RSpec.describe RegistrationChangeHistoryService do
 
     it "includes the correct reason_for_change value" do
       expect(service_response.last[:reason_for_change]).to eq("Fixing the typo in name")
+    end
+
+    it "includes the correct reason_for_change value for each version even reason text hasn't changed" do
+      expect(service_response[2][:reason_for_change]).to eq("Fixing the typo in name")
+      expect(service_response[3][:reason_for_change]).to eq("Fixing the typo in name")
     end
 
     it "includes the correct changed_by value" do


### PR DESCRIPTION
Refactored RegistrationChangeHistoryService to handle repeated reason_for_change in version history