### PR TITLE
Fix/ruby 3944 manual site address

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: f56b3a4852006914eaaec81b9f606ee60c18adf1
+  revision: c426be35466a84a6b20c7274ddc98ac2c575fc6c
   branch: main
   specs:
     waste_exemptions_engine (0.1.0)
@@ -160,7 +160,7 @@ GEM
     bigdecimal (3.3.1)
     bindex (0.8.1)
     builder (3.3.0)
-    bullet (8.0.8)
+    bullet (8.1.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (12.0.0)
@@ -379,8 +379,8 @@ GEM
     orm_adapter (0.5.0)
     os_map_ref (0.5.0)
     ostruct (0.6.3)
-    paper_trail (16.0.0)
-      activerecord (>= 6.1)
+    paper_trail (17.0.0)
+      activerecord (>= 7.1)
       request_store (~> 1.4)
     parallel (1.27.0)
     parser (3.3.9.0)
@@ -594,7 +594,7 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
-    uniform_notifier (1.17.0)
+    uniform_notifier (1.18.0)
     uri (1.0.3)
     useragent (0.16.11)
     validates_email_format_of (1.8.2)

--- a/app/models/waste_exemptions_engine/registration_exemption.rb
+++ b/app/models/waste_exemptions_engine/registration_exemption.rb
@@ -57,10 +57,10 @@ module WasteExemptionsEngine
       # For a multisite registration, registration_exemptions belong to the site address,
       # not to the registration.
       # We use this to establish whether this is a multi-site registration_exemption.
-      return false unless address.present?
+      return false if address.blank?
 
       # Check for edge cases where an address has a single registration_exemption
-      address.registration_exemptions.count > 1
+      address.registration_exemptions.many?
     end
   end
 end

--- a/app/models/waste_exemptions_engine/registration_exemption.rb
+++ b/app/models/waste_exemptions_engine/registration_exemption.rb
@@ -57,7 +57,10 @@ module WasteExemptionsEngine
       # For a multisite registration, registration_exemptions belong to the site address,
       # not to the registration.
       # We use this to establish whether this is a multi-site registration_exemption.
-      address.present?
+      return false unless address.present?
+
+      # Check for edge cases where an address has a single registration_exemption
+      address.registration_exemptions.count > 1
     end
   end
 end

--- a/spec/models/waste_exemptions_engine/registration_exemption_spec.rb
+++ b/spec/models/waste_exemptions_engine/registration_exemption_spec.rb
@@ -186,8 +186,15 @@ RSpec.describe WasteExemptionsEngine::RegistrationExemption do
       it { expect(registration_exemption.multisite?).to be false }
     end
 
+    context "when the registration is single-site with a site address and not a grid reference" do
+      let(:site_address) { build(:address, :manual, address_type: "site") }
+      let(:registration_exemption) { build(:registration_exemption, address: site_address) }
+
+      it { expect(registration_exemption.multisite?).to be false }
+    end
+
     context "when the registration is multi-site" do
-      let(:registration) { build(:registration, :multisite_complete) }
+      let(:registration) { create(:registration, :multisite_complete) }
       let(:registration_exemption) { registration.site_addresses.last.registration_exemptions.last }
 
       it { expect(registration_exemption.multisite?).to be true }


### PR DESCRIPTION
This fixes a bug where a single-site registration with a manually entered site address was incorrectly categorised as multisite.
https://eaflood.atlassian.net/browse/RUBY-3944