### PR TITLE
[RUBY-4137] Refactor registration number in EPR report to use configurable site suffix separator with default hyphen

### DIFF
--- a/app/presenters/reports/exemption_epr_report_presenter.rb
+++ b/app/presenters/reports/exemption_epr_report_presenter.rb
@@ -10,7 +10,7 @@ module Reports
     end
 
     def registration_number
-      return owning_registration.reference unless multisite? && address.site_suffix.present?
+      return owning_registration.reference unless owning_registration.multisite? && address.site_suffix.present?
 
       separator = ENV.fetch("REPORT_SITE_SUFFIX_SEPARATOR", "-")
       "#{owning_registration.reference}#{separator}#{address.site_suffix}"

--- a/app/presenters/reports/exemption_epr_report_presenter.rb
+++ b/app/presenters/reports/exemption_epr_report_presenter.rb
@@ -14,7 +14,7 @@ module Reports
     def registration_number
       return owning_registration.reference unless multisite? && address.site_suffix.present?
 
-      separator = ENV.fetch("WEX_SITE_SUFFIX_SEPARATOR", "-")
+      separator = ENV.fetch("REPORT_SITE_SUFFIX_SEPARATOR", "-")
       "#{owning_registration.reference}#{separator}#{address.site_suffix}"
     end
 

--- a/app/presenters/reports/exemption_epr_report_presenter.rb
+++ b/app/presenters/reports/exemption_epr_report_presenter.rb
@@ -12,12 +12,10 @@ module Reports
     end
 
     def registration_number
-      # if registration_exemption.multisite?
-      if multisite?
-        "#{owning_registration.reference}/#{address.site_suffix}"
-      else
-        owning_registration.reference
-      end
+      return owning_registration.reference unless multisite? && address.site_suffix.present?
+
+      separator = ENV.fetch("WEX_SITE_SUFFIX_SEPARATOR", "-")
+      "#{owning_registration.reference}#{separator}#{address.site_suffix}"
     end
 
     def organisation_name

--- a/spec/presenters/reports/exemption_epr_report_presenter_spec.rb
+++ b/spec/presenters/reports/exemption_epr_report_presenter_spec.rb
@@ -30,8 +30,17 @@ module Reports
         let(:site_address) { multisite_registration.site_addresses.last }
         let(:registration_exemption) { site_address.registration_exemptions.last }
 
-        it "includes the site suffix" do
-          expect(presenter.registration_number).to eq("#{multisite_registration.reference}/#{site_address.site_suffix}")
+        it "includes the site suffix with hyphen separator" do
+          expect(presenter.registration_number).to eq("#{multisite_registration.reference}-#{site_address.site_suffix}")
+        end
+
+        context "when WEX_SITE_SUFFIX_SEPARATOR is set" do
+          before { allow(ENV).to receive(:fetch).with("WEX_SITE_SUFFIX_SEPARATOR", "-").and_return("/") }
+          after { allow(ENV).to receive(:fetch).and_call_original }
+
+          it "uses the custom separator" do
+            expect(presenter.registration_number).to eq("#{multisite_registration.reference}/#{site_address.site_suffix}")
+          end
         end
 
         # A multisite registration_exemption has an indirect association to the owning registration.

--- a/spec/presenters/reports/exemption_epr_report_presenter_spec.rb
+++ b/spec/presenters/reports/exemption_epr_report_presenter_spec.rb
@@ -36,7 +36,6 @@ module Reports
 
         context "when REPORT_SITE_SUFFIX_SEPARATOR is set" do
           before { allow(ENV).to receive(:fetch).with("REPORT_SITE_SUFFIX_SEPARATOR", "-").and_return("/") }
-          after { allow(ENV).to receive(:fetch).and_call_original }
 
           it "uses the custom separator" do
             expect(presenter.registration_number).to eq("#{multisite_registration.reference}/#{site_address.site_suffix}")

--- a/spec/presenters/reports/exemption_epr_report_presenter_spec.rb
+++ b/spec/presenters/reports/exemption_epr_report_presenter_spec.rb
@@ -34,8 +34,8 @@ module Reports
           expect(presenter.registration_number).to eq("#{multisite_registration.reference}-#{site_address.site_suffix}")
         end
 
-        context "when WEX_SITE_SUFFIX_SEPARATOR is set" do
-          before { allow(ENV).to receive(:fetch).with("WEX_SITE_SUFFIX_SEPARATOR", "-").and_return("/") }
+        context "when REPORT_SITE_SUFFIX_SEPARATOR is set" do
+          before { allow(ENV).to receive(:fetch).with("REPORT_SITE_SUFFIX_SEPARATOR", "-").and_return("/") }
           after { allow(ENV).to receive(:fetch).and_call_original }
 
           it "uses the custom separator" do


### PR DESCRIPTION
[RUBY-4137] Use configurable suffix separator with default hyphen for registration number in EPR report

https://eaflood.atlassian.net/browse/RUBY-4137

[RUBY-4137]: https://eaflood.atlassian.net/browse/RUBY-4137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