### PR TITLE
[RUBY-4068] Support multisite registration in testing endpoint

### DIFF
--- a/app/controllers/testing_controller.rb
+++ b/app/controllers/testing_controller.rb
@@ -9,28 +9,42 @@ class TestingController < ApplicationController
 
   def create_registration
     @expiry_date = Date.parse(params[:expiry_date])
-    # exemptions from params[:exemptions] which is a list of exemption codes
-    # e.g. "create_registration/2022-01-01?exemptions=U1&exemptions=U2&exemptions=U3"
-    # "testing/create_registration/2022-01-01?exemptions[]=U4&exemptions[]=U5&exemptions[]=U1"
-    registration_exemptions = if params[:exemptions].present?
-                                create_registration_exemptions_by_codes(params[:exemptions])
-                              else
-                                create_registration_exemptions_by_count(3)
-                              end
+    registration_exemptions = build_registration_exemptions
 
     # https://github.com/thoughtbot/factory_bot/blob/ca810767e70ccd85c7cb63f775bc16f653a97dc8/GETTING_STARTED.md#rails-preloaders-and-rspec
     FactoryBot.reload
 
-    registration = FactoryBot.create(:registration,
-                                     registration_exemptions: registration_exemptions)
+    number_of_sites = params[:number_of_sites].present? ? params[:number_of_sites].to_i : 1
+    registration = create_registration_with_sites(number_of_sites, registration_exemptions)
 
     # Ensure edit_token_created_at is populated
     registration.regenerate_and_timestamp_edit_token
 
-    # Add an order
+    # Add an order and calculate charges
+    add_order_and_calculate_charges(registration)
+
+    render :show, locals: { registration: registration }
+  end
+
+  private
+
+  # exemptions from params[:exemptions] which is a list of exemption codes
+  # e.g. "create_registration/2022-01-01?exemptions=U1&exemptions=U2&exemptions=U3"
+  # "testing/create_registration/2022-01-01?exemptions[]=U4&exemptions[]=U5&exemptions[]=U1"
+  def build_registration_exemptions
+    if params[:exemptions].present?
+      create_registration_exemptions_by_codes(params[:exemptions])
+    else
+      create_registration_exemptions_by_count(3)
+    end
+  end
+
+  def add_order_and_calculate_charges(registration)
     order = FactoryBot.create(:order)
     registration.account.orders << order
-    registration_exemptions.map { |re| order.order_exemptions.create!(exemption: re.exemption) }
+
+    registration_exemptions = registration.site_addresses.flat_map(&:registration_exemptions)
+    registration_exemptions.each { |re| order.order_exemptions.create!(exemption: re.exemption) }
 
     # force creation of charge_detail and calculation of balance
     calc = WasteExemptionsEngine::OrderCalculator.new(
@@ -38,11 +52,7 @@ class TestingController < ApplicationController
       strategy_type: WasteExemptionsEngine::RegularChargingStrategy
     )
     calc.charge_detail
-
-    render :show, locals: { registration: registration }
   end
-
-  private
 
   def create_registration_exemptions_by_count(count)
     selected_exemptions = WasteExemptionsEngine::Exemption.first(count)
@@ -58,6 +68,28 @@ class TestingController < ApplicationController
       FactoryBot.build(:registration_exemption,
                        expires_on: @expiry_date,
                        exemption: exemption)
+    end
+  end
+
+  def create_registration_with_sites(number_of_sites, registration_exemptions)
+    is_multisite = number_of_sites > 1
+
+    FactoryBot.create(:registration, is_multisite_registration: is_multisite,
+                                     registration_exemptions: registration_exemptions).tap do |registration|
+      if is_multisite
+        registration.site_addresses = (1..number_of_sites).map do |i|
+          site_address = FactoryBot.build(:address, :site_address)
+          site_address.registration_exemptions = registration_exemptions.map(&:dup)
+          site_address.site_suffix = format("%05d", i)
+          site_address
+        end
+      else
+        # For single-site, also attach exemptions to the site address
+        site_address = registration.site_addresses.find { |a| a.address_type == "site" }
+        site_address.registration_exemptions = registration_exemptions if site_address
+      end
+
+      registration.save!
     end
   end
 

--- a/app/views/testing/show.html.erb
+++ b/app/views/testing/show.html.erb
@@ -19,28 +19,56 @@
 </dl>
 
 <h2 class="govuk-heading-l">Exemptions</h2>
-<p class="govuk-body">This registration includes the following exemptions:</p>
-<dl class="govuk-summary-list">
-  <% registration.registration_exemptions.each do |registration_exemption| %>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
-        <span class="govuk-!-font-weight-bold"><%= registration_exemption.exemption.code %></span>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= registration_exemption.exemption.summary %>
-      </dd>
-      <% if registration_exemption.exemption.band.present? %>
-        <dd class="govuk-summary-list__actions">
-          <span class="govuk-tag govuk-tag--blue">
-            <%= registration_exemption.exemption.band.name %>
-          </span>
-        </dd>
-      <% else %>
-        <dd class="govuk-summary-list__actions"></dd>
+<% if registration.is_multisite_registration? %>
+  <p class="govuk-body">This is a multisite registration with <%= registration.site_addresses.count %> sites.</p>
+  <% registration.site_addresses.each_with_index do |site_address, index| %>
+    <h3 class="govuk-heading-m">Site <%= index + 1 %><% if site_address.site_suffix.present? %> (<%= site_address.site_suffix %>)<% end %></h3>
+    <dl class="govuk-summary-list">
+      <% site_address.registration_exemptions.each do |registration_exemption| %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
+            <span class="govuk-!-font-weight-bold"><%= registration_exemption.exemption.code %></span>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= registration_exemption.exemption.summary %>
+          </dd>
+          <% if registration_exemption.exemption.band.present? %>
+            <dd class="govuk-summary-list__actions">
+              <span class="govuk-tag govuk-tag--blue">
+                <%= registration_exemption.exemption.band.name %>
+              </span>
+            </dd>
+          <% else %>
+            <dd class="govuk-summary-list__actions"></dd>
+          <% end %>
+        </div>
       <% end %>
-    </div>
+    </dl>
   <% end %>
-</dl>
+<% else %>
+  <p class="govuk-body">This registration includes the following exemptions:</p>
+  <dl class="govuk-summary-list">
+    <% registration.registration_exemptions.each do |registration_exemption| %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
+          <span class="govuk-!-font-weight-bold"><%= registration_exemption.exemption.code %></span>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= registration_exemption.exemption.summary %>
+        </dd>
+        <% if registration_exemption.exemption.band.present? %>
+          <dd class="govuk-summary-list__actions">
+            <span class="govuk-tag govuk-tag--blue">
+              <%= registration_exemption.exemption.band.name %>
+            </span>
+          </dd>
+        <% else %>
+          <dd class="govuk-summary-list__actions"></dd>
+        <% end %>
+      </div>
+    <% end %>
+  </dl>
+<% end %>
 
 <h2 class="govuk-heading-l">Attributes</h2>
 <dl class="govuk-summary-list">


### PR DESCRIPTION
- Refactor to support multisite registrations by adding site handling logic.
- Update views to display multisite info

https://eaflood.atlassian.net/browse/RUBY-4068