### PR TITLE
[RUBY-4179] Add rake tasks for cleaning up duplicate and orphan addresses

### DIFF
--- a/lib/tasks/one_off/cleanup_duplicate_addresses.rake
+++ b/lib/tasks/one_off/cleanup_duplicate_addresses.rake
@@ -1,5 +1,69 @@
 # frozen_string_literal: true
 
+module CleanupDuplicateAddresses
+  module_function
+
+  def find_duplicate_address_groups(type_name, type_value)
+    scope = WasteExemptionsEngine::Address.where(address_type: type_value).where.not(registration_id: nil)
+
+    # exclude legitimate multisite registrations
+    if type_name == "site"
+      multisite_registration_ids = WasteExemptionsEngine::Registration
+                                   .where(is_multisite_registration: true)
+                                   .pluck(:id)
+      scope = scope.where.not(registration_id: multisite_registration_ids) if multisite_registration_ids.any?
+    end
+
+    scope.group(:registration_id)
+         .having("COUNT(*) > 1")
+         .pluck(:registration_id, Arel.sql("ARRAY_AGG(id ORDER BY id)"))
+         .to_h
+  end
+
+  def deduplicate_address_group(registration_id, address_ids, dry_run: false)
+    return 0 unless valid_duplicate_group?(registration_id, address_ids)
+
+    ids_to_delete = ids_to_delete_from(address_ids)
+    return 0 if ids_to_delete.empty?
+
+    log_deletion(ids_to_delete, registration_id, dry_run: dry_run)
+    delete_addresses(ids_to_delete) unless dry_run
+
+    ids_to_delete.length
+  end
+
+  def valid_duplicate_group?(registration_id, address_ids)
+    addresses = WasteExemptionsEngine::Address.where(id: address_ids)
+    addresses.pluck(:registration_id).uniq == [registration_id] &&
+      addresses.pluck(:address_type).uniq.one?
+  end
+
+  def ids_to_delete_from(address_ids)
+    with_exemptions = address_ids.select do |id|
+      WasteExemptionsEngine::RegistrationExemption.exists?(address_id: id)
+    end
+
+    if with_exemptions.any?
+      address_ids - with_exemptions
+    else
+      address_ids[1..]
+    end
+  end
+
+  def log_deletion(ids_to_delete, registration_id, dry_run: false)
+    return if Rails.env.test?
+
+    prefix = dry_run ? "[DRY RUN] Would delete" : "Deleting"
+    puts "#{prefix} addresses #{ids_to_delete.join(', ')} for registration #{registration_id}"
+  end
+
+  def delete_addresses(ids_to_delete)
+    ActiveRecord::Base.transaction do
+      WasteExemptionsEngine::Address.where(id: ids_to_delete).destroy_all
+    end
+  end
+end
+
 namespace :one_off do
   # rake one_off:cleanup_duplicate_addresses[live-run] to perform actual deletions,
   # otherwise runs in dry-run mode by default
@@ -10,11 +74,11 @@ namespace :one_off do
 
     puts "[DRY RUN] No records will be modified" if dry_run && !Rails.env.test?
 
-    # Process each address type: operator (1), contact (2), site (3)
+    # process each address type: operator (1), contact (2), site (3)
     WasteExemptionsEngine::Address.address_types.each do |type_name, type_value|
       next if type_value.zero? # skip unknown
 
-      duplicate_groups = find_duplicate_groups(type_name, type_value)
+      duplicate_groups = CleanupDuplicateAddresses.find_duplicate_address_groups(type_name, type_value)
       next if duplicate_groups.empty?
 
       unless Rails.env.test?
@@ -22,7 +86,7 @@ namespace :one_off do
       end
 
       duplicate_groups.each do |registration_id, address_ids|
-        deleted = deduplicate_address_group(registration_id, address_ids, dry_run: dry_run)
+        deleted = CleanupDuplicateAddresses.deduplicate_address_group(registration_id, address_ids, dry_run: dry_run)
         total_deleted += deleted
       end
     end
@@ -30,57 +94,3 @@ namespace :one_off do
     puts "Total addresses #{dry_run ? 'to delete' : 'deleted'}: #{total_deleted}" unless Rails.env.test?
   end
 end
