### PR TITLE
[RUBY-3764] Update waste_exemptions_engine branch and improve EA Public Face Area data loading

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem "sucker_punch", "~> 3.2"
 # Use the waste exemptions engine for the user journey from the local repo
 gem "waste_exemptions_engine",
     git: "https://github.com/DEFRA/waste-exemptions-engine",
-    branch: "main"
+    branch: "RUBY-3764-wex-charging-implement-geospatial-ea-area-lookup"
 
 # for handling EA Areas GeoJSON data
 gem "rgeo-geojson"

--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem "sucker_punch", "~> 3.2"
 # Use the waste exemptions engine for the user journey from the local repo
 gem "waste_exemptions_engine",
     git: "https://github.com/DEFRA/waste-exemptions-engine",
-    branch: "RUBY-3764-wex-charging-implement-geospatial-ea-area-lookup"
+    branch: "main"
 
 # for handling EA Areas GeoJSON data
 gem "rgeo-geojson"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: 9d15140bfa68c312d0862034cce2f9d05cefe0e8
-  branch: main
+  revision: 3e9ab1d58844b441cfd27bd2406a3189217428c0
+  branch: RUBY-3764-wex-charging-implement-geospatial-ea-area-lookup
   specs:
     waste_exemptions_engine (0.1.0)
       aasm (~> 5.5)
@@ -13,6 +13,7 @@ GIT
       defra_ruby_email
       defra_ruby_govpay
       defra_ruby_validators (~> 3.0)
+      ffi-geos (~> 1.2.0)
       high_voltage (~> 3.1)
       notifications-ruby-client
       os_map_ref (~> 0.5)
@@ -272,6 +273,8 @@ GEM
     faraday-retry (2.3.2)
       faraday (~> 2.0)
     ffi (1.17.0)
+    ffi-geos (1.2.2)
+      ffi (>= 1.0.0)
     fiber-annotation (0.2.0)
     fiber-local (1.1.0)
       fiber-storage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: 3e9ab1d58844b441cfd27bd2406a3189217428c0
+  revision: 663940308db2a2ba764c7a071d8941c8898fed5c
   branch: RUBY-3764-wex-charging-implement-geospatial-ea-area-lookup
   specs:
     waste_exemptions_engine (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: 663940308db2a2ba764c7a071d8941c8898fed5c
-  branch: RUBY-3764-wex-charging-implement-geospatial-ea-area-lookup
+  revision: b0ca1d59410294efd85ad4e68249dd114d2fee8a
+  branch: main
   specs:
     waste_exemptions_engine (0.1.0)
       aasm (~> 5.5)
@@ -391,7 +391,7 @@ GEM
       rake (>= 0.8.1)
     pg (1.5.9)
     pgreset (0.4)
-    phonelib (0.10.10)
+    phonelib (0.10.11)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)

--- a/app/services/ea_public_face_area_data_load_service.rb
+++ b/app/services/ea_public_face_area_data_load_service.rb
@@ -10,19 +10,21 @@ class EaPublicFaceAreaDataLoadService < WasteExemptionsEngine::BaseService
     ActiveRecord::Base.transaction do
 
       features.each do |feature|
+        next if feature.properties["seaward"] == "Yes"
+
         attributes = {
           name: feature.properties["long_name"],
           area_id: feature.properties["identifier"],
           area: feature.geometry
         }
 
-        area = WasteExemptionsEngine::EaPublicFaceArea.where(code: feature["code"]).first
+        area = WasteExemptionsEngine::EaPublicFaceArea.where(code: feature.properties["code"]).first
 
         if area.present?
           area.update(attributes)
           puts "Updated EA Public Face Area \"#{area.code}\" (#{area.name})" unless Rails.env.test? # rubocop:disable Rails/Output
         else
-          area = WasteExemptionsEngine::EaPublicFaceArea.create(attributes.merge(code: feature["code"]))
+          area = WasteExemptionsEngine::EaPublicFaceArea.create(attributes.merge(code: feature.properties["code"]))
           puts "Created EA Public Face Area \"#{area.code}\" (#{area.name})" unless Rails.env.test? # rubocop:disable Rails/Output
         end
       end

--- a/lib/tasks/load_admin_areas.rake
+++ b/lib/tasks/load_admin_areas.rake
@@ -2,7 +2,10 @@
 
 desc "Load administrative boundary definitions"
 task load_admin_areas: :environment do
-  EaPublicFaceAreaDataLoadService.run
+  results = EaPublicFaceAreaDataLoadService.run
+  results.each do |result|
+    puts "#{result[:action].capitalize} EA Public Face Area \"#{result[:code]}\" (#{result[:name]})"
+  end
 rescue StandardError => e
   puts "Error loading Administrative areas: #{e}\n#{e.backtrace}"
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-3764
- Update gemfile to version of engine with ffi-geos
- Changed `EaPublicFaceAreaDataLoadService` to skip features marked as seaward (keep the land based features). The feature zip file contains duplicates of some of the regions which include an offshore and onshore version of some areas, before they were getting arbitrarily replaced based on the order of the file

