### PR TITLE
[RUBY-3914] Override scope to exclude placeholder registrations in search

### DIFF
--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -35,6 +35,10 @@ module WasteExemptionsEngine
 
     scope :opted_in_to_renewal_emails, -> { where(reminder_opt_in: true) }
 
+    scope :search_registration_and_relations, lambda { |term|
+      base_search_registration_and_relations(term).where(placeholder: false)
+    }
+
     def active?
       state == "active"
     end

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -35,6 +35,10 @@ module WasteExemptionsEngine
 
     scope :opted_in_to_renewal_emails, -> { where(reminder_opt_in: true) }
 
+    # Override the base search scope to exclude placeholder registrations
+    # (which don't exist for transient registrations)
+    # Placeholder registrations are empty shells created for govpay reference purposes
+    # and should not appear in search results
     scope :search_registration_and_relations, lambda { |term|
       base_search_registration_and_relations(term).where(placeholder: false)
     }

--- a/spec/models/waste_exemptions_engine/registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/registration_spec.rb
@@ -331,6 +331,15 @@ RSpec.describe WasteExemptionsEngine::Registration do
         expect(scope).not_to include(non_matching_registration)
       end
     end
+
+    context "when a registration is a placeholder" do
+      let(:placeholder_registration) { create(:registration, placeholder: true) }
+      let(:term) { placeholder_registration.reference }
+
+      it "does not return placeholder registrations" do
+        expect(scope).not_to include(placeholder_registration)
+      end
+    end
   end
 
   describe "#active?" do


### PR DESCRIPTION
- Override `search_registration_and_relations` scope in registration model to filter out placeholder registrations from search results.

https://eaflood.atlassian.net/browse/RUBY-3914
