### PR TITLE
Chore/ruby 4095 single multi site spike

### DIFF
--- a/lib/tasks/one_off/create_test_registrations.rake
+++ b/lib/tasks/one_off/create_test_registrations.rake
@@ -11,7 +11,7 @@ namespace :one_off do
     count = (args[:count] || 1_000).to_i
     expiry_date = Date.parse(args[:expiry_date] || "2028-01-01")
 
-    puts "Creating #{count} test registrations with expiry date #{expiry_date}..."
+    puts "Creating #{count} test registrations with expiry date #{expiry_date}..." unless Rails.env.test?
 
     FactoryBot.reload
 
@@ -33,7 +33,7 @@ namespace :one_off do
       puts "Progress: #{i + 1}/#{count}" if ((i + 1) % 100).zero?
     end
 
-    puts "Complete: #{count} registrations created"
+    puts "Complete: #{count} registrations created" unless Rails.env.test?
   end
 end
 

--- a/lib/tasks/one_off/create_test_registrations.rake
+++ b/lib/tasks/one_off/create_test_registrations.rake
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+namespace :one_off do
+  # rake "one_off:create_test_registrations[10000,2028-01-01]"
+  desc "Create test registrations using FactoryBot"
+  task :create_test_registrations, %i[count expiry_date] => [:environment] do |_task, args|
+    raise "This task cannot run in production" if Rails.env.production?
+
+    require "factory_bot_rails"
+
+    count = (args[:count] || 1_000).to_i
+    expiry_date = Date.parse(args[:expiry_date] || "2028-01-01")
+
+    puts "Creating #{count} test registrations with expiry date #{expiry_date}..."
+
+    FactoryBot.reload
+
+    count.times do |i|
+      registration_exemptions = create_registration_exemptions(expiry_date, 3)
+      registration = FactoryBot.create(:registration, registration_exemptions: registration_exemptions)
+      registration.regenerate_and_timestamp_edit_token
+
+      order = FactoryBot.create(:order)
+      registration.account.orders << order
+      registration_exemptions.each { |re| order.order_exemptions.create!(exemption: re.exemption) }
+
+      calc = WasteExemptionsEngine::OrderCalculator.new(
+        order: order,
+        strategy_type: WasteExemptionsEngine::RegularChargingStrategy
+      )
+      calc.charge_detail
+
+      puts "Progress: #{i + 1}/#{count}" if ((i + 1) % 100).zero?
+    end
+
+    puts "Complete: #{count} registrations created"
+  end
+end
+
+def create_registration_exemptions(expiry_date, count)
+  selected_exemptions = WasteExemptionsEngine::Exemption.first(count)
+  (0..(count - 1)).map do |n|
+    FactoryBot.build(:registration_exemption,
+                     expires_on: expiry_date,
+                     exemption: selected_exemptions[n] || FactoryBot.create(:exemption))
+  end
+end

--- a/lib/tasks/one_off/migrate_legacy_single_site_registrations.rake
+++ b/lib/tasks/one_off/migrate_legacy_single_site_registrations.rake
@@ -34,8 +34,7 @@ def qualifying_addresses
   registration_ids_with_exemptions = WasteExemptionsEngine::RegistrationExemption
                                      .joins(:registration)
                                      .where(registrations: { is_multisite_registration: [false, nil] })
-                                     .distinct
-                                     .pluck(:registration_id)
+                                     .pluck(:registration_id).uniq
 
   WasteExemptionsEngine::Address.where(address_type: 3)
                                 .where.missing(:registration_exemptions)

--- a/lib/tasks/one_off/migrate_legacy_single_site_registrations.rake
+++ b/lib/tasks/one_off/migrate_legacy_single_site_registrations.rake
@@ -11,38 +11,35 @@ namespace :one_off do
       site_addresses = address_scope(batch_size)
       break if site_addresses.empty?
 
-      puts "Batch limit #{batch_size}; migrating #{site_addresses.length} addresses"
-# byebug
+      puts "Batch limit #{batch_size}; migrating #{site_addresses.length} addresses" unless Rails.env.test?
       site_addresses.each do |site_address|
-byebug
-        # belt and braces:
         next unless site_address.registration_exemptions.empty?
-byebug
         next if site_address.registration.registration_exemptions.empty?
 
-byebug
-# site_address.registration
-# .registration_exemptions
-# .update_all(address_id: site_address.id) # rubocop:disable Rails/SkipsModelValidations
-
         site_address.update(registration_exemptions: site_address.registration.registration_exemptions)
-byebug
       end
 
       finish_time = Time.zone.now
       duration = (finish_time - start_time)
       rate_per_k = (1000 * duration / site_addresses.length).round(1)
-      puts "Migration complete after #{duration.round(2)} seconds (#{rate_per_k} seconds per thousand); " \
-           "#{qualifying_addresses.length} remaining addresses to migrate."
-byebug
+      unless Rails.env.test?
+        puts "Migration complete after #{duration.round(2)} seconds (#{rate_per_k} seconds per thousand); " \
+             "#{qualifying_addresses.length} remaining addresses to migrate."
+      end
     end
   end
 end
 
 def qualifying_addresses
+  registration_ids_with_exemptions = WasteExemptionsEngine::RegistrationExemption
+                                     .joins(:registration)
+                                     .where(registrations: { is_multisite_registration: [false, nil] })
+                                     .pluck(:registration_id)
+
   WasteExemptionsEngine::Address.where(address_type: 3)
                                 .where.missing(:registration_exemptions)
-                                .where(registration.registration_exemptions.present)
+                                .joins(:registration)
+                                .where(registration: { id: registration_ids_with_exemptions })
 end
 
 def address_scope(batch_size)

