### PR TITLE
[RUBY-4194] Fix charge amount calculation for multisite registrations in finance export

### DIFF
--- a/app/presenters/reports/finance_data_report/additional_compliance_charge_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/additional_compliance_charge_row_presenter.rb
@@ -2,43 +2,17 @@
 
 module Reports
   module FinanceDataReport
-    class AdditionalComplianceChargeRowPresenter < BaseRegistrationRowPresenter
+    class AdditionalComplianceChargeRowPresenter < ComplianceChargeRowPresenter
       def charge_type
         "compliance_additional"
       end
 
-      def charge_amount
-        charge_amount = if @registration.multisite?
-                          @secondary_object.additional_compliance_charge_amount /
-                            @secondary_object.charge_detail.site_count
-                        else
-                          @secondary_object.additional_compliance_charge_amount
-                        end
-
-        display_pence_as_pounds_and_pence(pence: charge_amount,
-                                          hide_pence_if_zero: true)
-      end
-
-      def charge_band
-        @secondary_object.band.sequence
-      end
-
-      def exemption
-        @secondary_object.charge_detail.order.exemptions.select do |e|
-          e.band_id == @secondary_object.band_id && bucket_exemption_codes.exclude?(e.code)
-        end.map(&:code).sort.join(", ")
-      end
-
-      def balance
-        @total -= @secondary_object.additional_compliance_charge_amount
-        display_pence_as_pounds_and_pence(pence: @total,
-                                          hide_pence_if_zero: true)
-      end
-
-      private
-
-      def bucket_exemption_codes
-        @secondary_object.charge_detail.order.bucket&.exemptions&.map(&:code) || []
+      def charge_amount_in_pence
+        if @registration.multisite?
+          @secondary_object.additional_compliance_charge_amount / @secondary_object.charge_detail.site_count
+        else
+          @secondary_object.additional_compliance_charge_amount
+        end
       end
     end
   end

--- a/app/presenters/reports/finance_data_report/additional_compliance_charge_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/additional_compliance_charge_row_presenter.rb
@@ -8,7 +8,13 @@ module Reports
       end
 
       def charge_amount
