### PR TITLE
[RUBY-3985] Add styles for `.button-link` and `.button-link.clear-background` in application.scss

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,3 +26,16 @@
   @extend .govuk-table__cell;
   border: none;
 }
+
+.button-link {
+  border: none;
+  color: #005ea5;
+  font-size: 1.1875rem;
+  padding: 0;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.button-link.clear-background {
+  background-color: #ffffff;
+}


### PR DESCRIPTION
- Define `.button-link` with no border, blue color, underline, and pointer cursor
- Add `.clear-background` variant with white background color