-
-def find_duplicate_groups(type_name, type_value)
-  scope = WasteExemptionsEngine::Address.where(address_type: type_value).where.not(registration_id: nil)
-
-  # For site addresses, exclude legitimate multisite registrations
-  if type_name == "site"
-    multisite_registration_ids = WasteExemptionsEngine::Registration
-                                 .where(is_multisite_registration: true)
-                                 .pluck(:id)
-    scope = scope.where.not(registration_id: multisite_registration_ids) if multisite_registration_ids.any?
-  end
-
-  scope.group(:registration_id)
-       .having("COUNT(*) > 1")
-       .pluck(:registration_id, Arel.sql("ARRAY_AGG(id ORDER BY id)"))
-       .to_h
-end
-
-# rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength
-def deduplicate_address_group(registration_id, address_ids, dry_run: false)
-  addresses = WasteExemptionsEngine::Address.where(id: address_ids)
-  # double check all addresses belong to same registration
-  return 0 if addresses.pluck(:registration_id).uniq != [registration_id]
-  # double check all addresses belong to the same type
-  return 0 if addresses.pluck(:address_type).uniq.count != 1
-
-  with_exemptions = address_ids.select do |id|
-    WasteExemptionsEngine::RegistrationExemption.exists?(address_id: id)
-  end
-
-  without_exemptions = address_ids - with_exemptions
-
-  ids_to_delete = if with_exemptions.any?
-                    # Keep addresses that have exemptions, delete the rest
-                    without_exemptions
-                  else
-                    # No exemptions on any duplicate — keep the first (lowest id), delete the rest
-                    address_ids[1..]
-                  end
-
-  return 0 if ids_to_delete.empty?
-
-  prefix = dry_run ? "[DRY RUN] Would delete" : "Deleting"
-  puts "#{prefix} addresses #{ids_to_delete.join(', ')} for registration #{registration_id}" unless Rails.env.test?
-
-  unless dry_run
-    ActiveRecord::Base.transaction do
-      WasteExemptionsEngine::Address.where(id: ids_to_delete).destroy_all
-    end
-  end
-
-  ids_to_delete.length
-end
-# rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength

--- a/lib/tasks/one_off/cleanup_duplicate_addresses.rake
+++ b/lib/tasks/one_off/cleanup_duplicate_addresses.rake
@@ -72,10 +72,8 @@ def deduplicate_address_group(registration_id, address_ids, dry_run: false)
 
   return 0 if ids_to_delete.empty?
 
-  unless Rails.env.test?
-    prefix = dry_run ? "[DRY RUN] Would delete" : "Deleting"
-    puts "#{prefix} addresses #{ids_to_delete.join(', ')} for registration #{registration_id}"
-  end
+  prefix = dry_run ? "[DRY RUN] Would delete" : "Deleting"
+  puts "#{prefix} addresses #{ids_to_delete.join(', ')} for registration #{registration_id}" unless Rails.env.test?
 
   unless dry_run
     ActiveRecord::Base.transaction do

