### PR TITLE
[RUBY-4070] Adding indication that registration is a multisite or linear

### DIFF
--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -31,5 +31,17 @@ module DashboardsHelper
       t("operator_name", scope: LOCALE)
     end
   end
+
+  def resource_heading_for(resource)
+    registration_type = if resource.is_linear == true
+                          "linear"
+                        elsif resource.is_legacy_bulk == true || resource.is_multisite_registration == true
+                          "multisite"
+                        else
+                          "regular"
+                        end
+
+    t(".heading.#{registration_type}", reference: resource.reference)
+  end
 end
 # rubocop:enable Rails/HelperInstanceVariable

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -5,7 +5,7 @@
     <%= render("shared/error", error: flash[:error], details: flash[:error_details]) if flash[:error].present? %>
 
     <h1 class="govuk-heading-l">
-      <%= t(".heading", reference: @resource.reference) %>
+      <%= resource_heading_for(@resource) %>
     </h1>
   </div>
 </div>

--- a/config/locales/registrations.en.yml
+++ b/config/locales/registrations.en.yml
@@ -2,7 +2,10 @@ en:
   registrations:
     show:
       title: Registration details
-      heading: "Registration details for %{reference}"
+      heading: 
+        regular: "Registration details for %{reference}"
+        linear: "Linear registration details for %{reference}"
+        multisite: "Multiple site registration details for %{reference}"
       back_link_label: Back to search results
     marked_as_legacy_bulk: You have marked this registration as multiple site
     marked_as_legacy_linear: You have marked this registration as linear

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -133,4 +133,47 @@ RSpec.describe DashboardsHelper do
       end
     end
   end
+
+  describe "resource_heading_for" do
+    let(:resource) { build(:registration, reference: "WEX123456") }
+
+    before do
+      allow(helper).to receive(:t).with(".heading.linear", reference: "WEX123456").and_return("Linear heading")
+      allow(helper).to receive(:t).with(".heading.multisite", reference: "WEX123456").and_return("Multisite heading")
+      allow(helper).to receive(:t).with(".heading.regular", reference: "WEX123456").and_return("Regular heading")
+    end
+
+    shared_examples "a resource heading" do |heading_type, expected_heading|
+      it "returns the #{heading_type} heading translation" do
+        expect(helper.resource_heading_for(resource)).to eq(expected_heading)
+      end
+
+      it "calls translation with correct key and parameters" do
+        helper.resource_heading_for(resource)
+        expect(helper).to have_received(:t).with(".heading.#{heading_type}", reference: "WEX123456")
+      end
+    end
+
+    context "when resource is a regular registration" do
+      it_behaves_like "a resource heading", "regular", "Regular heading"
+    end
+
+    context "when resource is linear registration" do
+      before { resource.is_linear = true }
+
+      it_behaves_like "a resource heading", "linear", "Linear heading"
+    end
+
+    context "when resource is legacy bulk registration" do
+      before { resource.is_legacy_bulk = true }
+
+      it_behaves_like "a resource heading", "multisite", "Multisite heading"
+    end
+
+    context "when resource is multisite registration" do
+      before { resource.is_multisite_registration = true }
+
+      it_behaves_like "a resource heading", "multisite", "Multisite heading"
+    end
+  end
 end


### PR DESCRIPTION
WEX - BO - Add indication that registration is a multiple site or linear in the registration details
https://eaflood.atlassian.net/browse/RUBY-4070

- Added a helper method to display the registration heading based on the registration type.