### PR TITLE
[RUBY-4017] Add resend invite for back office users

### DIFF
--- a/app/controllers/resend_user_invites_controller.rb
+++ b/app/controllers/resend_user_invites_controller.rb
@@ -7,7 +7,9 @@ class ResendUserInvitesController < ApplicationController
   before_action :assign_user
   before_action :check_invitation_pending
 
-  def new; end
+  def new
+    # Renders the confirmation page; @user is assigned by the before_actions
+  end
 
   def create
     resend_invite

--- a/app/controllers/resend_user_invites_controller.rb
+++ b/app/controllers/resend_user_invites_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class ResendUserInvitesController < ApplicationController
+  include CanSetFlashMessages
+
+  before_action :authorize
+  before_action :assign_user
+  before_action :check_invitation_pending
+
+  def new; end
+
+  def create
+    resend_invite
+
+    redirect_to users_url
+  end
+
+  private
+
+  def authorize
+    authorize! :invite, current_user
+  end
+
+  def assign_user
+    @user = User.find(params[:id])
+  end
+
+  def check_invitation_pending
+    redirect_to users_url unless invitation_pending?
+  end
+
+  def invitation_pending?
+    @user.active? && @user.invitation_token.present? && current_user.can_administer?(@user)
+  end
+
+  def resend_invite
+    @user.invite!
+
+    flash_success(I18n.t("resend_user_invites.messages.success", email: @user.email))
+  rescue StandardError => e
+    Airbrake.notify(e, email: @user.email)
+    Rails.logger.error "Failed to resend invitation email to user #{@user.id}"
+
+    flash_error(I18n.t("resend_user_invites.messages.failure", email: @user.email),
+                I18n.t("resend_user_invites.messages.failure_details"))
+  end
+end

--- a/app/views/resend_user_invites/new.html.erb
+++ b/app/views/resend_user_invites/new.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render("waste_exemptions_engine/shared/back", back_path: users_path) %>
+
+    <h1 class="govuk-heading-l">
+      <%= t(".heading") %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <p class="govuk-body"><%= t(".paragraph_1") %></p>
+    <p class="govuk-body govuk-!-font-weight-bold"><%= @user.email %></p>
+    <p class="govuk-body"><%= t(".paragraph_2") %></p>
+
+    <%= button_to t(".button"),
+              resend_user_invite_path(@user.id),
+              class: "govuk-button" %>
+  </div>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,5 +1,8 @@
 <%= render("waste_exemptions_engine/shared/back", back_path: root_path) %>
 
+<%= render("shared/message", message: flash[:message]) if flash[:message].present? %>
+<%= render("shared/error", error: flash[:error], details: flash[:error_details]) if flash[:error].present? %>
+
 <h1 class="govuk-heading-l">
   <%= t(".heading") %>
 </h1>
@@ -77,6 +80,17 @@
                     <% end %>
                   <% end %>
                   </li>
+                  <% if user.active? && user.invitation_token.present? && current_user.can_administer?(user) %>
+                    <li>
+                      <%= link_to resend_user_invite_form_path(user.id) do %>
+                        <%= t(".user_list.actions.resend_invite.link_text") %>
+                        <span class="govuk-visually-hidden">
+                          <%= t(".user_list.actions.resend_invite.visually_hidden_text",
+                                email: user.email) %>
+                        </span>
+                      <% end %>
+                    </li>
+                  <% end %>
                 </ul>
               </td>
             </tr>

--- a/config/locales/resend_user_invites.en.yml
+++ b/config/locales/resend_user_invites.en.yml
@@ -1,0 +1,12 @@
+en:
+  resend_user_invites:
+    new:
+      title: "Resend invite"
+      heading: "Resend invite"
+      paragraph_1: "You are about to resend an invitation email to this user:"
+      paragraph_2: "This will send a new invitation link and reset its expiry date. Links in previous invitation emails will stop working."
+      button: "Resend invite"
+    messages:
+      success: "Invitation email sent to %{email}"
+      failure: "We could not send an invitation email to %{email}"
+      failure_details: "The error has been logged. Try again later or contact an administrator."

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -37,6 +37,9 @@ en:
           activate:
             link_text: Activate
             visually_hidden_text: " %{email}"
+          resend_invite:
+            link_text: Resend invite
+            visually_hidden_text: " to %{email}"
   activerecord:
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,9 @@ Rails.application.routes.draw do
   post "/users/activate/:id", to: "user_activations#activate", as: :activate_user
   post "/users/deactivate/:id", to: "user_activations#deactivate", as: :deactivate_user
 
+  get "/users/resend-invite/:id", to: "resend_user_invites#new", as: :resend_user_invite_form
+  post "/users/resend-invite/:id", to: "resend_user_invites#create", as: :resend_user_invite
+
   # Confirmation Letter
   get "/confirmation-letter/:id", to: "confirmation_letter#show", as: :confirmation_letter
 

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -44,5 +44,11 @@ FactoryBot.define do
     trait :inactive do
       active { false }
     end
+
+    trait :invited do
+      invitation_token { SecureRandom.hex(20) }
+      invitation_created_at { 1.day.ago }
+      invitation_sent_at { 1.day.ago }
+    end
   end
 end

