### PR TITLE
Update passenger gem version constraints to exclude 6.0.27

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ group :production do
   # and problem diagnosis. It is used in production because it gives us an ability
   # to scale by creating additional processes, and will automatically restart any
   # that fail. We don't use it when running tests for speed's sake.
-  gem "passenger", "~> 6.0", "!= 6.0.23", require: "phusion_passenger/rack_handler"
+  gem "passenger", "~> 6.0", "!= 6.0.23", "!= 6.0.27", require: "phusion_passenger/rack_handler"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -629,7 +629,7 @@ DEPENDENCIES
   net-smtp
   notifications-ruby-client
   paper_trail
-  passenger (~> 6.0, != 6.0.23)
+  passenger (~> 6.0, != 6.0.27, != 6.0.23)
   pg
   pgreset
   pry-byebug


### PR DESCRIPTION
Exclude passenger version 6.0.27 to avoid compatibility issues with rackup