### PR TITLE
[RUBY-4208] Add site count display with pluralization in resource site addresses

### DIFF
--- a/app/views/shared/_resource_site_addresses.html.erb
+++ b/app/views/shared/_resource_site_addresses.html.erb
@@ -1,4 +1,7 @@
 <div class="govuk-summary-list__row">
+  <% site_count = resource.site_addresses.count %>
+  <% site_count_text = t(".values.site_count", count: site_count) %>
+
   <dt class="govuk-summary-list__key">
     <%= t('.heading') %>
   </dt>
@@ -8,16 +11,11 @@
     </p>
 
     <p class="govuk-body">
-      <%= resource.site_addresses.count %>
+      <% if resource.reference.present? %>
+        <%= link_to site_count_text, registration_sites_path(registration_reference: resource.reference), class: "govuk-link" %>
+      <% else %>
+        <%= site_count_text %>
+      <% end %>
     </p>
-  </dd>
-  <dd class="govuk-summary-list__value">
-    <p class="govuk-body govuk-!-font-weight-bold">
-      &nbsp;
-    </p>
-
-    <% if resource.reference.present? %>
-      <%= link_to t('.labels.see_sites'), registration_sites_path(registration_reference: resource.reference), class: "govuk-link" %>
-    <% end %>
   </dd>
 </div>

--- a/config/locales/partials/resource_site_addresses.en.yml
+++ b/config/locales/partials/resource_site_addresses.en.yml
@@ -4,4 +4,7 @@ en:
       heading: Site location(s)
       labels:
         sites: Sites
-        see_sites: See sites
+      values:
+        site_count:
+          one: "%{count} site"
+          other: "%{count} sites"

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -32,6 +32,26 @@ RSpec.describe "Registrations" do
         root_path_with_search_terms = root_path(search_terms).gsub("&", "&amp;")
         expect(response.body).to include(root_path_with_search_terms)
       end
+
+      it "shows the single site count as a link in the sites row" do
+        get "/registrations/#{registration.reference}"
+
+        aggregate_failures do
+          expect(response.body).to include("Site location(s)")
+          expect(response.body).to include(%(href="/registrations/#{registration.reference}/sites">1 site</a>))
+          expect(response.body).not_to include("See sites")
+        end
+      end
+
+      it "pluralises the linked site count for multisite registrations" do
+        multisite_registration = create(:registration, :multisite_complete)
+
+        get "/registrations/#{multisite_registration.reference}"
+
+        expect(response.body).to include(
+          %(href="/registrations/#{multisite_registration.reference}/sites">#{multisite_registration.site_addresses.count} sites</a>)
+        )
+      end
     end
 
     context "when a valid user is not signed in" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-4208, based on comment: https://eaflood.atlassian.net/browse/RUBY-4119?focusedCommentId=836101

This answers additional request from AK to collapse the link and site count into one column.
<img width="944" height="617" alt="image" src="https://github.com/user-attachments/assets/9d5a2fdc-a640-4ebd-a1c5-03495d46aa4b" />