-        display_pence_as_pounds_and_pence(pence: @secondary_object.additional_compliance_charge_amount,
+        charge_amount = if @registration.multisite?
+                          @secondary_object.additional_compliance_charge_amount / @secondary_object.charge_detail.site_count
+                        else
+                          @secondary_object.additional_compliance_charge_amount
+                        end
+
+        display_pence_as_pounds_and_pence(pence: charge_amount,
                                           hide_pence_if_zero: true)
       end
 

--- a/app/presenters/reports/finance_data_report/additional_compliance_charge_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/additional_compliance_charge_row_presenter.rb
@@ -9,7 +9,8 @@ module Reports
 
       def charge_amount
         charge_amount = if @registration.multisite?
-                          @secondary_object.additional_compliance_charge_amount / @secondary_object.charge_detail.site_count
+                          @secondary_object.additional_compliance_charge_amount /
+                            @secondary_object.charge_detail.site_count
                         else
                           @secondary_object.additional_compliance_charge_amount
                         end

--- a/app/presenters/reports/finance_data_report/compliance_charge_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/compliance_charge_row_presenter.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Reports
+  module FinanceDataReport
+    class ComplianceChargeRowPresenter < BaseRegistrationRowPresenter
+      def charge_band
+        @secondary_object.band.sequence
+      end
+
+      def charge_amount_in_pence
+        raise NotImplementedError
+      end
+
+      def charge_amount
+        display_pence_as_pounds_and_pence(pence: charge_amount_in_pence,
+                                          hide_pence_if_zero: true)
+      end
+
+      def exemption
+        @secondary_object.charge_detail.order.exemptions.select do |e|
+          e.band_id == @secondary_object.band_id && bucket_exemption_codes.exclude?(e.code)
+        end.map(&:code).sort.join(", ")
+      end
+
+      def balance
+        @total -= charge_amount_in_pence
+        display_pence_as_pounds_and_pence(pence: @total,
+                                          hide_pence_if_zero: true)
+      end
+
+      private
+
+      def bucket_exemption_codes
+        @secondary_object.charge_detail.order.bucket&.exemptions&.map(&:code) || []
+      end
+    end
+  end
+end

--- a/app/presenters/reports/finance_data_report/initial_compliance_charge_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/initial_compliance_charge_row_presenter.rb
@@ -2,43 +2,17 @@
 
 module Reports
   module FinanceDataReport
-    class InitialComplianceChargeRowPresenter < BaseRegistrationRowPresenter
+    class InitialComplianceChargeRowPresenter < ComplianceChargeRowPresenter
       def charge_type
         "compliance_initial"
       end
 
-      def charge_amount
-        charge_amount = if @registration.multisite?
-                          @secondary_object.initial_compliance_charge_amount /
-                            @secondary_object.charge_detail.site_count
-                        else
-                          @secondary_object.initial_compliance_charge_amount
-                        end
-
-        display_pence_as_pounds_and_pence(pence: charge_amount,
-                                          hide_pence_if_zero: true)
-      end
-
-      def charge_band
-        @secondary_object.band.sequence
-      end
-
-      def exemption
-        @secondary_object.charge_detail.order.exemptions.select do |e|
-          e.band_id == @secondary_object.band_id && bucket_exemption_codes.exclude?(e.code)
-        end.map(&:code).sort.join(", ")
-      end
-
-      def balance
-        @total -= @secondary_object.initial_compliance_charge_amount
-        display_pence_as_pounds_and_pence(pence: @total,
-                                          hide_pence_if_zero: true)
-      end
-
-      private
-
-      def bucket_exemption_codes
-        @secondary_object.charge_detail.order.bucket&.exemptions&.map(&:code) || []
+      def charge_amount_in_pence
+        if @registration.multisite?
+          @secondary_object.initial_compliance_charge_amount / @secondary_object.charge_detail.site_count
+        else
+          @secondary_object.initial_compliance_charge_amount
+        end
       end
     end
   end

--- a/app/presenters/reports/finance_data_report/initial_compliance_charge_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/initial_compliance_charge_row_presenter.rb
@@ -8,7 +8,13 @@ module Reports
       end
 
       def charge_amount
-        display_pence_as_pounds_and_pence(pence: @secondary_object.initial_compliance_charge_amount,
+        charge_amount = if @registration.multisite?
+                          @secondary_object.initial_compliance_charge_amount / @secondary_object.charge_detail.site_count
+                        else
+                          @secondary_object.initial_compliance_charge_amount
+                        end
+
+        display_pence_as_pounds_and_pence(pence: charge_amount,
                                           hide_pence_if_zero: true)
       end
 

--- a/app/presenters/reports/finance_data_report/initial_compliance_charge_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/initial_compliance_charge_row_presenter.rb
@@ -9,7 +9,8 @@ module Reports
 
       def charge_amount
         charge_amount = if @registration.multisite?
-                          @secondary_object.initial_compliance_charge_amount / @secondary_object.charge_detail.site_count
+                          @secondary_object.initial_compliance_charge_amount /
+                            @secondary_object.charge_detail.site_count
                         else
                           @secondary_object.initial_compliance_charge_amount
                         end

--- a/spec/presenters/reports/finance_data_report/additional_compliance_charge_row_presenter_spec.rb
+++ b/spec/presenters/reports/finance_data_report/additional_compliance_charge_row_presenter_spec.rb
@@ -25,8 +25,24 @@ module Reports
       end
 
       describe "#charge_amount" do
-        it "returns the formatted charge amount" do
-          expect(presenter.charge_amount).to eq("20")
+        context "when registration is single site" do
+          it "returns the formatted charge amount" do
+            expect(presenter.charge_amount).to eq("20")
+          end
+        end
+
+        context "when registration is multisite" do
+          let(:registration) { build(:registration, :multisite, reference: "REG123", submitted_at: Time.zone.now, account: account) }
+          let(:site_address) { build(:address, registration: registration) }
+          let(:presenter) { described_class.new(registration: registration, secondary_object: band_charge_detail, site_address: site_address, total: -1150) }
+
+          before do
+            allow(order.charge_detail).to receive(:site_count).and_return(2)
+          end
+
+          it "returns the formatted charge amount divided by site count" do
+            expect(presenter.charge_amount).to eq("10")
+          end
         end
       end
 

--- a/spec/presenters/reports/finance_data_report/additional_compliance_charge_row_presenter_spec.rb
+++ b/spec/presenters/reports/finance_data_report/additional_compliance_charge_row_presenter_spec.rb
@@ -24,10 +24,10 @@ module Reports
         end
       end
 
-      describe "#charge_amount" do
+      describe "#charge_amount_in_pence" do
         context "when registration is single site" do
-          it "returns the formatted charge amount" do
-            expect(presenter.charge_amount).to eq("20")
+          it "returns the formatted charge amount in pence" do
+            expect(presenter.charge_amount_in_pence).to eq(2000)
           end
         end
 
@@ -41,41 +41,8 @@ module Reports
           end
 
           it "returns the formatted charge amount divided by site count" do
-            expect(presenter.charge_amount).to eq("10")
+            expect(presenter.charge_amount_in_pence).to eq(1000)
           end
-        end
-      end
-
-      describe "#charge_band" do
-        it "returns the band sequence" do
-          expect(presenter.charge_band).to eq(2)
-        end
-      end
-
-      describe "#exemption" do
-        context "when there are no farmer exemptions" do
-          it "returns exemption code(s)" do
-            expect(presenter.exemption).to be_present
-          end
-        end
-
-        context "when there are farmer exemptions" do
-          let(:bucket) { build(:bucket, :farmer_exemptions) }
-          let(:order) { build(:order, :with_exemptions, :with_charge_detail, order_owner: account, bucket: bucket) }
-
-          it "does not include farmer exemption code(s)" do
-            farmer_exemption = order.exemptions.last
-            bucket.exemptions << farmer_exemption
-
-            expect(presenter.exemption).to be_present
-            expect(presenter.exemption).not_to include(farmer_exemption.code)
-          end
-        end
-      end
-
-      describe "#balance" do
-        it "returns the formatted balance amount" do
-          expect(presenter.balance).to eq("-31.50")
         end
       end
     end

--- a/spec/presenters/reports/finance_data_report/compliance_charge_row_presenter_spec.rb
+++ b/spec/presenters/reports/finance_data_report/compliance_charge_row_presenter_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Reports
+  module FinanceDataReport
+    RSpec.describe ComplianceChargeRowPresenter do
+      let(:account) { build(:account) }
+      let(:order) { build(:order, :with_exemptions, :with_charge_detail, order_owner: account) }
+
+      let(:band_charge_detail) do
+        band_charge_detail = order.charge_detail.band_charge_details.first
+        band_charge_detail.initial_compliance_charge_amount = 1000
+        band_charge_detail.band.sequence = 2
+        band_charge_detail
+      end
+
+      let(:registration) { build(:registration, reference: "REG123", submitted_at: Time.zone.now, account: account) }
+      let(:presenter) { described_class.new(registration: registration, secondary_object: band_charge_detail, total: -1000) }
+
+      describe "#charge_band" do
+        it "returns the band sequence" do
+          expect(presenter.charge_band).to eq(2)
+        end
+      end
+
+      describe "#charge_amount_in_pence" do
+        it "raises NotImplementedError" do
+          expect { presenter.charge_amount_in_pence }.to raise_error(NotImplementedError)
+        end
+      end
+
+      describe "#charge_amount" do
+        before do
+          allow(presenter).to receive(:charge_amount_in_pence).and_return(1000)
+        end
+
+        it "returns the formatted charge amount" do
+          expect(presenter.charge_amount).to eq("10")
+        end
+      end
+
+      describe "#exemption" do
+        context "when there are no farmer exemptions" do
+          it "returns exemption code(s)" do
+            expect(presenter.exemption).to be_present
+            order.exemptions.each do |exemption|
+              expect(presenter.exemption).to include(exemption.code)
+            end
+          end
+        end
+
+        context "when there are farmer exemptions" do
+          let(:bucket) { build(:bucket, :farmer_exemptions) }
+          let(:order) { build(:order, :with_exemptions, :with_charge_detail, order_owner: account, bucket: bucket) }
+
+          it "does not include farmer exemption code(s)" do
+            farmer_exemption = order.exemptions.last
+            bucket.exemptions << farmer_exemption
+
+            expect(presenter.exemption).to be_present
+            expect(presenter.exemption).not_to include(farmer_exemption.code)
+          end
+        end
+      end
+
+      describe "#balance" do
+        before do
+          allow(presenter).to receive(:charge_amount_in_pence).and_return(1000)
+        end
+
+        it "returns the formatted balance amount" do
+          expect(presenter.balance).to eq("-20")
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/reports/finance_data_report/initial_compliance_charge_row_presenter_spec.rb
+++ b/spec/presenters/reports/finance_data_report/initial_compliance_charge_row_presenter_spec.rb
@@ -25,8 +25,24 @@ module Reports
       end
 
       describe "#charge_amount" do
-        it "returns the formatted charge amount" do
-          expect(presenter.charge_amount).to eq("10")
+        context "when registration is single site" do
+          it "returns the formatted charge amount" do
+            expect(presenter.charge_amount).to eq("10")
+          end
+        end
+
+        context "when registration is multisite" do
+          let(:registration) { build(:registration, :multisite, reference: "REG123", submitted_at: Time.zone.now, account: account) }
+          let(:site_address) { build(:address, registration: registration) }
+          let(:presenter) { described_class.new(registration: registration, secondary_object: band_charge_detail, site_address: site_address, total: -1000) }
+
+          before do
+            allow(order.charge_detail).to receive(:site_count).and_return(2)
+          end
+
+          it "returns the formatted charge amount divided by site count" do
+            expect(presenter.charge_amount).to eq("5")
+          end
         end
       end
 

--- a/spec/presenters/reports/finance_data_report/initial_compliance_charge_row_presenter_spec.rb
+++ b/spec/presenters/reports/finance_data_report/initial_compliance_charge_row_presenter_spec.rb
@@ -24,10 +24,10 @@ module Reports
         end
       end
 
-      describe "#charge_amount" do
+      describe "#charge_amount_in_pence" do
         context "when registration is single site" do
           it "returns the formatted charge amount" do
-            expect(presenter.charge_amount).to eq("10")
+            expect(presenter.charge_amount_in_pence).to eq(1000)
           end
         end
 
@@ -41,44 +41,8 @@ module Reports
           end
 
           it "returns the formatted charge amount divided by site count" do
-            expect(presenter.charge_amount).to eq("5")
+            expect(presenter.charge_amount_in_pence).to eq(500)
           end
-        end
-      end
-
-      describe "#charge_band" do
-        it "returns the band sequence" do
-          expect(presenter.charge_band).to eq(2)
-        end
-      end
-
-      describe "#exemption" do
-        context "when there are no farmer exemptions" do
-          it "returns exemption code(s)" do
-            expect(presenter.exemption).to be_present
-            order.exemptions.each do |exemption|
-              expect(presenter.exemption).to include(exemption.code)
-            end
-          end
-        end
-
-        context "when there are farmer exemptions" do
-          let(:bucket) { build(:bucket, :farmer_exemptions) }
-          let(:order) { build(:order, :with_exemptions, :with_charge_detail, order_owner: account, bucket: bucket) }
-
-          it "does not include farmer exemption code(s)" do
-            farmer_exemption = order.exemptions.last
-            bucket.exemptions << farmer_exemption
-
-            expect(presenter.exemption).to be_present
-            expect(presenter.exemption).not_to include(farmer_exemption.code)
-          end
-        end
-      end
-
-      describe "#balance" do
-        it "returns the formatted balance amount" do
-          expect(presenter.balance).to eq("-20")
         end
       end
     end


### PR DESCRIPTION
WEX - Finance Export - incorrect compliance_initial charge
https://eaflood.atlassian.net/browse/RUBY-4194

- Extracted common logic from InitialComplianceChargeRowPresenter and AdditionalComplianceChargeRowPresenter into a parent class ComplianceChargeRowPresenter
- Fixed charge amount calculation for multisite registrations in finance export
- Fixed an issue with balance not being calculated properly for multisite registrations