### PR TITLE
[RUBY-4189] Add vertical alignment to payment details table cells

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -44,3 +44,7 @@
 .no-wrap {
   white-space: nowrap;
 }
+
+.vertical-align-top {
+  vertical-align: top;
+}

--- a/app/presenters/payment_details/charge_breakdown_presenter.rb
+++ b/app/presenters/payment_details/charge_breakdown_presenter.rb
@@ -20,7 +20,7 @@ module PaymentDetails
       end
 
       def amount_cell_classes
-        return "govuk-table__cell govuk-!-text-align-right govuk-!-padding-top-0 vertical-align-top" if @total
+        return "govuk-table__cell govuk-!-text-align-right govuk-!-padding-top-0" if @total
         return "govuk-!-text-align-right govuk-!-padding-top-2 vertical-align-top" if @top_padded
 
         "govuk-!-text-align-right vertical-align-top"

--- a/app/presenters/payment_details/charge_breakdown_presenter.rb
+++ b/app/presenters/payment_details/charge_breakdown_presenter.rb
@@ -20,10 +20,10 @@ module PaymentDetails
       end
 
       def amount_cell_classes
-        return "govuk-table__cell govuk-!-text-align-right govuk-!-padding-top-0" if @total
-        return "govuk-!-text-align-right govuk-!-padding-top-2" if @top_padded
+        return "govuk-table__cell govuk-!-text-align-right govuk-!-padding-top-0 vertical-align-top" if @total
+        return "govuk-!-text-align-right govuk-!-padding-top-2 vertical-align-top" if @top_padded
 
-        "govuk-!-text-align-right"
+        "govuk-!-text-align-right vertical-align-top"
       end
     end
 

--- a/app/views/payment_details/index.html.erb
+++ b/app/views/payment_details/index.html.erb
@@ -53,7 +53,7 @@
             <td class="govuk-table__cell">
               <%= adjustment.reason %>
             </td>
-            <td class="govuk-table__cell govuk-!-text-align-right no-wrap">
+            <td class="govuk-table__cell govuk-!-text-align-right no-wrap vertical-align-top">
               <%= adjustment.amount %>
             </td>
           </tr>
@@ -83,13 +83,13 @@
             <td class="govuk-table__cell">
               <%= payment.payment_type %>
             </td>
-            <td class="govuk-table__cell govuk-!-text-align-right no-wrap">
+            <td class="govuk-table__cell govuk-!-text-align-right no-wrap vertical-align-top">
               <%= payment.payment_amount %>
             </td>
-            <td class="govuk-table__cell govuk-!-text-align-right no-wrap">
+            <td class="govuk-table__cell govuk-!-text-align-right no-wrap vertical-align-top">
               <%= display_pence_as_pounds_sterling_and_pence(pence: payment.total_refunded_amount) %>
             </td>
-            <td class="govuk-table__cell govuk-!-text-align-right no-wrap">
+            <td class="govuk-table__cell govuk-!-text-align-right no-wrap vertical-align-top">
               <%= payment.available_refund_amount %>
             </td>
           </tr>
@@ -115,7 +115,7 @@
             <td class="govuk-table__cell"><%= format_date(payment.created_at) %></td>
             <td class="govuk-table__cell"><%= payment.reference %></td>
             <td class="govuk-table__cell"><%= payment.comments %></td>
-            <td class="govuk-table__cell govuk-!-text-align-right no-wrap">
+            <td class="govuk-table__cell govuk-!-text-align-right no-wrap vertical-align-top">
               <%= payment.payment_amount %>
             </td>
           </tr>
@@ -142,7 +142,7 @@
           <td class="govuk-table__cell govuk-!-font-weight-bold">
             <%= t(".details_section.balance.amount") %>
           </td>
-          <td class="govuk-table__cell govuk-!-text-align-right no-wrap" id="balance">
+          <td class="govuk-table__cell govuk-!-text-align-right no-wrap vertical-align-top" id="balance">
             <%= @presenter.balance %>
           </td>
         </tr>

--- a/app/views/payment_details/index.html.erb
+++ b/app/views/payment_details/index.html.erb
@@ -53,7 +53,7 @@
             <td class="govuk-table__cell">
               <%= adjustment.reason %>
             </td>
-            <td class="govuk-table__cell govuk-!-text-align-right no-wrap vertical-align-top">
+            <td class="govuk-table__cell govuk-!-text-align-right no-wrap">
               <%= adjustment.amount %>
             </td>
           </tr>
