### PR TITLE
Fix/ruby 4175 ensure charitable status shown when value is false

### DIFF
--- a/app/views/shared/_resource_details.html.erb
+++ b/app/views/shared/_resource_details.html.erb
@@ -113,7 +113,7 @@
           <%= resource.company_no %>
         </p>
       <% end %>
-      <% if resource.charitable_purpose.present? %>
+      <% if [true, false].include?(resource.charitable_purpose) %>
         <p class="govuk-body govuk-!-font-weight-bold">
           <%= t(".labels.charitable_purpose") %>
         </p>

--- a/config/locales/partials/resource_details.en.yml
+++ b/config/locales/partials/resource_details.en.yml
@@ -27,10 +27,10 @@ en:
         amount: Amount
       values:
         business_or_organisation_type:
-          charity: Charity or trust
+          charity: Third sector, community group or trust
           limitedCompany: Limited company
           limitedLiabilityPartnership: Limited liability partnership
-          localAuthority: Local authority or public body
+          localAuthority: Public sector
           partnership: Partnership
           soleTrader: Individual or sole trader
         charitable_purpose:


### PR DESCRIPTION
1. A fix for https://eaflood.atlassian.net/browse/RUBY-4175
- Now showing charitable purpose section even if the value is set to false

2. A fix for https://eaflood.atlassian.net/browse/RUBY-4174
- Updated business_type labels on registration view page in back office