### PR TITLE
Feature/ruby 4211 wex bo resend confirmation email action remove sending to applicant

### DIFF
--- a/app/controllers/resend_confirmation_email_controller.rb
+++ b/app/controllers/resend_confirmation_email_controller.rb
@@ -33,32 +33,24 @@ class ResendConfirmationEmailController < ApplicationController
   end
 
   def send_emails
-    emails_to_contact.each do |email|
-      WasteExemptionsEngine::ConfirmationEmailService.run(registration: registration,
-                                                          recipient: email)
-    end
-  end
+    return if registration.contact_email.blank?
 
-  def emails_to_contact
-    [registration.applicant_email, registration.contact_email]
-      .compact
-      .uniq
+    WasteExemptionsEngine::ConfirmationEmailService.run(registration: registration,
+                                                        recipient: registration.contact_email)
   end
 
   def success_message
-    I18n.t("resend_confirmation_email.messages.success",
-           applicant_email: registration.applicant_email,
-           contact_email: registration.contact_email,
-           default_email: emails_to_contact.first,
-           count: emails_to_contact.length)
+    if registration.contact_email.present?
+      I18n.t("resend_confirmation_email.messages.success",
+             contact_email: registration.contact_email)
+    else
+      I18n.t("resend_confirmation_email.messages.no_recipient")
+    end
   end
 
   def failure_message
     I18n.t("resend_confirmation_email.messages.failure",
-           applicant_email: registration.applicant_email,
-           contact_email: registration.contact_email,
-           default_email: emails_to_contact.first,
-           count: emails_to_contact.length)
+           contact_email: registration.contact_email)
   end
 
   def failure_description

--- a/config/locales/resend_confirmation_email.en.yml
+++ b/config/locales/resend_confirmation_email.en.yml
@@ -1,11 +1,7 @@
 en:
   resend_confirmation_email:
     messages:
-      success:
-        zero: "This registration only has an assisted digital email, so no confirmation emails were sent"
-        one: Confirmation email sent to %{default_email}
-        other: Confirmation email sent to %{contact_email} and %{applicant_email}
-      failure:
-        one: We could not send an email to %{default_email}
-        other: We could not send an email to %{contact_email} and %{applicant_email}
+      success: Confirmation email sent to %{contact_email}
+      failure: We could not send an email to %{contact_email}
       failure_details: The error has been logged. Try again later or contact an administrator.
+      no_recipient: No contact email address found, so no confirmation email was sent

--- a/spec/requests/resend_confirmation_email_spec.rb
+++ b/spec/requests/resend_confirmation_email_spec.rb
@@ -39,94 +39,27 @@ RSpec.describe "ResendConfirmationEmail" do
         Bullet.unused_eager_loading_enable = true
       end
 
