### PR TITLE
fix/RUBY-3761_bands

### DIFF
--- a/spec/requests/testing_spec.rb
+++ b/spec/requests/testing_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe "Testing" do
   end
 
   describe "/create_registration" do
+    include_context "with bands and charges"
+
     let(:expiry_date) { 2.days.from_now.strftime("%Y-%m-%d") }
 
     context "when in a non-production environment" do
@@ -77,7 +79,12 @@ RSpec.describe "Testing" do
       end
 
       it "calculates the account balance" do
-        get "/testing/create_registration/#{expiry_date}"
+        exemption_codes = [
+          create(:exemption, code: "U1", band: band_1),
+          create(:exemption, code: "U2", band: band_2),
+          create(:exemption, code: "U3", band: band_3)
+        ].map(&:code)
+        get "/testing/create_registration/#{expiry_date}", params: { exemptions: exemption_codes }
 
         expect(registration.account.balance).to be_negative
       end

--- a/spec/support/shared_contexts/bands_and_charges.rb
+++ b/spec/support/shared_contexts/bands_and_charges.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "with bands and charges" do
+  let!(:registration_charge_entity) { create(:charge, :registration_charge) }
+  let(:registration_charge_amount) { registration_charge_entity.charge_amount }
+
+  # rubocop:disable RSpec/IndexedLet,RSpec/LetSetup,Naming/VariableNumber
+  let!(:band_1) do
+    create(:band,
+           initial_compliance_charge: build(:charge, :initial_compliance_charge, charge_amount: 5),
+           additional_compliance_charge: build(:charge, :additional_compliance_charge, charge_amount: 5))
+  end
+  let!(:band_2) do
+    create(:band,
+           initial_compliance_charge: build(:charge, :initial_compliance_charge, charge_amount: 7),
+           additional_compliance_charge: build(:charge, :additional_compliance_charge, charge_amount: 5))
+  end
+  let!(:band_3) do
+    create(:band,
+           initial_compliance_charge: build(:charge, :initial_compliance_charge, charge_amount: 10),
+           additional_compliance_charge: build(:charge, :additional_compliance_charge, charge_amount: 7))
+  end
+  # rubocop:enable RSpec/IndexedLet,RSpec/LetSetup,Naming/VariableNumber
+end


### PR DESCRIPTION
The create_registration test helper was using the charge_detail factory. This had the side-effect of adding bands each time the helper was called. This change uses OrderCalculator instead.
https://eaflood.atlassian.net/browse/RUBY-3761