### PR TITLE
[RUBY-3932] Filter finance export to include only successful card payments

### DIFF
--- a/app/models/reports/finance_data_report/data_serializer.rb
+++ b/app/models/reports/finance_data_report/data_serializer.rb
@@ -63,8 +63,8 @@ module Reports
         registration.account.charge_adjustments.map do |charge_adjustment|
           order_rows.concat(charge_adjustment_row(registration, charge_adjustment).compact)
         end
-        # payment rows
-        registration.account.payments.order(date_time: :asc).map do |payment|
+        # payment rows - only include successful payments
+        registration.account.payments.success.order(date_time: :asc).map do |payment|
           order_rows.concat(payment_row(registration, payment).compact)
         end
         order_rows


### PR DESCRIPTION
Updated `DataSerializer` to exclude unsuccessful card payments from the finance export by using the `success` scope on payments.

Added specs to verify that only successful payments are included in the CSV output, ensuring failed, cancelled, and errored payments are excluded.