-      context "when the recipients are the same" do
-        before do
-          registration.update(applicant_email: registration.contact_email)
-        end
-
-        it "returns a success message" do
-          VCR.use_cassette("first_confirmation_reminder_email") do
-            success_message = I18n.t("resend_confirmation_email.messages.success.one",
-                                     default_email: registration.contact_email)
-
-            get request_path, params: {}, headers: { "HTTP_REFERER" => "/" }
-            follow_redirect!
-
-            expect(response.body).to include(success_message)
-          end
-        end
-
-        context "when an error happens" do
-          before do
-            allow(WasteExemptionsEngine::ConfirmationEmailService).to receive(:run).and_raise(StandardError)
-          end
-
-          it "returns an error message" do
-            error_message = I18n.t("resend_confirmation_email.messages.failure_details")
-
-            get request_path, params: {}, headers: { "HTTP_REFERER" => "/" }
-            follow_redirect!
-
-            expect(response.body).to include(error_message)
-          end
-        end
-      end
-
-      context "when there is one valid recipient and one blank recipient" do
-        before do
-          registration.update(contact_email: nil)
-        end
-
-        it "returns a success message" do
-          success_message = I18n.t("resend_confirmation_email.messages.success.one",
-                                   default_email: registration.applicant_email)
-
-          get request_path, params: {}, headers: { "HTTP_REFERER" => "/" }
-          follow_redirect!
-          expect(response.body).to include(success_message)
-          expect(WasteExemptionsEngine::ConfirmationEmailService).to have_received(:run).with(
-            registration: registration,
-            recipient: registration.applicant_email
-          )
-          expect(WasteExemptionsEngine::ConfirmationEmailService).not_to have_received(:run).with(
-            registration: registration,
-            recipient: registration.contact_email
-          )
-        end
-
-        context "when an error happens" do
-          before do
-            allow(WasteExemptionsEngine::ConfirmationEmailService).to receive(:run).and_raise(StandardError)
-          end
-
-          it "returns an error message" do
-            error_message = I18n.t("resend_confirmation_email.messages.failure_details")
-
-            get request_path, params: {}, headers: { "HTTP_REFERER" => "/" }
-            follow_redirect!
-
-            expect(response.body).to include(error_message)
-          end
-        end
-      end
-
-      context "when there are multiple recipients" do
-        it "returns a success message" do
-          success_message = I18n.t("resend_confirmation_email.messages.success.other",
-                                   applicant_email: registration.applicant_email,
+      context "when the registration has a contact email" do
+        it "sends confirmation email to the contact email only" do
+          success_message = I18n.t("resend_confirmation_email.messages.success",
                                    contact_email: registration.contact_email)
 
           get request_path, params: {}, headers: { "HTTP_REFERER" => "/" }
           follow_redirect!
 
           expect(response.body).to include(success_message)
-          expect(WasteExemptionsEngine::ConfirmationEmailService).to have_received(:run).with(
-            registration: registration,
-            recipient: registration.applicant_email
-          )
-          expect(WasteExemptionsEngine::ConfirmationEmailService).to have_received(:run).with(
+          expect(WasteExemptionsEngine::ConfirmationEmailService).to have_received(:run).once.with(
             registration: registration,
             recipient: registration.contact_email
+          )
+        end
+
+        it "does not send to the applicant email" do
+          get request_path, params: {}, headers: { "HTTP_REFERER" => "/" }
+
+          expect(WasteExemptionsEngine::ConfirmationEmailService).not_to have_received(:run).with(
+            registration: registration,
+            recipient: registration.applicant_email
           )
         end
 
@@ -146,14 +79,13 @@ RSpec.describe "ResendConfirmationEmail" do
         end
       end
 
-      context "when there are no recipients" do
+      context "when the registration has no contact email" do
         before do
-          registration.update(applicant_email: nil,
-                              contact_email: nil)
+          registration.update(contact_email: nil)
         end
 
-        it "returns a success message" do
-          success_message = I18n.t("resend_confirmation_email.messages.success.zero")
+        it "does not send any email and returns a no recipient message" do
+          success_message = I18n.t("resend_confirmation_email.messages.no_recipient")
 
           get request_path, params: {}, headers: { "HTTP_REFERER" => "/" }
           follow_redirect!

--- a/spec/services/analytics/page_dwell_times_service_spec.rb
+++ b/spec/services/analytics/page_dwell_times_service_spec.rb
@@ -45,7 +45,8 @@ module Analytics
       end
 
       it do
-        expect(result["operator-name"]).to eq(
+        # Allow a margin of error for daylight saving time changes (1 hour = 3600 seconds)
+        expect(result["operator-name"]).to be_within(3600).of(
           (
             (time_diff(1.hour, 2.days) +
             time_diff(7.minutes, 25.hours)


### PR DESCRIPTION
WEX - BO - Resend confirmation email action - remove sending to applicant
https://eaflood.atlassian.net/browse/RUBY-4211
- Refactored resend confirmation email logic to send only to contact email

Unrelated issue fixed:
- Refactored analytics/page_dwell_times_service_spec.rb tests by adding margin of error for daylight saving time