--- a/lib/tasks/one_off/cleanup_duplicate_addresses.rake
+++ b/lib/tasks/one_off/cleanup_duplicate_addresses.rake
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+namespace :one_off do
+  # rake one_off:cleanup_duplicate_addresses[live-run] to perform actual deletions,
+  # otherwise runs in dry-run mode by default
+  desc "Remove duplicate addresses from registrations (keeps addresses with exemptions, deletes those without)"
+  task :cleanup_duplicate_addresses, [:mode] => [:environment] do |_task, args|
+    dry_run = args[:mode] != "live-run"
+    total_deleted = 0
+
+    puts "[DRY RUN] No records will be modified" if dry_run && !Rails.env.test?
+
+    # Process each address type: operator (1), contact (2), site (3)
+    WasteExemptionsEngine::Address.address_types.each do |type_name, type_value|
+      next if type_value.zero? # skip unknown
+
+      duplicate_groups = find_duplicate_groups(type_name, type_value)
+      next if duplicate_groups.empty?
+
+      unless Rails.env.test?
+        puts "Processing #{duplicate_groups.length} registrations with duplicate #{type_name} addresses"
+      end
+
+      duplicate_groups.each do |registration_id, address_ids|
+        deleted = deduplicate_address_group(registration_id, address_ids, dry_run: dry_run)
+        total_deleted += deleted
+      end
+    end
+
+    puts "Total addresses #{dry_run ? 'to delete' : 'deleted'}: #{total_deleted}" unless Rails.env.test?
+  end
+end
+
+def find_duplicate_groups(type_name, type_value)
+  scope = WasteExemptionsEngine::Address.where(address_type: type_value).where.not(registration_id: nil)
+
+  # For site addresses, exclude legitimate multisite registrations
+  if type_name == "site"
+    multisite_registration_ids = WasteExemptionsEngine::Registration
+                                 .where(is_multisite_registration: true)
+                                 .pluck(:id)
+    scope = scope.where.not(registration_id: multisite_registration_ids) if multisite_registration_ids.any?
+  end
+
+  scope.group(:registration_id)
+       .having("COUNT(*) > 1")
+       .pluck(:registration_id, Arel.sql("ARRAY_AGG(id ORDER BY id)"))
+       .to_h
+end
+
+# rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength
+def deduplicate_address_group(registration_id, address_ids, dry_run: false)
+  addresses = WasteExemptionsEngine::Address.where(id: address_ids)
+  # double check all addresses belong to same registration
+  return 0 if addresses.pluck(:registration_id).uniq != [registration_id]
+  # double check all addresses belong to the same type
+  return 0 if addresses.pluck(:address_type).uniq.count != 1
+
+  with_exemptions = address_ids.select do |id|
+    WasteExemptionsEngine::RegistrationExemption.exists?(address_id: id)
+  end
+
+  without_exemptions = address_ids - with_exemptions
+
+  ids_to_delete = if with_exemptions.any?
+                    # Keep addresses that have exemptions, delete the rest
+                    without_exemptions
+                  else
+                    # No exemptions on any duplicate — keep the first (lowest id), delete the rest
+                    address_ids[1..]
+                  end
+
+  return 0 if ids_to_delete.empty?
+
+  unless Rails.env.test?
+    prefix = dry_run ? "[DRY RUN] Would delete" : "Deleting"
+    puts "#{prefix} addresses #{ids_to_delete.join(', ')} for registration #{registration_id}"
+  end
+
+  unless dry_run
+    ActiveRecord::Base.transaction do
+      WasteExemptionsEngine::Address.where(id: ids_to_delete).destroy_all
+    end
+  end
+
+  ids_to_delete.length
+end
+# rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength

--- a/lib/tasks/one_off/cleanup_orphan_addresses.rake
+++ b/lib/tasks/one_off/cleanup_orphan_addresses.rake
@@ -1,5 +1,32 @@
 # frozen_string_literal: true
 
+module CleanupOrphanAddresses
+  module_function
+
+  def cleanup_orphan_addresses(dry_run: false)
+    orphans = WasteExemptionsEngine::Address.where(registration_id: nil)
+    safe_to_delete = orphans.where.missing(:registration_exemptions)
+    ids = safe_to_delete.pluck(:id)
+
+    prefix = dry_run ? "[DRY RUN] Would delete" : "Deleting"
+    puts "#{prefix} orphan address IDs: #{ids.join(', ')}" unless Rails.env.test? || ids.empty?
+
+    WasteExemptionsEngine::Address.where(id: ids).delete_all unless dry_run
+    ids.length
+  end
+
+  def cleanup_orphan_transient_addresses(dry_run: false)
+    orphans = WasteExemptionsEngine::TransientAddress.where(transient_registration_id: nil)
+    ids = orphans.pluck(:id)
+
+    prefix = dry_run ? "[DRY RUN] Would delete" : "Deleting"
+    puts "#{prefix} orphan transient_address IDs: #{ids.join(', ')}" unless Rails.env.test? || ids.empty?
+
+    WasteExemptionsEngine::TransientAddress.where(id: ids).delete_all unless dry_run
+    ids.length
+  end
+end
+
 namespace :one_off do
   # rake one_off:cleanup_orphan_addresses[live-run] to perform actual deletions,
   # otherwise runs in dry-run mode by default
@@ -9,33 +36,10 @@ namespace :one_off do
 
     puts "[DRY RUN] No records will be modified" if dry_run && !Rails.env.test?
 
