### PR TITLE
[RUBY-4116] Add devise-security session_limitable to restrict simultaneous logins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem "cancancan", "~> 3.5"
 # Use Devise for user authentication
 gem "devise"
 gem "devise_invitable"
+gem "devise-security"
 
 # Use Kaminari for pagination
 gem "kaminari", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,6 +218,8 @@ GEM
       railties (>= 7.0)
       responders
       warden (~> 1.2.3)
+    devise-security (0.18.0)
+      devise (>= 4.3.0)
     devise_invitable (2.0.11)
       actionmailer (>= 5.0)
       devise (>= 4.6)
@@ -639,6 +641,7 @@ DEPENDENCIES
   defra_ruby_style
   defra_ruby_template (~> 5.11)
   devise
+  devise-security
   devise_invitable
   dotenv-rails
   factory_bot_rails
@@ -744,6 +747,7 @@ CHECKSUMS
   defra_ruby_template (5.11.1) sha256=9d8c1d7e765b92651cc8975010cb825fda0284e7a74b7d3f24a121dd1274faf9
   defra_ruby_validators (3.0.0) sha256=8a483981012306a203e19afe1b230142304671ced7155f37aebe946869bb4a9d
   devise (5.0.2) sha256=254330c9290e612ad9681e8a18c96aa21fb95bc391af936b84480965444bb0b6
+  devise-security (0.18.0) sha256=fc06be1624b5151044ff9c5d8e61abdfa7d56eb16bfdaec16a11235d54708513
   devise_invitable (2.0.11) sha256=780014f74b8848218d93a297300590120f1742984396acf3d6799ab49b9a6a3f
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,6 +53,7 @@ class User < WasteExemptionsEngine::ApplicationRecord
          :lockable,
          :recoverable,
          :trackable,
+         :session_limitable,
          :validatable
 
   # Devise security improvements, used to invalidate old sessions on logout

--- a/config/locales/devise.security_extension.en.yml
+++ b/config/locales/devise.security_extension.en.yml
@@ -1,0 +1,4 @@
+en:
+  devise:
+    failure:
+      session_limited: "Your login credentials were used in another browser. Please sign in again to continue in this browser."

--- a/config/locales/devise.security_extension.en.yml
+++ b/config/locales/devise.security_extension.en.yml
@@ -1,4 +1,4 @@
 en:
   devise:
     failure:
-      session_limited: "Your login credentials were used in another browser. Please sign in again to continue in this browser."
+      session_limited: "You have been signed out of your account because it has been accessed by another user. Reset your password to login again. Do not share your new password."

--- a/db/migrate/20260225172751_add_unique_session_id_to_users.rb
+++ b/db/migrate/20260225172751_add_unique_session_id_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueSessionIdToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :unique_session_id, :string, limit: 20
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_05_130000) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_25_172751) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -500,6 +500,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_05_130000) do
     t.datetime "last_sign_in_at"
     t.inet "current_sign_in_ip"
     t.inet "last_sign_in_ip"
+    t.string "unique_session_id", limit: 20
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
WEX - ITHC - restrict simultaneous login
https://eaflood.atlassian.net/browse/RUBY-4116

When a user signs in from a second browser, the first session is invalidated and the user is redirected to the sign-in page with an error message.