### PR TITLE
[RUBY-3992] Refactor payment details page and add support for multisite registrations

### DIFF
--- a/app/views/payment_details/_charge_breakdown_multisite.html.erb
+++ b/app/views/payment_details/_charge_breakdown_multisite.html.erb
@@ -1,0 +1,66 @@
+    <h2 class="govuk-heading-m">
+      <%= t(".details_section.charges.heading") %>
+    </h2>
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header">
+            <%= t(".details_section.charges.headers.date") %>
+          </th>
+          <th class="govuk-table__header">
+            <%= t(".details_section.charges.headers.breakdown") %>
+          </th>
+          <th class="govuk-table__header govuk-!-text-align-right">
+            <%= t(".details_section.charges.headers.amount") %>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <% presenter.sorted_orders.each do |order| %>
+          <tr class="govuk-table__row">
+            <td rowspan="4" class="govuk-table__cell">
+              <%= format_date(order.created_at) %>
+            </td>
+            <td class="govuk-!-padding-top-2">
+              <% if order.exemption_codes_excluding_bucket.present? %>
+                <%= order.exemption_codes_excluding_bucket %> x [<%= resource.site_addresses.count %>]
+              <% end %>
+            </td>
+            <td class="govuk-!-text-align-right govuk-!-padding-top-2">
+              <% if order.exemption_codes_excluding_bucket.present? %>
+                <%= display_pence_as_pounds_sterling_and_pence(pence: (order.charge_detail&.total_compliance_charge_amount_excluding_bucket)) %>
+              <% end %>
+            </td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td>
+              <% if order.bucket.present? %>
+                <%= t(".details_section.charges.bucket_exemptions_label.#{order.bucket.bucket_type}") %>
+                <%= order.bucket_exemption_codes %> x [<%= resource.site_addresses.count %>]
+              <% end %>
+            </td>
+            <td class="govuk-!-text-align-right">
+              <% if order.bucket.present? %>
+                <%= display_pence_as_pounds_sterling_and_pence(pence: order.charge_detail&.bucket_charge_amount) %>
+              <% end %>
+            </td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td>
+              <%= t(".details_section.charges.registration_charge_label") %>
+            </td>
+            <td class="govuk-!-text-align-right">
+              <%= display_pence_as_pounds_sterling_and_pence(pence: order.charge_detail&.registration_charge_amount) %>
+            </td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell govuk-!-padding-top-0">
+              <%= t(".details_section.charges.total_charge_label") %>
+            </td>
+            <td class="govuk-table__cell govuk-!-text-align-right govuk-!-padding-top-0">
+              <%= display_pence_as_pounds_sterling_and_pence(pence: order.charge_detail&.total_charge_amount) %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>

--- a/app/views/payment_details/_charge_breakdown_singlesite.html.erb
+++ b/app/views/payment_details/_charge_breakdown_singlesite.html.erb
@@ -1,0 +1,66 @@
+    <h2 class="govuk-heading-m">
+      <%= t(".details_section.charges.heading") %>
+    </h2>
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header">
+            <%= t(".details_section.charges.headers.date") %>
+          </th>
+          <th class="govuk-table__header">
+            <%= t(".details_section.charges.headers.breakdown") %>
+          </th>
+          <th class="govuk-table__header govuk-!-text-align-right">
+            <%= t(".details_section.charges.headers.amount") %>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <% presenter.sorted_orders.each do |order| %>
+          <tr class="govuk-table__row">
+            <td rowspan="4" class="govuk-table__cell">
+              <%= format_date(order.created_at) %>
+            </td>
+            <td class="govuk-!-padding-top-2">
+              <% if order.exemption_codes_excluding_bucket.present? %>
+                <%= order.exemption_codes_excluding_bucket %>
+              <% end %>
+            </td>
+            <td class="govuk-!-text-align-right govuk-!-padding-top-2">
+              <% if order.exemption_codes_excluding_bucket.present? %>
+                <%= display_pence_as_pounds_sterling_and_pence(pence: (order.charge_detail&.total_compliance_charge_amount_excluding_bucket)) %>
+              <% end %>
+            </td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td>
+              <% if order.bucket.present? %>
+                <%= t(".details_section.charges.bucket_exemptions_label.#{order.bucket.bucket_type}") %>
+                <%= order.bucket_exemption_codes %>
+              <% end %>
+            </td>
+            <td class="govuk-!-text-align-right">
+              <% if order.bucket.present? %>
+                <%= display_pence_as_pounds_sterling_and_pence(pence: order.charge_detail&.bucket_charge_amount) %>
+              <% end %>
+            </td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td>
+              <%= t(".details_section.charges.registration_charge_label") %>
+            </td>
+            <td class="govuk-!-text-align-right">
+              <%= display_pence_as_pounds_sterling_and_pence(pence: order.charge_detail&.registration_charge_amount) %>
+            </td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell govuk-!-padding-top-0">
+              <%= t(".details_section.charges.total_charge_label") %>
+            </td>
+            <td class="govuk-table__cell govuk-!-text-align-right govuk-!-padding-top-0">
+              <%= display_pence_as_pounds_sterling_and_pence(pence: order.charge_detail&.total_charge_amount) %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>