@@ -83,13 +83,13 @@
             <td class="govuk-table__cell">
               <%= payment.payment_type %>
             </td>
-            <td class="govuk-table__cell govuk-!-text-align-right no-wrap vertical-align-top">
+            <td class="govuk-table__cell govuk-!-text-align-right no-wrap">
               <%= payment.payment_amount %>
             </td>
-            <td class="govuk-table__cell govuk-!-text-align-right no-wrap vertical-align-top">
+            <td class="govuk-table__cell govuk-!-text-align-right no-wrap">
               <%= display_pence_as_pounds_sterling_and_pence(pence: payment.total_refunded_amount) %>
             </td>
-            <td class="govuk-table__cell govuk-!-text-align-right no-wrap vertical-align-top">
+            <td class="govuk-table__cell govuk-!-text-align-right no-wrap">
               <%= payment.available_refund_amount %>
             </td>
           </tr>
@@ -115,7 +115,7 @@
             <td class="govuk-table__cell"><%= format_date(payment.created_at) %></td>
             <td class="govuk-table__cell"><%= payment.reference %></td>
             <td class="govuk-table__cell"><%= payment.comments %></td>
-            <td class="govuk-table__cell govuk-!-text-align-right no-wrap vertical-align-top">
+            <td class="govuk-table__cell govuk-!-text-align-right no-wrap">
               <%= payment.payment_amount %>
             </td>
           </tr>
@@ -142,7 +142,7 @@
           <td class="govuk-table__cell govuk-!-font-weight-bold">
             <%= t(".details_section.balance.amount") %>
           </td>
-          <td class="govuk-table__cell govuk-!-text-align-right no-wrap vertical-align-top" id="balance">
+          <td class="govuk-table__cell govuk-!-text-align-right no-wrap" id="balance">
             <%= @presenter.balance %>
           </td>
         </tr>

--- a/spec/presenters/payment_details/charge_breakdown_presenter_spec.rb
+++ b/spec/presenters/payment_details/charge_breakdown_presenter_spec.rb
@@ -66,9 +66,11 @@ RSpec.describe PaymentDetails::ChargeBreakdownPresenter do
 
     it "exposes presentational cell classes on each row" do
       expect(rows.first.breakdown_cell_classes).to eq("govuk-!-padding-top-2")
-      expect(rows.first.amount_cell_classes).to eq("govuk-!-text-align-right govuk-!-padding-top-2")
+      expect(rows.first.amount_cell_classes).to eq("govuk-!-text-align-right govuk-!-padding-top-2 vertical-align-top")
       expect(rows.last.breakdown_cell_classes).to eq("govuk-table__cell govuk-!-padding-top-0")
-      expect(rows.last.amount_cell_classes).to eq("govuk-table__cell govuk-!-text-align-right govuk-!-padding-top-0")
+      expect(rows.last.amount_cell_classes).to eq(
+        "govuk-table__cell govuk-!-text-align-right govuk-!-padding-top-0 vertical-align-top"
+      )
     end
   end
 

--- a/spec/presenters/payment_details/charge_breakdown_presenter_spec.rb
+++ b/spec/presenters/payment_details/charge_breakdown_presenter_spec.rb
@@ -68,9 +68,7 @@ RSpec.describe PaymentDetails::ChargeBreakdownPresenter do
       expect(rows.first.breakdown_cell_classes).to eq("govuk-!-padding-top-2")
       expect(rows.first.amount_cell_classes).to eq("govuk-!-text-align-right govuk-!-padding-top-2 vertical-align-top")
       expect(rows.last.breakdown_cell_classes).to eq("govuk-table__cell govuk-!-padding-top-0")
-      expect(rows.last.amount_cell_classes).to eq(
-        "govuk-table__cell govuk-!-text-align-right govuk-!-padding-top-0 vertical-align-top"
-      )
+      expect(rows.last.amount_cell_classes).to eq("govuk-table__cell govuk-!-text-align-right govuk-!-padding-top-0")
     end
   end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-4189?focusedCommentId=855524

Added top vertical alignment to the amount cells on the payment details page so the amounts stay at the top of each row when other cells wrap onto multiple lines, such as charge breakdown rows with many exemptions.

<img width="649" height="372" alt="image" src="https://github.com/user-attachments/assets/109f534c-62b6-4d6a-99d8-b0c6b01377c1" />