-    orphan_address_count = cleanup_orphan_addresses(dry_run: dry_run)
+    orphan_address_count = CleanupOrphanAddresses.cleanup_orphan_addresses(dry_run: dry_run)
     puts "Orphan addresses #{dry_run ? 'to delete' : 'deleted'}: #{orphan_address_count}" unless Rails.env.test?
 
-    orphan_count = cleanup_orphan_transient_addresses(dry_run: dry_run)
+    orphan_count = CleanupOrphanAddresses.cleanup_orphan_transient_addresses(dry_run: dry_run)
     puts "Orphan transient_addresses #{dry_run ? 'to delete' : 'deleted'}: #{orphan_count}" unless Rails.env.test?
   end
-end
-
-def cleanup_orphan_addresses(dry_run: false)
-  orphans = WasteExemptionsEngine::Address.where(registration_id: nil)
-  safe_to_delete = orphans.where.missing(:registration_exemptions)
-  ids = safe_to_delete.pluck(:id)
-
-  prefix = dry_run ? "[DRY RUN] Would delete" : "Deleting"
-  puts "#{prefix} orphan address IDs: #{ids.join(', ')}" unless Rails.env.test? || ids.empty?
-
-  WasteExemptionsEngine::Address.where(id: ids).delete_all unless dry_run
-  ids.length
-end
-
-def cleanup_orphan_transient_addresses(dry_run: false)
-  orphans = WasteExemptionsEngine::TransientAddress.where(transient_registration_id: nil)
-  ids = orphans.pluck(:id)
-
-  prefix = dry_run ? "[DRY RUN] Would delete" : "Deleting"
-  puts "#{prefix} orphan transient_address IDs: #{ids.join(', ')}" unless Rails.env.test? || ids.empty?
-
-  WasteExemptionsEngine::TransientAddress.where(id: ids).delete_all unless dry_run
-  ids.length
 end

--- a/lib/tasks/one_off/cleanup_orphan_addresses.rake
+++ b/lib/tasks/one_off/cleanup_orphan_addresses.rake
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+namespace :one_off do
+  # rake one_off:cleanup_orphan_addresses[live-run] to perform actual deletions,
+  # otherwise runs in dry-run mode by default
+  desc "Remove orphan addresses and transient addresses with no associated registration"
+  task :cleanup_orphan_addresses, [:mode] => [:environment] do |_task, args|
+    dry_run = args[:mode] != "live-run"
+
+    puts "[DRY RUN] No records will be modified" if dry_run && !Rails.env.test?
+
+    orphan_address_count = cleanup_orphan_addresses(dry_run: dry_run)
+    puts "Orphan addresses #{dry_run ? 'to delete' : 'deleted'}: #{orphan_address_count}" unless Rails.env.test?
+
+    orphan_count = cleanup_orphan_transient_addresses(dry_run: dry_run)
+    puts "Orphan transient_addresses #{dry_run ? 'to delete' : 'deleted'}: #{orphan_count}" unless Rails.env.test?
+  end
+end
+
+def cleanup_orphan_addresses(dry_run: false)
+  orphans = WasteExemptionsEngine::Address.where(registration_id: nil)
+  safe_to_delete = orphans.where.missing(:registration_exemptions)
+  ids = safe_to_delete.pluck(:id)
+
+  unless Rails.env.test? || ids.empty?
+    prefix = dry_run ? "[DRY RUN] Would delete" : "Deleting"
+    puts "#{prefix} orphan address IDs: #{ids.join(', ')}"
+  end
+
+  WasteExemptionsEngine::Address.where(id: ids).delete_all unless dry_run
+  ids.length
+end
+
+def cleanup_orphan_transient_addresses(dry_run: false)
+  orphans = WasteExemptionsEngine::TransientAddress.where(transient_registration_id: nil)
+  ids = orphans.pluck(:id)
+
+  unless Rails.env.test? || ids.empty?
+    prefix = dry_run ? "[DRY RUN] Would delete" : "Deleting"
+    puts "#{prefix} orphan transient_address IDs: #{ids.join(', ')}"
+  end
+
+  WasteExemptionsEngine::TransientAddress.where(id: ids).delete_all unless dry_run
+  ids.length
+end

