### PR TITLE
Feature/ruby 3744 hide initial versions from change history page

### DIFF
--- a/app/services/registration_change_history_service.rb
+++ b/app/services/registration_change_history_service.rb
@@ -37,7 +37,9 @@ class RegistrationChangeHistoryService < WasteExemptionsEngine::BaseService
   ].freeze
 
   def run(registration)
-    registration.versions.where.not(event: "create").includes(:item).map do |version|
+    # exclude first 3 versions as they are the initial create events
+    versions_ids_to_exclude = registration.versions.first(3).map(&:id)
+    registration.versions.where.not(id: versions_ids_to_exclude).includes(:item).map do |version|
       version_changes(version)
     end.compact
   end

--- a/app/services/registration_change_history_service.rb
+++ b/app/services/registration_change_history_service.rb
@@ -57,7 +57,7 @@ class RegistrationChangeHistoryService < WasteExemptionsEngine::BaseService
 
   def find_placeholder_change_version(registration)
     registration.versions.find do |v|
-      v.object_changes.include?("placeholder") &&
+      v.object_changes&.include?("placeholder") &&
         v.object_changes["placeholder"][0] == true &&
         v.object_changes["placeholder"][1] == false
     end

--- a/app/services/registration_change_history_service.rb
+++ b/app/services/registration_change_history_service.rb
@@ -37,14 +37,31 @@ class RegistrationChangeHistoryService < WasteExemptionsEngine::BaseService
   ].freeze
 
   def run(registration)
-    # exclude first 3 versions as they are the initial create events
-    versions_ids_to_exclude = registration.versions.first(3).map(&:id)
-    registration.versions.where.not(id: versions_ids_to_exclude).includes(:item).map do |version|
+    # exclude all versions up until placeholder value gets changed from true to false
+    # but no more than 3 versions
+    ids_to_exclude = version_ids_to_exclude(registration)
+    registration.versions.where.not(id: ids_to_exclude).includes(:item).map do |version|
       version_changes(version)
     end.compact
   end
 
   private
+
+  def version_ids_to_exclude(registration)
+    placeholder_change_version = find_placeholder_change_version(registration)
+    # return first 3 versions if placeholder_change_version is nil
+    return registration.versions.first(3).map(&:id) unless placeholder_change_version
+
+    registration.versions.select { |v| v.id <= placeholder_change_version.id }.map(&:id)
+  end
+
+  def find_placeholder_change_version(registration)
+    registration.versions.find do |v|
+      v.object_changes.include?("placeholder") &&
+        v.object_changes["placeholder"][0] == true &&
+        v.object_changes["placeholder"][1] == false
+    end
+  end
 
   def version_changes(version)
     return if version.changeset.nil?

--- a/config/locales/change_history.en.yml
+++ b/config/locales/change_history.en.yml
@@ -5,7 +5,7 @@ en:
       heading: "Change history"
       date: "Date"
       changed_to: "Updated details"
-      changed_from: "Changed from"
+      changed_from: "Previous details"
       reason_for_change: "Reason for change"
       changed_by: "Changed by"
       view_registration: "View registration"

--- a/spec/requests/change_history_spec.rb
+++ b/spec/requests/change_history_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe "Change History" do
   describe "GET /bo/registrations/:reference/change_history/", :versioning do
     context "when change history is present" do
       before do
+        # Initial registration settings that will be ignored
+        registration.update(placeholder: true)
+        registration.update(reference: "WEX123", placeholder: false)
+        # Registration change
         registration.update(contact_first_name: "Johnny", contact_last_name: "Smith", contact_position: "Manager")
       end
 
@@ -37,7 +41,7 @@ RSpec.describe "Change History" do
         expect(response).to render_template(:index)
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Change history")
-        expect(response.body).to include("System")
+        expect(response.body).not_to include("System")
       end
     end
 

--- a/spec/services/registration_change_history_service_spec.rb
+++ b/spec/services/registration_change_history_service_spec.rb
@@ -12,7 +12,11 @@ RSpec.describe RegistrationChangeHistoryService do
       PaperTrail.request.whodunnit = user.id
 
       # Create versions with changes
-
+      #
+      # Initial registration settings
+      registration.update(placeholder: true)
+      # 1st version
+      registration.update(reference: "WEX123", placeholder: false)
       # 2nd version
       registration.update(contact_first_name: "Johnny", contact_last_name: "Smiths", contact_position: "Manager", reason_for_change: "Fixing the typo in name")
       # 3rd version

--- a/spec/services/registration_change_history_service_spec.rb
+++ b/spec/services/registration_change_history_service_spec.rb
@@ -5,23 +5,22 @@ require "rails_helper"
 RSpec.describe RegistrationChangeHistoryService do
   describe ".run", :versioning do
     let(:user) { create(:user, email: "developer@wex.gov.uk") }
-    let(:registration) { create(:registration) }
-    let(:service_response) { described_class.run(registration) }
-
-    before do
-      PaperTrail.request.whodunnit = user.id
-
-      # Create versions with changes
-      #
-      # Initial registration settings
-      registration.update(placeholder: true)
+    let(:registration) do
+      reg = build(:registration, placeholder: true)
       # 1st version
