### PR TITLE
[RUBY-4201] Add summary and no compliance charge rows to finance data report

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ Metrics/BlockLength:
 
 Metrics/ClassLength:
   Exclude:
-  # Not worthwhile refacting now as the offense is marginal and we anticipate refactoring 
+  # Not worthwhile refacting now as the offense is marginal and we anticipate refactoring
   # this serializer anyway once we have more charge and payment data in the system.
     - app/models/reports/finance_data_report/data_serializer.rb
 
@@ -87,6 +87,7 @@ Naming/PredicatePrefix:
   Exclude:
     # Presenter column names are driven by the registration field names and can't be changed
     - 'app/presenters/reports/finance_data_report/base_registration_row_presenter.rb'
+    - 'app/presenters/reports/finance_data_report/summary_row_presenter.rb'
 
 FactoryBot/ExcessiveCreateList:
   Exclude:

--- a/app/models/reports/finance_data_report/data_serializer.rb
+++ b/app/models/reports/finance_data_report/data_serializer.rb
@@ -193,14 +193,10 @@ module Reports
       def summary_row(registration)
         presenter = FinanceDataReport::SummaryRowPresenter.new(
           registration:,
-          secondary_object: @charge_total,
-          total: @total,
-          show_payment_status: true
+          charge_total_in_pence: @charge_total,
+          balance_in_pence: @total
         )
-        output = ATTRIBUTES.map do |attribute|
-          presenter.public_send(attribute)
-        end
-        @total = presenter.total
+        output = presenter.to_row(ATTRIBUTES)
         [output]
       end
 

--- a/app/presenters/reports/finance_data_report/base_registration_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/base_registration_row_presenter.rb
@@ -7,11 +7,12 @@ module Reports
 
       include FinanceDetailsHelper
 
-      def initialize(registration:, secondary_object: nil, total: nil, site_address: nil)
+      def initialize(registration:, secondary_object: nil, total: nil, site_address: nil, show_payment_status: false)
         @registration = registration
         @secondary_object = secondary_object
         @total = total
         @site_address = site_address
+        @show_payment_status = show_payment_status
       end
 
       def registration_no
@@ -44,6 +45,10 @@ module Reports
 
       def charge_amount
         nil
+      end
+
+      def summary_charge_amount_in_pence
+        0
       end
 
       def charge_band
@@ -91,6 +96,7 @@ module Reports
       end
 
       def payment_status
+        return nil unless @show_payment_status
         return nil if @total.nil?
 
         if @total.negative?

--- a/app/presenters/reports/finance_data_report/base_registration_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/base_registration_row_presenter.rb
@@ -7,12 +7,11 @@ module Reports
 
       include FinanceDetailsHelper
 
-      def initialize(registration:, secondary_object: nil, total: nil, site_address: nil, show_payment_status: false)
+      def initialize(registration:, secondary_object: nil, total: nil, site_address: nil)
         @registration = registration
         @secondary_object = secondary_object
         @total = total
         @site_address = site_address
-        @show_payment_status = show_payment_status
       end
 
       def registration_no
@@ -96,16 +95,7 @@ module Reports
       end
 
       def payment_status
-        return nil unless @show_payment_status
-        return nil if @total.nil?
-
-        if @total.negative?
-          "Unpaid"
-        elsif @total.zero?
-          "Paid"
-        else
-          "Overpaid"
-        end
+        nil
       end
 
       def status

--- a/app/presenters/reports/finance_data_report/charge_adjustment_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/charge_adjustment_row_presenter.rb
@@ -11,6 +11,14 @@ module Reports
         display_pence_as_pounds_and_pence(pence: charge_adjustment_amount, hide_pence_if_zero: true)
       end
 
+      def summary_charge_amount_in_pence
+        charge_adjustment_amount
+      end
+
+      def comments
+        @secondary_object.reason.presence
+      end
+
       def balance
         @total -= charge_adjustment_amount
         display_pence_as_pounds_and_pence(pence: @total,

--- a/app/presenters/reports/finance_data_report/compliance_charge_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/compliance_charge_row_presenter.rb
@@ -16,6 +16,10 @@ module Reports
                                           hide_pence_if_zero: true)
       end
 
+      def summary_charge_amount_in_pence
+        charge_amount_in_pence
+      end
+
       def exemption
         @secondary_object.charge_detail.order.exemptions.select do |e|
           e.band_id == @secondary_object.band_id && bucket_exemption_codes.exclude?(e.code)

--- a/app/presenters/reports/finance_data_report/compliance_no_charge_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/compliance_no_charge_row_presenter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Reports
+  module FinanceDataReport
+    class ComplianceNoChargeRowPresenter < ComplianceChargeRowPresenter
+      def charge_type
+        "compliance_no_charge"
+      end
+
+      def charge_amount_in_pence
+        0
+      end
+    end
+  end
+end

--- a/app/presenters/reports/finance_data_report/farm_compliance_charge_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/farm_compliance_charge_row_presenter.rb
@@ -12,6 +12,10 @@ module Reports
                                           hide_pence_if_zero: true)
       end
 
+      def summary_charge_amount_in_pence
+        @secondary_object.bucket_charge_amount
+      end
+
       def exemption
         order = @secondary_object.order
         order_bucket = order.bucket

--- a/app/presenters/reports/finance_data_report/payment_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/payment_row_presenter.rb
@@ -14,6 +14,10 @@ module Reports
         display_pence_as_pounds_and_pence(pence: amount_to_credit, hide_pence_if_zero: true)
       end
 
+      def comments
+        @secondary_object.comments.presence
+      end
+
       def balance
         @total += amount_to_credit
         display_pence_as_pounds_and_pence(pence: @total, hide_pence_if_zero: true)

--- a/app/presenters/reports/finance_data_report/registration_charge_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/registration_charge_row_presenter.rb
@@ -11,6 +11,10 @@ module Reports
         display_pence_as_pounds_and_pence(pence: @secondary_object.registration_charge_amount, hide_pence_if_zero: true)
       end
 