--- a/lib/tasks/one_off/cleanup_orphan_addresses.rake
+++ b/lib/tasks/one_off/cleanup_orphan_addresses.rake
@@ -22,10 +22,8 @@ def cleanup_orphan_addresses(dry_run: false)
   safe_to_delete = orphans.where.missing(:registration_exemptions)
   ids = safe_to_delete.pluck(:id)
 
-  unless Rails.env.test? || ids.empty?
-    prefix = dry_run ? "[DRY RUN] Would delete" : "Deleting"
-    puts "#{prefix} orphan address IDs: #{ids.join(', ')}"
-  end
+  prefix = dry_run ? "[DRY RUN] Would delete" : "Deleting"
+  puts "#{prefix} orphan address IDs: #{ids.join(', ')}" unless Rails.env.test? || ids.empty?
 
   WasteExemptionsEngine::Address.where(id: ids).delete_all unless dry_run
   ids.length
@@ -35,10 +33,8 @@ def cleanup_orphan_transient_addresses(dry_run: false)
   orphans = WasteExemptionsEngine::TransientAddress.where(transient_registration_id: nil)
   ids = orphans.pluck(:id)
 
-  unless Rails.env.test? || ids.empty?
-    prefix = dry_run ? "[DRY RUN] Would delete" : "Deleting"
-    puts "#{prefix} orphan transient_address IDs: #{ids.join(', ')}"
-  end
+  prefix = dry_run ? "[DRY RUN] Would delete" : "Deleting"
+  puts "#{prefix} orphan transient_address IDs: #{ids.join(', ')}" unless Rails.env.test? || ids.empty?
 
   WasteExemptionsEngine::TransientAddress.where(id: ids).delete_all unless dry_run
   ids.length

--- a/spec/lib/tasks/one_off/cleanup_duplicate_addresses_spec.rb
+++ b/spec/lib/tasks/one_off/cleanup_duplicate_addresses_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "one_off:cleanup_duplicate_addresses", type: :rake do
+
+  subject(:run_rake_task) { rake_task.invoke("live-run") }
+
+  include_context "rake"
+
+  let(:rake_task) { Rake::Task["one_off:cleanup_duplicate_addresses"] }
+
+  after { rake_task.reenable }
+
+  it { expect { run_rake_task }.not_to raise_error }
+
+  context "when running in dry run mode (default)" do
+    let(:registration) { create(:registration) }
+
+    before do
+      create(:address, :site_address, registration: registration)
+    end
+
+    it "does not delete any addresses" do
+      expect do
+        rake_task.invoke
+      end.not_to change(WasteExemptionsEngine::Address, :count)
+    end
+  end
+
+  context "when a registration has duplicate site addresses" do
+    let(:registration) { create(:registration) }
+    let(:kept_address) { registration.addresses.find_by(address_type: "site") }
+
+    before do
+      # Create a duplicate site address with no exemptions
+      create(:address, :site_address, registration: registration)
+    end
+
+    it "removes the duplicate" do
+      expect { run_rake_task }.to change {
+        registration.addresses.where(address_type: "site").count
+      }.from(2).to(1)
+    end
+
+    it "keeps the address that has registration_exemptions" do
+      run_rake_task
+
+      expect(registration.addresses.where(address_type: "site").pluck(:id)).to eq([kept_address.id])
+    end
+  end
+
+  context "when a registration has duplicate operator addresses" do
+    let(:registration) { create(:registration) }
+
+    before do
+      create(:address, :operator_address, registration: registration)
+    end
+
+    it "removes the duplicate" do
+      expect { run_rake_task }.to change {
+        registration.addresses.where(address_type: "operator").count
+      }.from(2).to(1)
+    end
+
+    it "keeps the first address (lowest id)" do
+      first_id = registration.addresses.where(address_type: "operator").order(:id).first.id
+
+      run_rake_task
+
+      expect(registration.addresses.where(address_type: "operator").pluck(:id)).to eq([first_id])
+    end
+  end
+
+  context "when a registration has duplicate contact addresses" do
+    let(:registration) { create(:registration) }
+
+    before do
+      create(:address, :contact_address, registration: registration)
+    end
+
+    it "removes the duplicate" do
+      expect { run_rake_task }.to change {
+        registration.addresses.where(address_type: "contact").count
+      }.from(2).to(1)
+    end
+  end
+
+  context "when the duplicate address has exemptions and the other does not" do
+    let(:registration) { create(:registration) }
+    let!(:address_with_exemptions) { registration.addresses.find_by(address_type: "site") }
+
+    before do
+      create(:address, :site_address, registration: registration)
+    end
+
+    it "keeps the address with exemptions" do
+      run_rake_task
+
+      remaining = registration.addresses.where(address_type: "site")
+      expect(remaining.count).to eq(1)
+      expect(remaining.first.id).to eq(address_with_exemptions.id)
+    end
+
+    it "does not delete any registration_exemptions" do
+      expect { run_rake_task }.not_to change {
+        registration.registration_exemptions.count
+      }
+    end
+  end
+
+  context "when neither duplicate has exemptions" do
+    let(:registration) { create(:registration) }
+
+    before do
+      # Remove exemptions from the site address
+      registration.registration_exemptions.update_all(address_id: nil) # rubocop:disable Rails/SkipsModelValidations
+      create(:address, :site_address, registration: registration)
+    end
+
+    it "keeps the first address (lowest id)" do
+      first_id = registration.addresses.where(address_type: "site").order(:id).first.id
+
+      run_rake_task
+
+      remaining = registration.addresses.where(address_type: "site")
+      expect(remaining.count).to eq(1)
+      expect(remaining.first.id).to eq(first_id)
+    end
+  end
+
+  context "when a legitimate multisite registration has multiple site addresses" do
+    before { create(:registration, :multisite_complete) }
+
+    it "does not remove any site addresses" do
+      expect { run_rake_task }.not_to change(WasteExemptionsEngine::Address.where(address_type: "site"), :count)
+    end
+  end
+
+  context "when a registration has no duplicate addresses" do
+    before { create(:registration) }
+
+    it "does not modify any addresses" do
+      expect { run_rake_task }.not_to change(WasteExemptionsEngine::Address, :count)
+    end
+  end
+end