-      registration.update(reference: "WEX123", placeholder: false)
+      reg.save(validate: false)
       # 2nd version
-      registration.update(contact_first_name: "Johnny", contact_last_name: "Smiths", contact_position: "Manager", reason_for_change: "Fixing the typo in name")
+      # the reference gets set automatically by the system
+      # fter the registration is created
       # 3rd version
-      registration.update(contact_first_name: "John", contact_last_name: "Smith", contact_position: "Senior Manager", reason_for_change: "Fixing the typo in name")
+      reg.update(applicant_first_name: "Firstcontact1", placeholder: false)
+      # 4th version
+      reg.update(contact_first_name: "Johnny", contact_last_name: "Smiths", contact_position: "Manager", reason_for_change: "Fixing the typo in name")
+      # 5th version
+      reg.update(contact_first_name: "John", contact_last_name: "Smith", contact_position: "Senior Manager", reason_for_change: "Fixing the typo in name")
+      reg
     end
+    let(:service_response) { described_class.run(registration) }
 
     it "has PaperTrail" do
       expect(PaperTrail).to be_enabled
@@ -38,8 +37,40 @@ RSpec.describe RegistrationChangeHistoryService do
       end
     end
 
-    it "does not include create events" do
-      expect(service_response.length).to eq(3)
+    context "when placeholder is present (newer registrations)" do
+      it "excludes versions before the placeholder change" do
+        expect(service_response.length).to eq(2)
+        expect(service_response[0][:changed][0][1]).not_to eq(%w[reference applicant_first_name])
+        expect(service_response[1][:changed][0][1]).not_to eq(%w[reference applicant_first_name])
+      end
+
+      it "excludes versions with placeholder change" do
+        expect(service_response.map { |v| v[:changed] }).not_to include(["~", "placeholder", true, false])
+      end
+    end
+
+    context "when placeholder is not present (older registrations)" do
+      let(:registration) do
+        reg = build(:registration, placeholder: nil)
+        # 1st version
+        reg.save(validate: false)
+        # 2nd version
+        # the reference gets set automatically by the system
+        # fter the registration is created
+        # 3nd version
+        reg.update(reference: "WEX123")
+        # 4th version
+        reg.update(contact_first_name: "Johnny", contact_last_name: "Smiths", contact_position: "Manager", reason_for_change: "Fixing the typo in name")
+        # 5th version
+        reg.update(contact_first_name: "John", contact_last_name: "Smith", contact_position: "Senior Manager", reason_for_change: "Fixing the typo in name")
+        reg
+      end
+
+      it "excludes first 3 versions" do
+        changeset = service_response
+        expect(service_response.length).to eq(2)
+        expect(changeset[0][:changed][0][1]).to eq("contact_first_name")
+      end
     end
 
     context "when several versions" do
@@ -57,24 +88,15 @@ RSpec.describe RegistrationChangeHistoryService do
       end
 
       it "returns correct changes for the previous version" do
-        second = service_response[1]
-
-        aggregate_failures do
-          expect(second[:date]).to be_present
-          expect(second[:changed]).to include(
-            ["~", "contact_first_name", a_string_matching(/^Firstcontact\d+$/), "Johnny"],
-            ["~", "contact_last_name", a_string_matching(/^Lastcontact\d+$/), "Smiths"],
-            ["+", "contact_position", "", "Manager"]
-          )
-        end
-      end
-
-      it "returns correct changes for the oldest version" do
         first = service_response[0]
 
         aggregate_failures do
           expect(first[:date]).to be_present
-          expect(first[:changed][0]).to include("reference")
+          expect(first[:changed]).to include(
+            ["~", "contact_first_name", a_string_matching(/^Firstcontact\d+$/), "Johnny"],
+            ["~", "contact_last_name", a_string_matching(/^Lastcontact\d+$/), "Smiths"],
+            ["+", "contact_position", "", "Manager"]
+          )
         end
       end
     end
@@ -94,17 +116,17 @@ RSpec.describe RegistrationChangeHistoryService do
     end
 
     it "includes the correct reason_for_change value for each version even reason text hasn't changed" do
+      expect(service_response[0][:reason_for_change]).to eq("Fixing the typo in name")
       expect(service_response[1][:reason_for_change]).to eq("Fixing the typo in name")
-      expect(service_response[2][:reason_for_change]).to eq("Fixing the typo in name")
     end
 
     it "includes the correct changed_by value" do
-      expect(service_response.last[:changed_by]).to eq("developer@wex.gov.uk")
+      expect(service_response.last[:changed_by]).to eq("System")
     end
 
     it "displays Changed By correctly when whodunnit is nil" do
       PaperTrail.request.whodunnit = nil
-      registration.update(contact_first_name: "Jane")
+      registration.update(contact_first_name: "Jane", reason_for_change: "Updating contact_first_name")
 
       expect(service_response.last[:changed_by]).to eq("System")
     end


### PR DESCRIPTION
Minor adjustments for 
https://eaflood.atlassian.net/browse/RUBY-3744

1. Initial registration changes have been excluded from the change history page
2. Changed label in change history page