+      def summary_charge_amount_in_pence
+        @secondary_object.registration_charge_amount
+      end
+
       def balance
         @total -= @secondary_object.registration_charge_amount
         display_pence_as_pounds_and_pence(pence: @total,

--- a/app/presenters/reports/finance_data_report/summary_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/summary_row_presenter.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Reports
+  module FinanceDataReport
+    class SummaryRowPresenter < BaseRegistrationRowPresenter
+      def charge_type
+        "summary"
+      end
+
+      def charge_amount
+        display_pence_as_pounds_and_pence(pence: summary_charge_total_in_pence, hide_pence_if_zero: true)
+      end
+
+      def balance
+        display_pence_as_pounds_and_pence(pence: @total, hide_pence_if_zero: true)
+      end
+
+      private
+
+      def summary_charge_total_in_pence
+        @secondary_object.to_i
+      end
+    end
+  end
+end

--- a/app/presenters/reports/finance_data_report/summary_row_presenter.rb
+++ b/app/presenters/reports/finance_data_report/summary_row_presenter.rb
@@ -2,23 +2,75 @@
 
 module Reports
   module FinanceDataReport
-    class SummaryRowPresenter < BaseRegistrationRowPresenter
+    class SummaryRowPresenter
+      include FinanceDetailsHelper
+
+      def initialize(registration:, charge_total_in_pence:, balance_in_pence:)
+        @registration = registration
+        @charge_total_in_pence = charge_total_in_pence
+        @balance_in_pence = balance_in_pence
+      end
+
+      def to_row(attributes)
+        attributes.map do |attribute|
+          next unless respond_to?(attribute)
+
+          public_send(attribute)
+        end
+      end
+
+      def registration_no
+        @registration.reference
+      end
+
+      def date
+        @registration.submitted_at.to_fs(:day_month_year_slashes)
+      end
+
+      def multisite
+        @registration.multisite? ? "TRUE" : "FALSE"
+      end
+
+      def organisation_name
+        @registration.operator_name
+      end
+
       def charge_type
         "summary"
       end
 
       def charge_amount
-        display_pence_as_pounds_and_pence(pence: summary_charge_total_in_pence, hide_pence_if_zero: true)
+        display_pence_as_pounds_and_pence(pence: @charge_total_in_pence, hide_pence_if_zero: true)
+      end
+
+      def on_a_farm
+        @registration.on_a_farm? ? "Yes" : "No"
+      end
+
+      def is_a_farmer
+        @registration.is_a_farmer? ? "Yes" : "No"
+      end
+
+      def ea_admin_area
+        @registration.site_address&.area
       end
 
       def balance
-        display_pence_as_pounds_and_pence(pence: @total, hide_pence_if_zero: true)
+        display_pence_as_pounds_and_pence(pence: @balance_in_pence, hide_pence_if_zero: true)
       end
 
-      private
+      def payment_status
+        if @balance_in_pence.negative?
+          "Unpaid"
+        elsif @balance_in_pence.zero?
+          "Paid"
+        else
+          "Overpaid"
+        end
+      end
 
-      def summary_charge_total_in_pence
-        @secondary_object.to_i
+      def status
+        @registration.state
       end
     end
   end

--- a/spec/models/reports/finance_data_report/data_serializer_spec.rb
+++ b/spec/models/reports/finance_data_report/data_serializer_spec.rb
@@ -2,445 +2,442 @@
 
 require "rails_helper"
 
-module Reports
-  module FinanceDataReport
-    RSpec.describe DataSerializer do
-      let(:account) { create(:account, :with_payment) }
+RSpec.describe Reports::FinanceDataReport::DataSerializer do
+  let(:account) { create(:account, :with_payment) }
+  let(:order) { create(:order, :with_exemptions, :with_charge_detail, order_owner: account) }
+  let(:charge_adjustment) { create(:charge_adjustment, account: account) }
+  let(:site_address) { create(:address, :site_address, premises: "Bar 123", area: "Wessex") }
+  let(:registration) { create(:registration, account: account, addresses: [site_address]) }
+
+  let(:serializer) { described_class.new }
+
+  shared_examples "a valid row with common fields" do |row_number|
+    it "has common fields populated correctly" do
+      aggregate_failures do
+        expect(csv[row_number]["registration_no"]).to eq(registration.reference)
+        expect(csv[row_number]["date"]).to eq(Time.zone.now.strftime("%d/%m/%Y"))
+        expect(csv[row_number]["multisite"]).to be_present
+        expect(csv[row_number]["organisation_name"]).to be_present
+        expect(csv[row_number]["on_a_farm"]).to be_present
+        expect(csv[row_number]["is_a_farmer"]).to be_present
+        expect(csv[row_number]["ea_admin_area"]).to be_present
+        expect(csv[row_number]["balance"]).to be_present
+        expect(csv[row_number]["status"]).to be_present
+      end
+    end
+  end
+
+  shared_examples "a valid registration charge row" do |row_number|
+    it_behaves_like "a valid row with common fields", row_number
+
+    it "has registration charge specific fields" do
+      aggregate_failures do
+        expect(csv[row_number]["site"]).to be_nil
+        expect(csv[row_number]["charge_type"]).to eq("registration")
+        expect(csv[row_number]["charge_amount"]).to be_present
+        expect(csv[row_number]["charge_band"]).to be_nil
+        expect(csv[row_number]["exemption"]).to be_nil
+        expect(csv[row_number]["payment_type"]).to be_nil
+        expect(csv[row_number]["refund_type"]).to be_nil
+        expect(csv[row_number]["reference"]).to be_nil
+        expect(csv[row_number]["comments"]).to be_nil
+        expect(csv[row_number]["payment_amount"]).to be_nil
+        expect(csv[row_number]["payment_status"]).to be_nil
+      end
+    end
+  end
+
+  shared_examples "a valid initial compliance charge row" do |row_number|
+    it_behaves_like "a valid row with common fields", row_number
+
+    it "has initial compliance charge specific fields" do
+      aggregate_failures do
+        expect(csv[row_number]["charge_type"]).to eq("compliance_initial")
+        expect(csv[row_number]["charge_amount"]).to be_present
+        expect(csv[row_number]["charge_band"]).to be_present
+        expect(csv[row_number]["exemption"]).to be_present
+        expect(csv[row_number]["payment_type"]).to be_nil
+        expect(csv[row_number]["refund_type"]).to be_nil
+        expect(csv[row_number]["reference"]).to be_nil
+        expect(csv[row_number]["comments"]).to be_nil
+        expect(csv[row_number]["payment_amount"]).to be_nil
+        expect(csv[row_number]["payment_status"]).to be_nil
+      end
+    end
+  end
+
+  shared_examples "a valid additional compliance charge row" do |row_number|
+    it_behaves_like "a valid row with common fields", row_number
+
+    it "has additional compliance charge specific fields" do
+      aggregate_failures do
+        expect(csv[row_number]["charge_type"]).to eq("compliance_additional")
+        expect(csv[row_number]["charge_amount"]).to be_present
+        expect(csv[row_number]["charge_band"]).to be_present
+        expect(csv[row_number]["exemption"]).to be_present
+        expect(csv[row_number]["payment_type"]).to be_nil
+        expect(csv[row_number]["refund_type"]).to be_nil
+        expect(csv[row_number]["reference"]).to be_nil
+        expect(csv[row_number]["comments"]).to be_nil
+        expect(csv[row_number]["payment_amount"]).to be_nil
+        expect(csv[row_number]["payment_status"]).to be_nil
+      end
+    end
+  end
+
+  shared_examples "a valid farm compliance charge row" do |row_number|
+    it_behaves_like "a valid row with common fields", row_number
+
+    it "has farm compliance charge specific fields" do
+      aggregate_failures do
+        expect(csv[row_number]["charge_type"]).to eq("compliance_farm")
+        expect(csv[row_number]["charge_amount"]).to be_present
+        expect(csv[row_number]["charge_band"]).to be_nil
+        expect(csv[row_number]["exemption"]).to be_present
+        expect(csv[row_number]["payment_type"]).to be_nil
+        expect(csv[row_number]["refund_type"]).to be_nil
+        expect(csv[row_number]["reference"]).to be_nil
+        expect(csv[row_number]["comments"]).to be_nil
+        expect(csv[row_number]["payment_amount"]).to be_nil
+        expect(csv[row_number]["on_a_farm"]).to be_truthy
+        expect(csv[row_number]["is_a_farmer"]).to be_truthy
+        expect(csv[row_number]["payment_status"]).to be_nil
+      end
+    end
+  end
+
+  shared_examples "a valid charge adjustment row" do |row_number|
+    it_behaves_like "a valid row with common fields", row_number
+
+    it "has charge adjustment specific fields" do
+      aggregate_failures do
+        expect(csv[row_number]["charge_type"]).to eq("charge_adjust")
+        expect(csv[row_number]["charge_amount"]).to be_present
+        expect(csv[row_number]["charge_band"]).to be_nil
+        expect(csv[row_number]["exemption"]).to be_nil
+        expect(csv[row_number]["payment_type"]).to be_nil
+        expect(csv[row_number]["refund_type"]).to be_nil
+        expect(csv[row_number]["reference"]).to be_nil
+        expect(csv[row_number]["comments"]).to be_present
+        expect(csv[row_number]["payment_amount"]).to be_nil
+        expect(csv[row_number]["payment_status"]).to be_nil
+      end
+    end
+  end
+
+  shared_examples "a valid payment row" do |row_number|
+    it_behaves_like "a valid row with common fields", row_number
+
+    it "has payment specific fields" do
+      aggregate_failures do
+        expect(csv[row_number]["charge_type"]).to be_nil
+        expect(csv[row_number]["charge_amount"]).to be_nil
+        expect(csv[row_number]["charge_band"]).to be_nil
+        expect(csv[row_number]["exemption"]).to be_nil
+        expect(csv[row_number]["payment_type"]).to be_present
+        expect(csv[row_number]["refund_type"]).to be_nil
+        expect(csv[row_number]["reference"]).to be_present
+        expect(csv[row_number]["comments"]).to be_nil
+        expect(csv[row_number]["payment_amount"]).to be_present
+        expect(csv[row_number]["payment_status"]).to be_nil
+      end
+    end
+  end
+
+  shared_examples "a valid summary row" do |row_number|
+    it "has summary row specific fields" do
+      aggregate_failures do
+        expect(csv[row_number]["registration_no"]).to eq(registration.reference)
+        expect(csv[row_number]["date"]).to eq(Time.zone.now.strftime("%d/%m/%Y"))
+        expect(csv[row_number]["multisite"]).to be_present
+        expect(csv[row_number]["organisation_name"]).to be_present
+        expect(csv[row_number]["site"]).to be_nil
+        expect(csv[row_number]["charge_type"]).to eq("summary")
+        expect(csv[row_number]["charge_amount"]).to be_present
+        expect(csv[row_number]["charge_band"]).to be_nil
+        expect(csv[row_number]["exemption"]).to be_nil
+        expect(csv[row_number]["payment_type"]).to be_nil
+        expect(csv[row_number]["refund_type"]).to be_nil
+        expect(csv[row_number]["reference"]).to be_nil
+        expect(csv[row_number]["comments"]).to be_nil
+        expect(csv[row_number]["payment_amount"]).to be_nil
+        expect(csv[row_number]["on_a_farm"]).to be_present
+        expect(csv[row_number]["is_a_farmer"]).to be_present
+        expect(csv[row_number]["ea_admin_area"]).to be_present
+        expect(csv[row_number]["balance"]).to be_present
+        expect(csv[row_number]["payment_status"]).to be_present
+        expect(csv[row_number]["status"]).to be_present
+      end
+    end
+  end
+
+  describe "#to_csv" do
+    context "when CSV output is generated - registration has single order" do
+      let(:csv) { CSV.parse(serializer.to_csv, headers: true) }
+
+      before do
+        order
+        charge_adjustment
+        registration
+        order.charge_detail.band_charge_details.each do |band_charge_detail|
+          band_charge_detail.update(band_id: order.exemptions.last.band_id)
+        end
+      end
+
+      it "generates correct header" do
+        expect(csv.headers).to eq(%w[registration_no date multisite organisation_name site charge_type charge_amount charge_band exemption
+                                     payment_type refund_type reference comments payment_amount on_a_farm is_a_farmer ea_admin_area balance payment_status status])
+      end
+
+      it_behaves_like "a valid registration charge row", 0
+
+      it_behaves_like "a valid initial compliance charge row", 1
+      it_behaves_like "a valid additional compliance charge row", 2
+
+      it_behaves_like "a valid initial compliance charge row", 3
+      it_behaves_like "a valid additional compliance charge row", 4
+
+      it_behaves_like "a valid initial compliance charge row", 5
+      it_behaves_like "a valid additional compliance charge row", 6
+
+      it_behaves_like "a valid charge adjustment row", 7
+      it_behaves_like "a valid payment row", 8
+      it_behaves_like "a valid summary row", 9
+
+      it "only includes payment_status on the summary row" do
+        summary_rows = csv.select { |row| row["charge_type"] == "summary" }
+        non_summary_rows = csv.reject { |row| row["charge_type"] == "summary" }
+
+        expect(summary_rows).not_to be_empty
+        expect(summary_rows.pluck("payment_status")).to all(be_present)
+        expect(non_summary_rows.pluck("payment_status")).to all(be_nil)
+      end
+
+      it "keeps the final balance unchanged on the summary row" do
+        expect(csv[9]["balance"]).to eq(csv[8]["balance"])
+      end
+
+      it "shows summary charge_amount as the total of charge rows" do
+        summary_charge_amount_in_pence = (csv[9]["charge_amount"].to_r * 100).to_i
+
+        charge_rows = csv.reject do |row|
+          row["charge_type"].blank? || row["charge_type"] == "summary"
+        end
+        charge_rows_total_in_pence = charge_rows.sum do |row|
+          (row["charge_amount"].to_r * 100).to_i
+        end
+
+        expect(summary_charge_amount_in_pence).to eq(charge_rows_total_in_pence)
+      end
+    end
+
+    context "when CSV output is generated - when registration has multiple orders" do
+      let(:order2) { create(:order, :with_exemptions, :with_charge_detail, order_owner: account) }
+      let(:csv) { CSV.parse(serializer.to_csv, headers: true) }
+
+      before do
+        order
+        charge_adjustment
+        registration
+        order.charge_detail.band_charge_details.each do |band_charge_detail|
+          band_charge_detail.update(band_id: order.exemptions.last.band_id)
+        end
+        order2
+        charge_adjustment
+        registration
+        order2.charge_detail.band_charge_details.each do |band_charge_detail2|
+          band_charge_detail2.update(band_id: order2.exemptions.last.band_id)
+        end
+      end
+
+      it "generates correct header" do
+        expect(csv.headers).to eq(%w[registration_no date multisite organisation_name site charge_type charge_amount charge_band exemption
+                                     payment_type refund_type reference comments payment_amount on_a_farm is_a_farmer ea_admin_area balance payment_status status])
+      end
+
+      # ORDER 1
+
+      it_behaves_like "a valid registration charge row", 0
+
+      it_behaves_like "a valid initial compliance charge row", 1
+      it_behaves_like "a valid additional compliance charge row", 2
+
+      it_behaves_like "a valid initial compliance charge row", 3
+      it_behaves_like "a valid additional compliance charge row", 4
+
+      it_behaves_like "a valid initial compliance charge row", 5
+      it_behaves_like "a valid additional compliance charge row", 6
+
+      it_behaves_like "a valid charge adjustment row", 7
+      it_behaves_like "a valid payment row", 8
+      it_behaves_like "a valid summary row", 9
+
+      # ORDER 2
+
+      it_behaves_like "a valid registration charge row", 10
+
+      it_behaves_like "a valid initial compliance charge row", 11
+      it_behaves_like "a valid additional compliance charge row", 12
+
+      it_behaves_like "a valid initial compliance charge row", 13
+      it_behaves_like "a valid additional compliance charge row", 14
+
+      it_behaves_like "a valid initial compliance charge row", 15
+      it_behaves_like "a valid additional compliance charge row", 16
+
+      it_behaves_like "a valid charge adjustment row", 17
+      it_behaves_like "a valid payment row", 18
+      it_behaves_like "a valid summary row", 19
+    end
+
+    context "when CSV output is generated - registration has both successful and failed payments" do
+      let(:account) { create(:account) }
       let(:order) { create(:order, :with_exemptions, :with_charge_detail, order_owner: account) }
-      let(:charge_adjustment) { create(:charge_adjustment, account: account) }
-      let(:site_address) { create(:address, :site_address, premises: "Bar 123", area: "Wessex") }
-      let(:registration) { create(:registration, account: account, addresses: [site_address]) }
+      let(:successful_payment) { create(:payment, account: account, payment_status: "success") }
+      let(:csv) { CSV.parse(serializer.to_csv, headers: true) }
 
-      let(:serializer) { described_class.new }
+      before do
+        order
+        registration
+        # Explicitly create payments with different statuses
+        successful_payment
+        create(:payment, account: account, payment_status: "failed")
+        create(:payment, account: account, payment_status: "cancelled")
+        create(:payment, account: account, payment_status: "error")
+      end
 
-      shared_examples "a valid row with common fields" do |row_number|
-        it "has common fields populated correctly" do
-          aggregate_failures do
-            expect(csv[row_number]["registration_no"]).to eq(registration.reference)
-            expect(csv[row_number]["date"]).to eq(Time.zone.now.strftime("%d/%m/%Y"))
-            expect(csv[row_number]["multisite"]).to be_present
-            expect(csv[row_number]["organisation_name"]).to be_present
-            expect(csv[row_number]["on_a_farm"]).to be_present
-            expect(csv[row_number]["is_a_farmer"]).to be_present
-            expect(csv[row_number]["ea_admin_area"]).to be_present
-            expect(csv[row_number]["balance"]).to be_present
-            expect(csv[row_number]["status"]).to be_present
-          end
+      it "only includes successful payments in the export" do
+        payment_rows = csv.select { |row| row["payment_type"].present? }
+
+        expect(payment_rows.count).to eq(1)
+
+        expect(payment_rows.first["reference"]).to eq(successful_payment.reference)
+      end
+    end
+
+    context "when CSV output is generated - registration has farmer exemptions" do
+      let(:bucket) { create(:bucket, :farmer_exemptions) }
+      let(:order) { create(:order, :with_exemptions, :with_charge_detail, order_owner: account, bucket: bucket) }
+      let(:csv) { CSV.parse(serializer.to_csv, headers: true) }
+
+      before do
+        order
+        charge_adjustment
+        registration
+        order.charge_detail.band_charge_details.each do |band_charge_detail|
+          band_charge_detail.update(band_id: order.exemptions.last.band_id)
+        end
+        bucket.exemptions << order.exemptions.last
+        order.charge_detail.update(bucket_charge_amount: 8850)
+      end
+
+      it "generates correct header" do
+        expect(csv.headers).to eq(%w[registration_no date multisite organisation_name site charge_type charge_amount charge_band exemption
+                                     payment_type refund_type reference comments payment_amount on_a_farm is_a_farmer ea_admin_area balance payment_status status])
+      end
+
+      it_behaves_like "a valid registration charge row", 0
+
+      it_behaves_like "a valid initial compliance charge row", 1
+      it_behaves_like "a valid additional compliance charge row", 2
+
+      it_behaves_like "a valid initial compliance charge row", 3
+      it_behaves_like "a valid additional compliance charge row", 4
+
+      it_behaves_like "a valid initial compliance charge row", 5
+      it_behaves_like "a valid additional compliance charge row", 6
+      it_behaves_like "a valid farm compliance charge row", 7
+
+      it_behaves_like "a valid charge adjustment row", 8
+      it_behaves_like "a valid payment row", 9
+      it_behaves_like "a valid summary row", 10
+    end
+
+    context "when registration is multisite" do
+      let(:multisite_registration) { create(:registration, :multisite_complete, account: account) }
+      let(:csv) { CSV.parse(serializer.to_csv, headers: true) }
+
+      before do
+        order.update(order_owner: multisite_registration.account)
+        multisite_registration.site_addresses.first.update(area: "Wessex")
+        multisite_registration.site_addresses.second.update(area: "Yorkshire")
+
+        multisite_registration.site_addresses.each do |_site_address|
+          order.exemptions.each { |exemption| create(:registration_exemption, registration: multisite_registration, exemption: exemption) }
+        end
+
+        order.charge_detail.band_charge_details.first.update(band_id: order.exemptions.first.band_id)
+      end
+
+      it "includes multisite flag as TRUE for multisite registrations" do
+        multisite_rows = csv.select { |row| row["registration_no"]&.include?(multisite_registration.reference) }
+
+        multisite_rows.each do |row|
+          expect(row["multisite"]).to eq("TRUE")
         end
       end
 
-      shared_examples "a valid registration charge row" do |row_number|
-        it_behaves_like "a valid row with common fields", row_number
+      it "generates compliance rows with site suffix for multisite registrations" do
+        compliance_rows = csv.select do |row|
+          row["charge_type"]&.start_with?("compliance") &&
+            row["registration_no"]&.include?("/")
+        end
 
-        it "has registration charge specific fields" do
-          aggregate_failures do
-            expect(csv[row_number]["site"]).to be_nil
-            expect(csv[row_number]["charge_type"]).to eq("registration")
-            expect(csv[row_number]["charge_amount"]).to be_present
-            expect(csv[row_number]["charge_band"]).to be_nil
-            expect(csv[row_number]["exemption"]).to be_nil
-            expect(csv[row_number]["payment_type"]).to be_nil
-            expect(csv[row_number]["refund_type"]).to be_nil
-            expect(csv[row_number]["reference"]).to be_nil
-            expect(csv[row_number]["comments"]).to be_nil
-            expect(csv[row_number]["payment_amount"]).to be_nil
-            expect(csv[row_number]["payment_status"]).to be_nil
-          end
+        expect(compliance_rows).not_to be_empty
+        compliance_rows.each do |row|
+          expect(row["registration_no"]).to match(%r{/\d{5}$})
+          expect(row["site"]).to match(/\d{5}/)
         end
       end
 
-      shared_examples "a valid initial compliance charge row" do |row_number|
-        it_behaves_like "a valid row with common fields", row_number
-
-        it "has initial compliance charge specific fields" do
-          aggregate_failures do
-            expect(csv[row_number]["charge_type"]).to eq("compliance_initial")
-            expect(csv[row_number]["charge_amount"]).to be_present
-            expect(csv[row_number]["charge_band"]).to be_present
-            expect(csv[row_number]["exemption"]).to be_present
-            expect(csv[row_number]["payment_type"]).to be_nil
-            expect(csv[row_number]["refund_type"]).to be_nil
-            expect(csv[row_number]["reference"]).to be_nil
-            expect(csv[row_number]["comments"]).to be_nil
-            expect(csv[row_number]["payment_amount"]).to be_nil
-            expect(csv[row_number]["payment_status"]).to be_nil
-          end
+      it "only includes one summary row for a multisite registration" do
+        summary_rows = csv.select do |row|
+          row["charge_type"] == "summary" && row["registration_no"] == multisite_registration.reference
         end
+
+        expect(summary_rows.count).to eq(1)
+        expect(summary_rows.first["multisite"]).to eq("TRUE")
+        expect(summary_rows.first["site"]).to be_nil
+      end
+    end
+
+    context "when payments include back office comments" do
+      let(:csv) { CSV.parse(serializer.to_csv, headers: true) }
+
+      before do
+        order
+        registration
+        account.payments.success.first.update!(comments: "Back office note")
       end
 
-      shared_examples "a valid additional compliance charge row" do |row_number|
-        it_behaves_like "a valid row with common fields", row_number
+      it "shows payment comments in the comments column" do
+        payment_row = csv.find { |row| row["payment_type"].present? }
 
-        it "has additional compliance charge specific fields" do
-          aggregate_failures do
-            expect(csv[row_number]["charge_type"]).to eq("compliance_additional")
-            expect(csv[row_number]["charge_amount"]).to be_present
-            expect(csv[row_number]["charge_band"]).to be_present
-            expect(csv[row_number]["exemption"]).to be_present
-            expect(csv[row_number]["payment_type"]).to be_nil
-            expect(csv[row_number]["refund_type"]).to be_nil
-            expect(csv[row_number]["reference"]).to be_nil
-            expect(csv[row_number]["comments"]).to be_nil
-            expect(csv[row_number]["payment_amount"]).to be_nil
-            expect(csv[row_number]["payment_status"]).to be_nil
-          end
+        expect(payment_row["comments"]).to eq("Back office note")
+      end
+    end
+
+    context "when a band has no compliance charge" do
+      let(:csv) { CSV.parse(serializer.to_csv, headers: true) }
+
+      before do
+        order
+        registration
+        order.charge_detail.band_charge_details.each do |band_charge_detail|
+          band_charge_detail.update!(band_id: order.exemptions.last.band_id)
         end
+
+        order.charge_detail.band_charge_details.first.update!(
+          initial_compliance_charge_amount: 0,
+          additional_compliance_charge_amount: 0
+        )
       end
 
-      shared_examples "a valid farm compliance charge row" do |row_number|
-        it_behaves_like "a valid row with common fields", row_number
-
-        it "has farm compliance charge specific fields" do
-          aggregate_failures do
-            expect(csv[row_number]["charge_type"]).to eq("compliance_farm")
-            expect(csv[row_number]["charge_amount"]).to be_present
-            expect(csv[row_number]["charge_band"]).to be_nil
-            expect(csv[row_number]["exemption"]).to be_present
-            expect(csv[row_number]["payment_type"]).to be_nil
-            expect(csv[row_number]["refund_type"]).to be_nil
-            expect(csv[row_number]["reference"]).to be_nil
-            expect(csv[row_number]["comments"]).to be_nil
-            expect(csv[row_number]["payment_amount"]).to be_nil
-            expect(csv[row_number]["on_a_farm"]).to be_truthy
-            expect(csv[row_number]["is_a_farmer"]).to be_truthy
-            expect(csv[row_number]["payment_status"]).to be_nil
-          end
-        end
-      end
-
-      shared_examples "a valid charge adjustment row" do |row_number|
-        it_behaves_like "a valid row with common fields", row_number
-
-        it "has charge adjustment specific fields" do
-          aggregate_failures do
-            expect(csv[row_number]["charge_type"]).to eq("charge_adjust")
-            expect(csv[row_number]["charge_amount"]).to be_present
-            expect(csv[row_number]["charge_band"]).to be_nil
-            expect(csv[row_number]["exemption"]).to be_nil
-            expect(csv[row_number]["payment_type"]).to be_nil
-            expect(csv[row_number]["refund_type"]).to be_nil
-            expect(csv[row_number]["reference"]).to be_nil
-            expect(csv[row_number]["comments"]).to be_present
-            expect(csv[row_number]["payment_amount"]).to be_nil
-            expect(csv[row_number]["payment_status"]).to be_nil
-          end
-        end
-      end
-
-      shared_examples "a valid payment row" do |row_number|
-        it_behaves_like "a valid row with common fields", row_number
-
-        it "has payment specific fields" do
-          aggregate_failures do
-            expect(csv[row_number]["charge_type"]).to be_nil
-            expect(csv[row_number]["charge_amount"]).to be_nil
-            expect(csv[row_number]["charge_band"]).to be_nil
-            expect(csv[row_number]["exemption"]).to be_nil
-            expect(csv[row_number]["payment_type"]).to be_present
-            expect(csv[row_number]["refund_type"]).to be_nil
-            expect(csv[row_number]["reference"]).to be_present
-            expect(csv[row_number]["comments"]).to be_nil
-            expect(csv[row_number]["payment_amount"]).to be_present
-            expect(csv[row_number]["payment_status"]).to be_nil
-          end
-        end
-      end
-
-      shared_examples "a valid summary row" do |row_number|
-        it "has summary row specific fields" do
-          aggregate_failures do
-            expect(csv[row_number]["registration_no"]).to eq(registration.reference)
-            expect(csv[row_number]["date"]).to eq(Time.zone.now.strftime("%d/%m/%Y"))
-            expect(csv[row_number]["multisite"]).to be_present
-            expect(csv[row_number]["organisation_name"]).to be_present
-            expect(csv[row_number]["site"]).to be_nil
-            expect(csv[row_number]["charge_type"]).to eq("summary")
-            expect(csv[row_number]["charge_amount"]).to be_present
-            expect(csv[row_number]["charge_band"]).to be_nil
-            expect(csv[row_number]["exemption"]).to be_nil
-            expect(csv[row_number]["payment_type"]).to be_nil
-            expect(csv[row_number]["refund_type"]).to be_nil
-            expect(csv[row_number]["reference"]).to be_nil
-            expect(csv[row_number]["comments"]).to be_nil
-            expect(csv[row_number]["payment_amount"]).to be_nil
-            expect(csv[row_number]["on_a_farm"]).to be_present
-            expect(csv[row_number]["is_a_farmer"]).to be_present
-            expect(csv[row_number]["ea_admin_area"]).to be_present
-            expect(csv[row_number]["balance"]).to be_present
-            expect(csv[row_number]["payment_status"]).to be_present
-            expect(csv[row_number]["status"]).to be_present
-          end
-        end
-      end
-
-      describe "#to_csv" do
-        context "when CSV output is generated - registration has single order" do
-          let(:csv) { CSV.parse(serializer.to_csv, headers: true) }
-
-          before do
-            order
-            charge_adjustment
-            registration
-            order.charge_detail.band_charge_details.each do |band_charge_detail|
-              band_charge_detail.update(band_id: order.exemptions.last.band_id)
-            end
-          end
-
-          it "generates correct header" do
-            expect(csv.headers).to eq(%w[registration_no date multisite organisation_name site charge_type charge_amount charge_band exemption
-                                         payment_type refund_type reference comments payment_amount on_a_farm is_a_farmer ea_admin_area balance payment_status status])
-          end
-
-          it_behaves_like "a valid registration charge row", 0
-
-          it_behaves_like "a valid initial compliance charge row", 1
-          it_behaves_like "a valid additional compliance charge row", 2
-
-          it_behaves_like "a valid initial compliance charge row", 3
-          it_behaves_like "a valid additional compliance charge row", 4
-
-          it_behaves_like "a valid initial compliance charge row", 5
-          it_behaves_like "a valid additional compliance charge row", 6
-
-          it_behaves_like "a valid charge adjustment row", 7
-          it_behaves_like "a valid payment row", 8
-          it_behaves_like "a valid summary row", 9
-
-          it "only includes payment_status on the summary row" do
-            summary_rows = csv.select { |row| row["charge_type"] == "summary" }
-            non_summary_rows = csv.reject { |row| row["charge_type"] == "summary" }
-
-            expect(summary_rows).not_to be_empty
-            expect(summary_rows.map { |row| row["payment_status"] }).to all(be_present)
-            expect(non_summary_rows.map { |row| row["payment_status"] }).to all(be_nil)
-          end
-
-          it "keeps the final balance unchanged on the summary row" do
-            expect(csv[9]["balance"]).to eq(csv[8]["balance"])
-          end
-
-          it "shows summary charge_amount as the total of charge rows" do
-            summary_charge_amount_in_pence = (csv[9]["charge_amount"].to_r * 100).to_i
-
-            charge_rows_total_in_pence = csv.reject do |row|
-              row["charge_type"].blank? || row["charge_type"] == "summary"
-            end.sum do |row|
-              (row["charge_amount"].to_r * 100).to_i
-            end
-
-            expect(summary_charge_amount_in_pence).to eq(charge_rows_total_in_pence)
-          end
-        end
-
-        context "when CSV output is generated - when registration has multiple orders" do
-          let(:order2) { create(:order, :with_exemptions, :with_charge_detail, order_owner: account) }
-          let(:csv) { CSV.parse(serializer.to_csv, headers: true) }
-
-          before do
-            order
-            charge_adjustment
-            registration
-            order.charge_detail.band_charge_details.each do |band_charge_detail|
-              band_charge_detail.update(band_id: order.exemptions.last.band_id)
-            end
-            order2
-            charge_adjustment
-            registration
-            order2.charge_detail.band_charge_details.each do |band_charge_detail2|
-              band_charge_detail2.update(band_id: order2.exemptions.last.band_id)
-            end
-          end
-
-          it "generates correct header" do
-            expect(csv.headers).to eq(%w[registration_no date multisite organisation_name site charge_type charge_amount charge_band exemption
-                                         payment_type refund_type reference comments payment_amount on_a_farm is_a_farmer ea_admin_area balance payment_status status])
-          end
-
-          # ORDER 1
-
-          it_behaves_like "a valid registration charge row", 0
-
-          it_behaves_like "a valid initial compliance charge row", 1
-          it_behaves_like "a valid additional compliance charge row", 2
-
-          it_behaves_like "a valid initial compliance charge row", 3
-          it_behaves_like "a valid additional compliance charge row", 4
-
-          it_behaves_like "a valid initial compliance charge row", 5
-          it_behaves_like "a valid additional compliance charge row", 6
-
-          it_behaves_like "a valid charge adjustment row", 7
-          it_behaves_like "a valid payment row", 8
-          it_behaves_like "a valid summary row", 9
-
-          # ORDER 2
-
-          it_behaves_like "a valid registration charge row", 10
-
-          it_behaves_like "a valid initial compliance charge row", 11
-          it_behaves_like "a valid additional compliance charge row", 12
-
-          it_behaves_like "a valid initial compliance charge row", 13
-          it_behaves_like "a valid additional compliance charge row", 14
-
-          it_behaves_like "a valid initial compliance charge row", 15
-          it_behaves_like "a valid additional compliance charge row", 16
-
-          it_behaves_like "a valid charge adjustment row", 17
-          it_behaves_like "a valid payment row", 18
-          it_behaves_like "a valid summary row", 19
-        end
-
-        context "when CSV output is generated - registration has both successful and failed payments" do
-          let(:account) { create(:account) }
-          let(:order) { create(:order, :with_exemptions, :with_charge_detail, order_owner: account) }
-          let(:successful_payment) { create(:payment, account: account, payment_status: "success") }
-          let(:csv) { CSV.parse(serializer.to_csv, headers: true) }
-
-          before do
-            order
-            registration
-            # Explicitly create payments with different statuses
-            successful_payment
-            create(:payment, account: account, payment_status: "failed")
-            create(:payment, account: account, payment_status: "cancelled")
-            create(:payment, account: account, payment_status: "error")
-          end
-
-          it "only includes successful payments in the export" do
-            payment_rows = csv.select { |row| row["payment_type"].present? }
-
-            expect(payment_rows.count).to eq(1)
-
-            expect(payment_rows.first["reference"]).to eq(successful_payment.reference)
-          end
-        end
-
-        context "when CSV output is generated - registration has farmer exemptions" do
-          let(:bucket) { create(:bucket, :farmer_exemptions) }
-          let(:order) { create(:order, :with_exemptions, :with_charge_detail, order_owner: account, bucket: bucket) }
-          let(:csv) { CSV.parse(serializer.to_csv, headers: true) }
-
-          before do
-            order
-            charge_adjustment
-            registration
-            order.charge_detail.band_charge_details.each do |band_charge_detail|
-              band_charge_detail.update(band_id: order.exemptions.last.band_id)
-            end
-            bucket.exemptions << order.exemptions.last
-            order.charge_detail.update(bucket_charge_amount: 8850)
-          end
-
-          it "generates correct header" do
-            expect(csv.headers).to eq(%w[registration_no date multisite organisation_name site charge_type charge_amount charge_band exemption
-                                         payment_type refund_type reference comments payment_amount on_a_farm is_a_farmer ea_admin_area balance payment_status status])
-          end
-
-          it_behaves_like "a valid registration charge row", 0
-
-          it_behaves_like "a valid initial compliance charge row", 1
-          it_behaves_like "a valid additional compliance charge row", 2
-
-          it_behaves_like "a valid initial compliance charge row", 3
-          it_behaves_like "a valid additional compliance charge row", 4
-
-          it_behaves_like "a valid initial compliance charge row", 5
-          it_behaves_like "a valid additional compliance charge row", 6
-          it_behaves_like "a valid farm compliance charge row", 7
-
-          it_behaves_like "a valid charge adjustment row", 8
-          it_behaves_like "a valid payment row", 9
-          it_behaves_like "a valid summary row", 10
-        end
-
-        context "when registration is multisite" do
-          let(:multisite_registration) { create(:registration, :multisite_complete, account: account) }
-          let(:csv) { CSV.parse(serializer.to_csv, headers: true) }
-
-          before do
-            order.update(order_owner: multisite_registration.account)
-            multisite_registration.site_addresses.first.update(area: "Wessex")
-            multisite_registration.site_addresses.second.update(area: "Yorkshire")
-
-            multisite_registration.site_addresses.each do |_site_address|
-              order.exemptions.each { |exemption| create(:registration_exemption, registration: multisite_registration, exemption: exemption) }
-            end
-
-            order.charge_detail.band_charge_details.first.update(band_id: order.exemptions.first.band_id)
-          end
-
-          it "includes multisite flag as TRUE for multisite registrations" do
-            multisite_rows = csv.select { |row| row["registration_no"]&.include?(multisite_registration.reference) }
-
-            multisite_rows.each do |row|
-              expect(row["multisite"]).to eq("TRUE")
-            end
-          end
-
-          it "generates compliance rows with site suffix for multisite registrations" do
-            compliance_rows = csv.select do |row|
-              row["charge_type"]&.start_with?("compliance") &&
-                row["registration_no"]&.include?("/")
-            end
-
-            expect(compliance_rows).not_to be_empty
-            compliance_rows.each do |row|
-              expect(row["registration_no"]).to match(%r{/\d{5}$})
-              expect(row["site"]).to match(/\d{5}/)
-            end
-          end
-
-          it "only includes one summary row for a multisite registration" do
-            summary_rows = csv.select do |row|
-              row["charge_type"] == "summary" && row["registration_no"] == multisite_registration.reference
-            end
-
-            expect(summary_rows.count).to eq(1)
-            expect(summary_rows.first["multisite"]).to eq("TRUE")
-            expect(summary_rows.first["site"]).to be_nil
-          end
-        end
-
-        context "when payments include back office comments" do
-          let(:csv) { CSV.parse(serializer.to_csv, headers: true) }
-
-          before do
-            order
-            registration
-            account.payments.success.first.update!(comments: "Back office note")
-          end
-
-          it "shows payment comments in the comments column" do
-            payment_row = csv.find { |row| row["payment_type"].present? }
-
-            expect(payment_row["comments"]).to eq("Back office note")
-          end
-        end
-
-        context "when a band has no compliance charge" do
-          let(:csv) { CSV.parse(serializer.to_csv, headers: true) }
-
-          before do
-            order
-            registration
-            order.charge_detail.band_charge_details.each do |band_charge_detail|
-              band_charge_detail.update!(band_id: order.exemptions.last.band_id)
-            end
-
-            order.charge_detail.band_charge_details.first.update!(
-              initial_compliance_charge_amount: 0,
-              additional_compliance_charge_amount: 0
-            )
-          end
-
-          it "exports a compliance_no_charge row with zero amount" do
-            no_charge_row = csv.find { |row| row["charge_type"] == "compliance_no_charge" }
-
-            expect(no_charge_row).to be_present
-            expect(no_charge_row["charge_amount"]).to eq("0")
-          end
-        end
+      it "exports a compliance_no_charge row with zero amount" do
+        no_charge_row = csv.find { |row| row["charge_type"] == "compliance_no_charge" }
+
+        expect(no_charge_row).to be_present
+        expect(no_charge_row["charge_amount"]).to eq("0")
       end
     end
   end

--- a/spec/presenters/reports/finance_data_report/charge_adjustment_row_presenter_spec.rb
+++ b/spec/presenters/reports/finance_data_report/charge_adjustment_row_presenter_spec.rb
@@ -26,6 +26,12 @@ module Reports
         end
       end
 
+      describe "#comments" do
+        it "returns the adjustment reason" do
+          expect(presenter.comments).to eq(charge_adjustment.reason)
+        end
+      end
+
       describe "#balance" do
         it "returns the formatted balance amount, calculated as the previous balance minus the charge adjustment amount" do
           expect(presenter.balance).to eq("-15")

--- a/spec/presenters/reports/finance_data_report/payment_row_presenter_spec.rb
+++ b/spec/presenters/reports/finance_data_report/payment_row_presenter_spec.rb
@@ -50,6 +50,14 @@ module Reports
         end
       end
 
+      describe "#comments" do
+        it "returns payment comments when present" do
+          account.payments.first.update(comments: "Back office note")
+
+          expect(presenter.comments).to eq("Back office note")
+        end
+      end
+
       describe "#balance" do
         it "returns the formatted balance amount, calculated as the previous balance minus amount paid" do
           account.payments.first.update(payment_type: "bank_transfer")

--- a/spec/presenters/reports/finance_data_report/summary_row_presenter_spec.rb
+++ b/spec/presenters/reports/finance_data_report/summary_row_presenter_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Reports
+  module FinanceDataReport
+    RSpec.describe SummaryRowPresenter do
+      let(:site_address) { build(:address, :site_address, area: "Wessex") }
+      let(:registration) do
+        build(
+          :registration,
+          reference: "REG123",
+          submitted_at: Time.zone.local(2025, 11, 27),
+          on_a_farm: true,
+          is_a_farmer: true,
+          addresses: [site_address]
+        )
+      end
+      let(:presenter) do
+        described_class.new(
+          registration: registration,
+          charge_total_in_pence: charge_total_in_pence,
+          balance_in_pence: balance_in_pence
+        )
+      end
+      let(:charge_total_in_pence) { 274_400 }
+      let(:balance_in_pence) { -274_400 }
+
+      before do
+        allow(registration).to receive(:state).and_return("active")
+      end
+
+      describe "#charge_type" do
+        it "returns summary" do
+          expect(presenter.charge_type).to eq("summary")
+        end
+      end
+
+      describe "#charge_amount" do
+        it "returns the formatted total charge amount" do
+          expect(presenter.charge_amount).to eq("2744")
+        end
+      end
+
+      describe "#balance" do
+        it "returns the formatted current balance" do
+          expect(presenter.balance).to eq("-2744")
+        end
+      end
+
+      describe "#payment_status" do
+        context "when balance is negative" do
+          it "returns Unpaid" do
+            expect(presenter.payment_status).to eq("Unpaid")
+          end
+        end
+
+        context "when balance is zero" do
+          let(:balance_in_pence) { 0 }
+
+          it "returns Paid" do
+            expect(presenter.payment_status).to eq("Paid")
+          end
+        end
+
+        context "when balance is positive" do
+          let(:balance_in_pence) { 100 }
+
+          it "returns Overpaid" do
+            expect(presenter.payment_status).to eq("Overpaid")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-4201

Alter Finance Data Export to show Current Balance of Registrations

 ## Summary

  - Add a summary row for each order with charge_type = summary
  - `payment_status` is now only populated on the `summary` row (blank on all other rows).
  - `summary.balance` shows the final running balance (current balance).
  - `summary.charge_amount` now shows the total of the charge rows being summarised.
  - Added `compliance_no_charge` rows (`charge_type = compliance_no_charge`, `charge_amount = 0`) when a band has no initial / additional compliance charge.
  - Added back-office comments to the export comments column:
    - payment row comments from `payment.comments`
    - charge adjustment comments from `charge_adjustment.reason`