### PR TITLE
[RUBY-4184] Use different pagination param for sites navigation

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -7,7 +7,7 @@ class SitesController < ApplicationController
     find_resource(params[:registration_reference])
 
     @site_addresses = @resource.site_addresses.includes([:registration_exemptions])
-                               .page(params[:page]).order(:id).per(20)
+                               .page(params[:sites_page]).order(:id).per(20)
   end
 
   private

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -62,7 +62,7 @@
           <%= page_entries_info @site_addresses, entry_name: "item" %>
         </div>
         <span class="govuk-body">
-          <%= paginate @site_addresses %>
+          <%= paginate @site_addresses, param_name: :sites_page %>
         </span>
       </nav>
     </div>

--- a/spec/requests/sites_spec.rb
+++ b/spec/requests/sites_spec.rb
@@ -52,12 +52,21 @@ RSpec.describe "Sites" do
         expect(response.body).to include("Next")
         expect(response.body).not_to include("Prev")
 
-        get "/registrations/#{registration.reference}/sites?page=2"
+        get "/registrations/#{registration.reference}/sites?sites_page=2"
 
         expect(response.body).to include("Waste operation sites")
         expect(response.body).to include("Showing 21 &ndash; 30 of 30 results")
         expect(response.body).not_to include("Next")
         expect(response.body).to include("Prev")
+      end
+
+      it "ignores the global page parameter from registrations pagination" do
+        registration = create(:registration, :multisite_complete, addresses: [])
+
+        get "/registrations/#{registration.reference}/sites", params: { page: "2" }
+
+        expect(response.body).to include("Waste operation sites")
+        expect(response.body).to include("Showing 1 &ndash; 20 of 30 results")
       end
     end
   end


### PR DESCRIPTION
WEX - BO - pagination query string causes sites to not display
https://eaflood.atlassian.net/browse/RUBY-4184

- Fix sites pagination issue by using different pagination param for sites navigation