--- a/app/views/payment_details/index.html.erb
+++ b/app/views/payment_details/index.html.erb
@@ -12,72 +12,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m">
-      <%= t(".details_section.charges.heading") %>
-    </h2>
-    <table class="govuk-table">
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th class="govuk-table__header">
-            <%= t(".details_section.charges.headers.date") %>
-          </th>
-          <th class="govuk-table__header">
-            <%= t(".details_section.charges.headers.breakdown") %>
-          </th>
-          <th class="govuk-table__header govuk-!-text-align-right">
-            <%= t(".details_section.charges.headers.amount") %>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @presenter.sorted_orders.each do |order| %>
-          <tr class="govuk-table__row">
-            <td rowspan="4" class="govuk-table__cell">
-              <%= format_date(order.created_at) %>
-            </td>
-            <td class="govuk-!-padding-top-2">
-              <% if order.exemption_codes_excluding_bucket.present? %>
-                <%= order.exemption_codes_excluding_bucket %>
-              <% end %>
-            </td>
-            <td class="govuk-!-text-align-right govuk-!-padding-top-2">
-              <% if order.exemption_codes_excluding_bucket.present? %>
-                <%= display_pence_as_pounds_sterling_and_pence(pence: (order.charge_detail&.total_compliance_charge_amount_excluding_bucket)) %>
-              <% end %>
-            </td>
-          </tr>
-          <tr class="govuk-table__row">
-            <td>
-              <% if order.bucket.present? %>
-                <%= t(".details_section.charges.bucket_exemptions_label.#{order.bucket.bucket_type}") %>
-                <%= order.bucket_exemption_codes %>
-              <% end %>
-            </td>
-            <td class="govuk-!-text-align-right">
-              <% if order.bucket.present? %>
-                <%= display_pence_as_pounds_sterling_and_pence(pence: order.charge_detail&.bucket_charge_amount) %>
-              <% end %>
-            </td>
-          </tr>
-          <tr class="govuk-table__row">
-            <td>
-              <%= t(".details_section.charges.registration_charge_label") %>
-            </td>
-            <td class="govuk-!-text-align-right">
-              <%= display_pence_as_pounds_sterling_and_pence(pence: order.charge_detail&.registration_charge_amount) %>
-            </td>
-          </tr>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell govuk-!-padding-top-0">
-              <%= t(".details_section.charges.total_charge_label") %>
-            </td>
-            <td class="govuk-table__cell govuk-!-text-align-right govuk-!-padding-top-0">
-              <%= display_pence_as_pounds_sterling_and_pence(pence: order.charge_detail&.total_charge_amount) %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
+    <% if @resource.multisite? %>
+      <%= render("charge_breakdown_multisite", presenter: @presenter, resource: @resource) %>
+    <% else %>
+      <%= render("charge_breakdown_singlesite", presenter: @presenter) %>
+    <% end %>
 
     <h2 class="govuk-heading-m">
       <%= t(".details_section.charge_adjustments.heading") %>

--- a/config/locales/payment_details.en.yml
+++ b/config/locales/payment_details.en.yml
@@ -6,17 +6,6 @@ en:
 
       details_section:
 
-        charges:
-          heading: Charges
-          headers:
-            date: Date
-            breakdown: Charge breakdown
-            amount: Amount
-          registration_charge_label: Registration charge
-          total_charge_label: Total charge
-          bucket_exemptions_label:
-            farmer: Farming exemptions
-
         charge_adjustments:
           heading: Charge adjustments
           headers:
@@ -54,3 +43,29 @@ en:
           reverse_payment: Reverse a payment
           charge_adjustment: Increase or reduce a charge
         add_payment: Record a payment
+
+    charge_breakdown_singlesite:
+      details_section:
+        charges:
+          heading: Charges
+          headers:
+            date: Date
+            breakdown: Charge breakdown
+            amount: Amount
+          registration_charge_label: Registration charge
+          total_charge_label: Total charge
+          bucket_exemptions_label:
+            farmer: Farming exemptions
+
+    charge_breakdown_multisite:
+      details_section:
+        charges:
+          heading: Charges
+          headers:
+            date: Date
+            breakdown: Charge breakdown
+            amount: Amount
+          registration_charge_label: Registration charge
+          total_charge_label: Total charge
+          bucket_exemptions_label:
+            farmer: Farming exemptions

--- a/spec/factories/account.rb
+++ b/spec/factories/account.rb
@@ -6,8 +6,8 @@ FactoryBot.define do
 
     trait :with_order do
       after(:build) do |acc|
-        bands = WasteExemptionsEngine::Band.first(3) || build_list(:band, 3)
-        exemptions = WasteExemptionsEngine::Exemption.first(3) || [
+        bands = WasteExemptionsEngine::Band.first(3).presence || build_list(:band, 3)
+        exemptions = WasteExemptionsEngine::Exemption.first(3).presence || [
           build(:exemption, band: bands[0]),
           build(:exemption, band: bands[1]),
           build(:exemption, band: bands[2])

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -163,5 +163,17 @@ FactoryBot.define do
     trait :multisite do
       is_multisite_registration { true }
     end
+
+    trait :multisite_full do
+      is_multisite_registration { true }
+
+      after(:build) do |registration|
+        registration.site_addresses = (1..30).map do |_i|
+          site_address = build(:address, :site_address)
+          site_address.registration_exemptions << build_list(:registration_exemption, 3, :ceased)
+          site_address
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
WEX - Multiple site registrations - BO - payment details page - charge breakdown
https://eaflood.atlassian.net/browse/RUBY-3992

- refactored payment details page
- extracted single-site specific details into dedicated partial 
- added new partial for multi-site specific details
- refactored specs and added coverage for multi-site registrations