### PR TITLE
Move github_changelog_generator gem outside of development group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,19 @@
 source "https://rubygems.org"
 ruby "3.4.6"
 
+# Allows us to automatically generate the change log from the tags, issues,
+# labels and pull requests on GitHub. Added as a dependency so all dev's have
+# access to it to generate a log, and so they are using the same version.
+# New dev's should first create GitHub personal app token and add it to their
+# ~/.bash_profile (or equivalent)
+# https://github.com/skywinder/github-changelog-generator#github-token
+# Then simply run `bundle exec rake changelog` to update CHANGELOG.md
+# Should be in the :development group however when it is it breaks the
+# Jenkins deployment. Hence moved outside group till we can understand why.
+# future versions of github_changelog_generator rely on async gem and
+# do cause errors. So pinning to a version that does not have this dependency.
+gem "github_changelog_generator", "~> 1.15.2", require: false
+
 # GOV.UK design system styling
 gem "defra_ruby_template", "~> 5.11"
 # GOV.UK design system forms
@@ -98,17 +111,6 @@ group :production do
 end
 
 group :development, :test do
-  # Allows us to automatically generate the change log from the tags, issues,
-  # labels and pull requests on GitHub. Added as a dependency so all dev's have
-  # access to it to generate a log, and so they are using the same version.
-  # New dev's should first create GitHub personal app token and add it to their
-  # ~/.bash_profile (or equivalent)
-  # https://github.com/skywinder/github-changelog-generator#github-token
-  # Then simply run `bundle exec rake changelog` to update CHANGELOG.md
-  # future versions of github_changelog_generator rely on async gem and
-  # do cause errors. So pinning to a version that does not have this dependency.
-  gem "github_changelog_generator", "~> 1.15.2"
-
   # Call 'binding.pry' anywhere in the code to stop execution and get a debugger console
   gem "pry-byebug"
 


### PR DESCRIPTION
Moved github_changelog_generator gem declaration back to the main Gemfile section to resolve deployment issue