### PR TITLE
Refactor version exclusion logic in RegistrationChangeHistoryService

### DIFF
--- a/app/services/registration_change_history_service.rb
+++ b/app/services/registration_change_history_service.rb
@@ -38,7 +38,7 @@ class RegistrationChangeHistoryService < WasteExemptionsEngine::BaseService
 
   def run(registration)
     # exclude all versions up until placeholder value gets changed from true to false
-    # but no more than 3 versions
+    # but no more than 2 versions
     ids_to_exclude = version_ids_to_exclude(registration)
     registration.versions.where.not(id: ids_to_exclude).includes(:item).map do |version|
       version_changes(version)
@@ -49,8 +49,8 @@ class RegistrationChangeHistoryService < WasteExemptionsEngine::BaseService
 
   def version_ids_to_exclude(registration)
     placeholder_change_version = find_placeholder_change_version(registration)
-    # return first 3 versions if placeholder_change_version is nil
-    return registration.versions.first(3).map(&:id) unless placeholder_change_version
+    # return first 2 versions if placeholder_change_version is nil
+    return registration.versions.first(2).map(&:id) unless placeholder_change_version
 
     registration.versions.select { |v| v.id <= placeholder_change_version.id }.map(&:id)
   end

--- a/spec/services/registration_change_history_service_spec.rb
+++ b/spec/services/registration_change_history_service_spec.rb
@@ -55,9 +55,9 @@ RSpec.describe RegistrationChangeHistoryService do
         # 2nd version
         # the reference gets set automatically by the system
         # fter the registration is created
-        # 4th version
+        # 43h version
         reg.update(contact_first_name: "Johnny", contact_last_name: "Smiths", contact_position: "Manager", reason_for_change: "Fixing the typo in name")
-        # 5th version
+        # 4th version
         reg.update(contact_first_name: "John", contact_last_name: "Smith", contact_position: "Senior Manager", reason_for_change: "Fixing the typo in name")
         reg
       end

--- a/spec/services/registration_change_history_service_spec.rb
+++ b/spec/services/registration_change_history_service_spec.rb
@@ -12,11 +12,9 @@ RSpec.describe RegistrationChangeHistoryService do
       # 2nd version
       # the reference gets set automatically by the system
       # fter the registration is created
-      # 3rd version
-      reg.update(applicant_first_name: "Firstcontact1", placeholder: false)
-      # 4th version
+      # 3th version
       reg.update(contact_first_name: "Johnny", contact_last_name: "Smiths", contact_position: "Manager", reason_for_change: "Fixing the typo in name")
-      # 5th version
+      # 4th version
       reg.update(contact_first_name: "John", contact_last_name: "Smith", contact_position: "Senior Manager", reason_for_change: "Fixing the typo in name")
       reg
     end
@@ -57,8 +55,6 @@ RSpec.describe RegistrationChangeHistoryService do
         # 2nd version
         # the reference gets set automatically by the system
         # fter the registration is created
-        # 3nd version
-        reg.update(reference: "WEX123")
         # 4th version
         reg.update(contact_first_name: "Johnny", contact_last_name: "Smiths", contact_position: "Manager", reason_for_change: "Fixing the typo in name")
         # 5th version
@@ -66,7 +62,7 @@ RSpec.describe RegistrationChangeHistoryService do
         reg
       end
 
-      it "excludes first 3 versions" do
+      it "excludes first 2 versions" do
         changeset = service_response
         expect(service_response.length).to eq(2)
         expect(changeset[0][:changed][0][1]).to eq("contact_first_name")

--- a/spec/services/registration_change_history_service_spec.rb
+++ b/spec/services/registration_change_history_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RegistrationChangeHistoryService do
       # 2nd version
       # the reference gets set automatically by the system
       # fter the registration is created
-      # 3th version
+      # 3rd version
       reg.update(contact_first_name: "Johnny", contact_last_name: "Smiths", contact_position: "Manager", reason_for_change: "Fixing the typo in name")
       # 4th version
       reg.update(contact_first_name: "John", contact_last_name: "Smith", contact_position: "Senior Manager", reason_for_change: "Fixing the typo in name")
@@ -55,7 +55,7 @@ RSpec.describe RegistrationChangeHistoryService do
         # 2nd version
         # the reference gets set automatically by the system
         # fter the registration is created
-        # 43h version
+        # 3rd version
         reg.update(contact_first_name: "Johnny", contact_last_name: "Smiths", contact_position: "Manager", reason_for_change: "Fixing the typo in name")
         # 4th version
         reg.update(contact_first_name: "John", contact_last_name: "Smith", contact_position: "Senior Manager", reason_for_change: "Fixing the typo in name")


### PR DESCRIPTION
Update version exclusion logic to limit to 2 versions in registration change history