### PR TITLE
[RUBY-3943] Add `is_multisite_registration` boolean column to registrations table

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_08_173000) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_29_145119) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -328,6 +328,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_08_173000) do
     t.boolean "placeholder", default: false
     t.string "reason_for_change", limit: 500
     t.string "edit_link_requested_by"
+    t.boolean "is_multisite_registration"
     t.index ["created_at"], name: "index_registrations_on_created_at"
     t.index ["deregistration_email_sent_at"], name: "index_registrations_on_deregistration_email_sent_at"
     t.index ["edit_token"], name: "index_registrations_on_edit_token", unique: true


### PR DESCRIPTION
This change updates the schema to include a new boolean field `is_multisite_registration` in the `registrations` table to support multiple site registrations functionality.
