### PR TITLE
Fix/ruby 4133 site expired

### DIFF
--- a/app/models/waste_exemptions_engine/address.rb
+++ b/app/models/waste_exemptions_engine/address.rb
@@ -17,14 +17,13 @@ module WasteExemptionsEngine
     end
 
     def site_status
-      state = if registration_exemptions.any? { |re| re.state == "active" }
-                "active"
-              elsif registration_exemptions.any? { |re| re.state == "expired" }
-                "expired"
-              else
-                "deregistered"
-              end
-      I18n.t "sites.index.states.#{state}"
+      if registration_exemptions.any? { |re| re.state == "active" }
+        "active"
+      elsif registration_exemptions.any? { |re| re.state == "expired" }
+        "expired"
+      else
+        "deregistered"
+      end
     end
 
     def ceased_or_revoked_exemptions

--- a/app/models/waste_exemptions_engine/address.rb
+++ b/app/models/waste_exemptions_engine/address.rb
@@ -17,7 +17,14 @@ module WasteExemptionsEngine
     end
 
     def site_status
-      registration_exemptions.any? { |re| re.state == "active" } ? "active" : "deregistered"
+      state = if registration_exemptions.any? { |re| re.state == "active" }
+                "active"
+              elsif registration_exemptions.any? { |re| re.state == "expired" }
+                "expired"
+              else
+                "deregistered"
+              end
+      I18n.t "sites.index.states.#{state}"
     end
 
     def ceased_or_revoked_exemptions

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -41,7 +41,7 @@
                 <%= site_address.area %>
               </td>
               <td class="govuk-table__cell">
-                <%= site_address.site_status %>
+                <%= site_address.site_status&.capitalize %>
               </td>
               <td class="govuk-table__cell">
                 <%= site_address.ceased_or_revoked_exemptions %>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -41,7 +41,7 @@
                 <%= site_address.area %>
               </td>
               <td class="govuk-table__cell">
-                <%= site_address.site_status&.capitalize %>
+                <%= t("sites.index.states.#{site_address.site_status}").capitalize %>
               </td>
               <td class="govuk-table__cell">
                 <%= site_address.ceased_or_revoked_exemptions %>

--- a/config/locales/sites.en.yml
+++ b/config/locales/sites.en.yml
@@ -11,6 +11,10 @@ en:
         status: "Site status"
         ceased_or_revoked: "Ceased/revoked exemptions"
         actions: "Actions"
+      states:
+        active: active
+        deregistered: deregistered
+        expired: expired
       actions:
         exemptions: "Exemptions"
         deregister: "Deregister"

--- a/spec/requests/sites_spec.rb
+++ b/spec/requests/sites_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Sites" do
     it { expect(response.body).to include(site_address.grid_reference) }
     it { expect(response.body).to include(site_address.description) }
     it { expect(response.body).to include(site_address.area.to_s) }
-    it { expect(response.body).to include(site_address.site_status) }
+    it { expect(response.body).to include(site_address.site_status.capitalize) }
     it { expect(response.body).to include(site_address.ceased_or_revoked_exemptions) }
   end
 
@@ -43,20 +43,19 @@ RSpec.describe "Sites" do
       it_behaves_like "includes the correct content"
 
       it "paginates the results" do
-        registration = create(:registration, :multisite, addresses: [])
-        create_list(:address, 25, :site_address, registration: registration)
+        registration = create(:registration, :multisite_complete, addresses: [])
 
         get "/registrations/#{registration.reference}/sites"
 
         expect(response.body).to include("Waste operation sites")
-        expect(response.body).to include("Showing 1 &ndash; 20 of 25 results")
+        expect(response.body).to include("Showing 1 &ndash; 20 of 30 results")
         expect(response.body).to include("Next")
         expect(response.body).not_to include("Prev")
 
         get "/registrations/#{registration.reference}/sites?page=2"
 
         expect(response.body).to include("Waste operation sites")
-        expect(response.body).to include("Showing 21 &ndash; 25 of 25 results")
+        expect(response.body).to include("Showing 21 &ndash; 30 of 30 results")
         expect(response.body).not_to include("Next")
         expect(response.body).to include("Prev")
       end

--- a/spec/services/deregistration_service_spec.rb
+++ b/spec/services/deregistration_service_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe DeregistrationService do
       context "when the site is active" do
         subject(:dereg_service) { described_class.new(admin_team_user, site) }
 
-        let(:registration) { create(:registration, :multisite, registration_exemptions: []) }
+        let(:registration) { create(:registration, :multisite_complete, registration_exemptions: []) }
         let(:site) do
           site = registration.site_address
           site.registration_exemptions = create_list(:registration_exemption, 2, state: "active")


### PR DESCRIPTION
Use i18n for site address status display and add support for "expired" status.
https://eaflood.atlassian.net/browse/RUBY-4133