### PR TITLE
[RUBY-4167] Refactor eligible_for_free_renewal? method and exclude t28 from free renewals

### DIFF
--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -60,9 +60,7 @@ module WasteExemptionsEngine
     end
 
     def eligible_for_free_renewal?
-      business_type == "charity" || registration_exemptions.includes([:exemption]).any? do |re|
-        re.exemption.code == "T28"
-      end
+      business_type == "charity"
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -492,7 +492,7 @@ RSpec.describe ActionLinksHelper do
                ])
       end
 
-      it { expect(helper.display_renew_links_for?(resource)).to be(true) }
+      it { expect(helper.display_renew_links_for?(resource)).to be(false) }
     end
 
     context "when the resource is not a registration" do

--- a/spec/models/waste_exemptions_engine/registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/registration_spec.rb
@@ -502,8 +502,8 @@ RSpec.describe WasteExemptionsEngine::Registration do
     end
 
     it { expect(charity_registration.eligible_for_free_renewal?).to be true }
-    it { expect(t28_only_registration.eligible_for_free_renewal?).to be true }
-    it { expect(t28_plus_registration.eligible_for_free_renewal?).to be true }
+    it { expect(t28_only_registration.eligible_for_free_renewal?).to be false }
+    it { expect(t28_plus_registration.eligible_for_free_renewal?).to be false }
     it { expect(non_charity_non_t28_registration.eligible_for_free_renewal?).to be false }
   end
 end

--- a/spec/services/renewal_reminders/renewal_reminder_email_service_selector_spec.rb
+++ b/spec/services/renewal_reminders/renewal_reminder_email_service_selector_spec.rb
@@ -32,7 +32,7 @@ module RenewalReminders
 
         it { expect(described_class.first_reminder_email_service(chargeable_registration)).to eq(FirstRenewalReminderEmailService) }
         it { expect(described_class.first_reminder_email_service(charity_registration)).to eq(FreeFirstRenewalReminderEmailService) }
-        it { expect(described_class.first_reminder_email_service(t28_registration)).to eq(FreeFirstRenewalReminderEmailService) }
+        it { expect(described_class.first_reminder_email_service(t28_registration)).to eq(FirstRenewalReminderEmailService) }
 
         it { expect(described_class.first_reminder_email_service(legacy_bulk_registration)).to eq(FirstRenewalReminderEmailService) }
       end
@@ -42,7 +42,7 @@ module RenewalReminders
 
         it { expect(described_class.first_reminder_email_service(chargeable_registration)).to eq(TemporaryFirstRenewalReminderEmailService) }
         it { expect(described_class.first_reminder_email_service(charity_registration)).to eq(FreeFirstRenewalReminderEmailService) }
-        it { expect(described_class.first_reminder_email_service(t28_registration)).to eq(FreeFirstRenewalReminderEmailService) }
+        it { expect(described_class.first_reminder_email_service(t28_registration)).to eq(TemporaryFirstRenewalReminderEmailService) }
 
         it { expect(described_class.first_reminder_email_service(legacy_bulk_registration)).to eq(FirstRenewalReminderEmailService) }
       end
@@ -56,7 +56,7 @@ module RenewalReminders
 
         it { expect(described_class.second_reminder_email_service(chargeable_registration)).to eq(SecondRenewalReminderEmailService) }
         it { expect(described_class.second_reminder_email_service(charity_registration)).to eq(FreeSecondRenewalReminderEmailService) }
-        it { expect(described_class.second_reminder_email_service(t28_registration)).to eq(FreeSecondRenewalReminderEmailService) }
+        it { expect(described_class.second_reminder_email_service(t28_registration)).to eq(SecondRenewalReminderEmailService) }
 
         it { expect(described_class.second_reminder_email_service(legacy_bulk_registration)).to eq(SecondRenewalReminderEmailService) }
       end
@@ -66,7 +66,7 @@ module RenewalReminders
 
         it { expect(described_class.second_reminder_email_service(chargeable_registration)).to eq(TemporarySecondRenewalReminderEmailService) }
         it { expect(described_class.second_reminder_email_service(charity_registration)).to eq(FreeSecondRenewalReminderEmailService) }
-        it { expect(described_class.second_reminder_email_service(t28_registration)).to eq(FreeSecondRenewalReminderEmailService) }
+        it { expect(described_class.second_reminder_email_service(t28_registration)).to eq(TemporarySecondRenewalReminderEmailService) }
 
         it { expect(described_class.second_reminder_email_service(legacy_bulk_registration)).to eq(SecondRenewalReminderEmailService) }
       end


### PR DESCRIPTION
WEX - NPJ - Send T28 exemptions a renewal reminder email to re-register rather than actual renewal email with magic link
https://eaflood.atlassian.net/browse/RUBY-4167

Refactored eligible_for_free_renewal? method to exclude registrations with t28 exemptions from free renewals