--- a/spec/requests/resend_user_invites_spec.rb
+++ b/spec/requests/resend_user_invites_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Resend User Invites" do
+  let(:invited_user) { create(:user, :invited) }
+  let(:accepted_user) { create(:user) }
+
+  describe "GET /users/resend-invite/:id" do
+    context "when a admin_team_user user is signed in" do
+      let(:user) { create(:user, :admin_team_user) }
+
+      before do
+        sign_in(user)
+      end
+
+      context "when the user has a pending invitation" do
+        it "renders the new template" do
+          get "/users/resend-invite/#{invited_user.id}"
+
+          expect(response).to render_template(:new)
+        end
+      end
+
+      context "when the user has already accepted their invitation" do
+        it "redirects to the user list" do
+          get "/users/resend-invite/#{accepted_user.id}"
+
+          expect(response).to redirect_to(users_path)
+        end
+      end
+
+      context "when the invited user is deactivated" do
+        let(:invited_user) { create(:user, :invited, :inactive) }
+
+        it "redirects to the user list" do
+          get "/users/resend-invite/#{invited_user.id}"
+
+          expect(response).to redirect_to(users_path)
+        end
+      end
+
+      context "when the current user cannot administer the invited user's role" do
+        let(:invited_user) { create(:user, :invited, :service_manager) }
+
+        it "redirects to the user list" do
+          get "/users/resend-invite/#{invited_user.id}"
+
+          expect(response).to redirect_to(users_path)
+        end
+      end
+    end
+
+    context "when a non-admin_team_user user is signed in" do
+      let(:user) { create(:user, :data_viewer) }
+
+      before do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        get "/users/resend-invite/#{invited_user.id}"
+
+        expect(response).to redirect_to("/pages/permission")
+      end
+    end
+  end
+
+  describe "POST /users/resend-invite/:id" do
+    context "when a admin_team_user user is signed in" do
+      let(:user) { create(:user, :admin_team_user) }
+
+      before do
+        sign_in(user)
+      end
+
+      context "when the user has a pending invitation" do
+        it "resends the invitation email, resets the invitation expiry and redirects to the user list" do
+          old_token = invited_user.invitation_token
+          old_created_at = invited_user.invitation_created_at
+
+          expect { post "/users/resend-invite/#{invited_user.id}" }
+            .to change { ActionMailer::Base.deliveries.count }.by(1)
+
+          expect(response).to redirect_to(users_path)
+
+          invited_user.reload
+          expect(invited_user.invitation_token).not_to eq(old_token)
+          expect(invited_user.invitation_created_at).to be > old_created_at
+          expect(invited_user.invitation_created_at).to be_within(1.minute).of(Time.zone.now)
+          expect(ActionMailer::Base.deliveries.last.to).to eq([invited_user.email])
+        end
+      end
+
+      context "when the user has already accepted their invitation" do
+        it "does not send an email and redirects to the user list" do
+          expect { post "/users/resend-invite/#{accepted_user.id}" }
+            .not_to change { ActionMailer::Base.deliveries.count }
+
+          expect(response).to redirect_to(users_path)
+        end
+      end
+
+      context "when the invited user is deactivated" do
+        let(:invited_user) { create(:user, :invited, :inactive) }
+
+        it "does not send an email and redirects to the user list" do
+          expect { post "/users/resend-invite/#{invited_user.id}" }
+            .not_to change { ActionMailer::Base.deliveries.count }
+
+          expect(response).to redirect_to(users_path)
+        end
+      end
+    end
+
+    context "when a non-admin_team_user user is signed in" do
+      let(:user) { create(:user, :data_viewer) }
+
+      before do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        post "/users/resend-invite/#{invited_user.id}"
+
+        expect(response).to redirect_to("/pages/permission")
+      end
+    end
+  end
+end

--- a/spec/requests/resend_user_invites_spec.rb
+++ b/spec/requests/resend_user_invites_spec.rb
@@ -92,6 +92,22 @@ RSpec.describe "Resend User Invites" do
         end
       end
 
+      context "when sending the invitation email fails" do
+        before do
+          allow(User).to receive(:find).and_return(invited_user)
+          allow(invited_user).to receive(:invite!).and_raise(StandardError)
+          allow(Airbrake).to receive(:notify)
+        end
+
+        it "notifies Airbrake and redirects to the user list with an error message" do
+          post "/users/resend-invite/#{invited_user.id}"
+          follow_redirect!
+
+          expect(response.body).to include(I18n.t("resend_user_invites.messages.failure_details"))
+          expect(Airbrake).to have_received(:notify)
+        end
+      end
+
       context "when the user has already accepted their invitation" do
         it "does not send an email and redirects to the user list" do
           expect { post "/users/resend-invite/#{accepted_user.id}" }

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe "Users" do
         expect(response.body).to include(active_user.email)
         expect(response.body).not_to include(deactivated_user.email)
       end
+
+      it "includes a resend invite link only for users with a pending invitation" do
+        invited_user = create(:user, :invited, email: "invited@example.com")
+        accepted_user = create(:user, email: "accepted@example.com")
+
+        get "/users"
+
+        expect(response.body).to include(resend_user_invite_form_path(invited_user.id))
+        expect(response.body).not_to include(resend_user_invite_form_path(accepted_user.id))
+      end
     end
 
     context "when a non-admin_team_user user is signed in" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-4017

- Add a "Resend invite" action to the Manage back office users page for accounts that are pending accepting their invite
- Resending resets the invite expiry to the configured time