### PR TITLE
Pin sonarqube action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
           sed -i "s@/home/runner/work/DEFRA/waste-exemptions-back-office@/github/workspace@g" coverage/coverage.json
 
       - name: Analyze with SonarCloud
-        uses: sonarsource/sonarqube-scan-action@master
+        uses: sonarsource/sonarqube-scan-action@v5.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
           SONAR_TOKEN: ${{ secrets.RUBY_SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets


### PR DESCRIPTION
Temporarily pin the sonarqube action version to avoid an issue introduced in v5.3.1:
https://community.sonarsource.com/t/sonarqube-scan-action-v5-3-1-is-broken/147965/9