--- a/lib/tasks/one_off/migrate_legacy_single_site_registrations.rake
+++ b/lib/tasks/one_off/migrate_legacy_single_site_registrations.rake
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+namespace :one_off do
+  desc "Migrate legacy single_site registrations to the multi_site model"
+  task :migrate_legacy_single_site_registrations, [:batch_size] => [:environment] do |_task, args|
+    batch_size = (args[:batch_size] || 1_000).to_i
+
+    loop do
+      start_time = Time.zone.now
+
+      site_addresses = address_scope(batch_size)
+      break if site_addresses.empty?
+
+      puts "Batch limit #{batch_size}; migrating #{site_addresses.length} addresses"
+# byebug
+      site_addresses.each do |site_address|
+byebug
+        # belt and braces:
+        next unless site_address.registration_exemptions.empty?
+byebug
+        next if site_address.registration.registration_exemptions.empty?
+
+byebug
+# site_address.registration
+# .registration_exemptions
+# .update_all(address_id: site_address.id) # rubocop:disable Rails/SkipsModelValidations
+
+        site_address.update(registration_exemptions: site_address.registration.registration_exemptions)
+byebug
+      end
+
+      finish_time = Time.zone.now
+      duration = (finish_time - start_time)
+      rate_per_k = (1000 * duration / site_addresses.length).round(1)
+      puts "Migration complete after #{duration.round(2)} seconds (#{rate_per_k} seconds per thousand); " \
+           "#{qualifying_addresses.length} remaining addresses to migrate."
+byebug
+    end
+  end
+end
+
+def qualifying_addresses
+  WasteExemptionsEngine::Address.where(address_type: 3)
+                                .where.missing(:registration_exemptions)
+                                .where(registration.registration_exemptions.present)
+end
+
+def address_scope(batch_size)
+  qualifying_addresses
+    .includes(registration: :registration_exemptions)
+    .limit(batch_size)
+end

--- a/spec/lib/tasks/one_off/create_test_registrations_spec.rb
+++ b/spec/lib/tasks/one_off/create_test_registrations_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../../../../db/seeds/charging_schemes"
+
+RSpec.describe "one_off:create_test_registrations", type: :rake do
+  subject(:run_rake_task) { rake_task.invoke(count, expiry_date) }
+
+  include_context "rake"
+
+  let(:rake_task) { Rake::Task["one_off:create_test_registrations"] }
+  let(:count) { 2 }
+  let(:expiry_date) { "2028-01-01" }
+
+  before { seed_charging_schemes }
+
+  after { rake_task.reenable }
+
+  it "creates the specified number of registrations" do
+    expect { run_rake_task }.to change(WasteExemptionsEngine::Registration, :count).by(2)
+  end
+
+  it "creates registrations with the specified expiry date" do
+    run_rake_task
+
+    registration = WasteExemptionsEngine::Registration.last
+    expect(registration.registration_exemptions.first.expires_on).to eq(Date.parse(expiry_date))
+  end
+
+  it "creates orders for each registration" do
+    expect { run_rake_task }.to change(WasteExemptionsEngine::Order, :count).by(2)
+  end
+end

--- a/spec/lib/tasks/one_off/migrate_legacy_single_site_registrations_spec.rb
+++ b/spec/lib/tasks/one_off/migrate_legacy_single_site_registrations_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe "one_off:migrate_legacy_single_site_registrations", type: :rake d
     it "removes the association from the registration to the site_address" do
       run_rake_task
 
-      expect(registration.site_address).to be_nil
+      expect(registration.registration_exemptions.where(address: nil)).to be_empty
+      expect(registration.site_address.registration_exemptions).to match_array(registration.registration_exemptions)
     end
   end
 end

--- a/spec/lib/tasks/one_off/migrate_legacy_single_site_registrations_spec.rb
+++ b/spec/lib/tasks/one_off/migrate_legacy_single_site_registrations_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "one_off:migrate_legacy_single_site_registrations", type: :rake do
+
+  subject(:run_rake_task) { rake_task.invoke }
+
+  include_context "rake"
+
+  let(:rake_task) { Rake::Task["one_off:migrate_legacy_single_site_registrations"] }
+
+  before { WasteExemptionsEngine::Address.destroy_all }
+
+  # By default Rails prevents multiple invocations of the same Rake task in succession
+  after { rake_task.reenable }
+
+  it { expect { run_rake_task }.not_to raise_error }
+
+  context "when the registration is true multisite" do
+    before { create(:registration, :multisite_complete) }
+
+    it "does not modify the registration" do
+      expect { run_rake_task }.not_to change(WasteExemptionsEngine::Registration, :last)
+    end
+  end
+
+  context "when the registration is a single-site registration using the multisite data model" do
+    before do
+      reg = create(:registration)
+      reg.site_address.update(registration_exemptions: reg.registration_exemptions)
+    end
+
+    it "does not modify the registration" do
+      expect { run_rake_task }.not_to change(WasteExemptionsEngine::Registration, :last)
+    end
+  end
+
+  context "when the registration is legacy single-site" do
+    let(:registration) { WasteExemptionsEngine::Registration.last }
+    let(:site_address) { registration.site_address }
+
+    before { create(:registration) }
+
+    it "adds registration_exemptions on the site_address" do
+      expect { run_rake_task }.to change { site_address.reload.registration_exemptions.count }.from(0)
+    end
+
+    it "creates a site_address association with each registration_exemption" do
+      run_rake_task
+
+      expect(site_address.registration_exemptions).to match_array(registration.registration_exemptions)
+    end
+
+    it "removes the association from the registration to the site_address" do
+      run_rake_task
+
+      expect(registration.site_address).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-4095

Rake task to migrate existing registrations to a new data model
- in the new data model, registration_exemptions get associated with the site address