### PR TITLE
Downgrade GitHub Actions runner from Ubuntu 24.04 to 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   build:
     # You must use a Linux environment when using service containers or container jobs
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-20.04
     env:
       ADDRESS_FACADE_CLIENT_ID: ${{ secrets.ACTIONS_ADDRESS_FACADE_CLIENT_ID }}
       ADDRESS_FACADE_CLIENT_KEY: ${{ secrets.ACTIONS_ADDRESS_FACADE_CLIENT_KEY }}


### PR DESCRIPTION
Updated the `runs-on` field in the CI workflow to use `ubuntu-20.04` instead of `ubuntu-24.04` for better compatibility.