--- a/spec/lib/tasks/one_off/cleanup_orphan_addresses_spec.rb
+++ b/spec/lib/tasks/one_off/cleanup_orphan_addresses_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "one_off:cleanup_orphan_addresses", type: :rake do
+
+  subject(:run_rake_task) { rake_task.invoke("live-run") }
+
+  include_context "rake"
+
+  let(:rake_task) { Rake::Task["one_off:cleanup_orphan_addresses"] }
+
+  after { rake_task.reenable }
+
+  it { expect { run_rake_task }.not_to raise_error }
+
+  context "when running in dry run mode (default)" do
+    before do
+      create(:address, address_type: 1, mode: 1, registration_id: nil)
+    end
+
+    it "does not delete any addresses" do
+      expect do
+        rake_task.invoke
+      end.not_to change { WasteExemptionsEngine::Address.where(registration_id: nil).count }
+    end
+  end
+
+  context "when there are orphan addresses with no registration" do
+    before do
+      create(:address, address_type: 1, mode: 1, registration_id: nil)
+      create(:address, address_type: 3, mode: 1, registration_id: nil)
+    end
+
+    it "deletes the orphan addresses" do
+      expect { run_rake_task }.to change {
+        WasteExemptionsEngine::Address.where(registration_id: nil).count
+      }.by(-2)
+    end
+  end
+
+  context "when there are orphan transient_addresses" do
+    before do
+      create(:transient_address, address_type: 3, mode: 1, transient_registration_id: nil)
+      create(:transient_address, address_type: 3, mode: 1, transient_registration_id: nil)
+    end
+
+    it "deletes the orphan transient_addresses" do
+      expect { run_rake_task }.to change {
+        WasteExemptionsEngine::TransientAddress.where(transient_registration_id: nil).count
+      }.by(-2)
+    end
+  end
+end


### PR DESCRIPTION
WEX - duplicate sites for legacy single site registration
https://eaflood.atlassian.net/browse/RUBY-4179

Added 2 rake tasks:
 - rake tasks for cleaning up duplicate registration addresses
 - rake tasks for cleaning up orphan addresses