### PR TITLE
Feature/ruby 4364 wex bo identify and fix broken registration data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
           sed -i "s@/home/runner/work/DEFRA/waste-exemptions-back-office@/github/workspace@g" coverage/coverage.json
 
       - name: Analyze with SonarCloud
-        uses: sonarsource/sonarqube-scan-action@v8.2.1
+        uses: sonarsource/sonarqube-scan-action@v8.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
           SONAR_TOKEN: ${{ secrets.RUBY_SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
           sed -i "s@/home/runner/work/DEFRA/waste-exemptions-back-office@/github/workspace@g" coverage/coverage.json
 
       - name: Analyze with SonarCloud
-        uses: sonarsource/sonarqube-scan-action@v6.0.0
+        uses: sonarsource/sonarqube-scan-action@v8.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
           SONAR_TOKEN: ${{ secrets.RUBY_SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets

--- a/app/lib/command_line_table_formatter.rb
+++ b/app/lib/command_line_table_formatter.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Formats a collection of row hashes as a fixed-width, aligned plain-text table
+# for command-line / rake output. The keys of the first row become the column
+# headers (in order); each row is read by those keys and its values stringified.
+# Columns are padded to the width of their widest value (header included).
+#
+#   CommandLineTableFormatter.new(
+#     [{ "ID" => 1, "Status" => "active" },
+#      { "ID" => 42, "Status" => "ceased" }]
+#   ).render
+#   # =>
+#   # ID  Status
+#   # --  ------
+#   # 1   active
+#   # 42  ceased
+#
+# A single hash is accepted and treated as a one-row table. An empty collection
+# renders as an empty string.
+class CommandLineTableFormatter
+  COLUMN_GAP = "  "
+
+  def initialize(rows)
+    @rows = rows.is_a?(Hash) ? [rows] : rows.to_a
+  end
+
+  def render
+    return "" if @rows.empty?
+
+    ([format_row(headers), format_row(dashes)] + data_rows).join("\n")
+  end
+
+  private
+
+  def keys
+    @keys ||= @rows.first.keys
+  end
+
+  def headers
+    keys.map(&:to_s)
+  end
+
+  def data_rows
+    @rows.map { |row| format_row(keys.map { |key| row[key].to_s }) }
+  end
+
+  def dashes
+    widths.map { |width| "-" * width }
+  end
+
+  def widths
+    @widths ||= keys.map { |key| ([key.to_s] + @rows.map { |row| row[key].to_s }).map(&:length).max }
+  end
+
+  def format_row(cells)
+    cells.each_with_index.map { |cell, index| cell.ljust(widths[index]) }.join(COLUMN_GAP).rstrip
+  end
+end

--- a/app/services/delete_registration_without_exemptions_service.rb
+++ b/app/services/delete_registration_without_exemptions_service.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Deletes a single registration (and all of its linked records) identified by its
+# reference, but ONLY when it has no registration exemptions. Returns a symbol
+# describing the outcome: :deleted, :not_found or :has_exemptions.
+class DeleteRegistrationWithoutExemptionsService < WasteExemptionsEngine::BaseService
+  def run(reference:)
+    @registration = WasteExemptionsEngine::Registration.find_by(reference: reference.to_s.strip)
+
+    return :not_found if @registration.nil?
+    return :has_exemptions if @registration.registration_exemptions.any?
+
+    delete_registration
+    :deleted
+  end
+
+  private
+
+  def delete_registration
+    ActiveRecord::Base.transaction do
+      # paper_trail would otherwise create a version for the deletion
+      PaperTrail.request(enabled: false) do
+        @registration.destroy!
+      end
+      clear_versions!
+      clear_versions_archive!
+    end
+  end
+
+  def clear_versions!
+    PaperTrail::Version
+      .where(item_type: "WasteExemptionsEngine::Registration", item_id: @registration.id)
+      .delete_all
+  end
+
+  def clear_versions_archive!
+    ActiveRecord::Base.connection.execute(
+      <<~SQL.squish
+        DELETE FROM version_archives
+        WHERE item_type = 'WasteExemptionsEngine::Registration'
+        AND item_id = #{@registration.id}
+      SQL
+    )
+  end
+end

--- a/app/services/identify_registrations_without_exemptions_or_sites_service.rb
+++ b/app/services/identify_registrations_without_exemptions_or_sites_service.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Identifies non-placeholder registrations that are missing exemptions and/or
+# site addresses. Returns one report row (hash) per registration
+class IdentifyRegistrationsWithoutExemptionsOrSitesService < WasteExemptionsEngine::BaseService
+  def run
+    registrations.map { |registration| row_for(registration) }
+  end
+
+  private
+
+  def registrations
+    site_type = WasteExemptionsEngine::Address.address_types.fetch(:site)
+
+    WasteExemptionsEngine::Registration
+      .where(placeholder: false)
+      .select(
+        "registrations.id",
+        "registrations.reference",
+        "(SELECT COUNT(*) FROM registration_exemptions re " \
+        "WHERE re.registration_id = registrations.id) AS exemptions_count",
+        "(SELECT COUNT(*) FROM addresses a " \
+        "WHERE a.registration_id = registrations.id AND a.address_type = #{site_type}) AS sites_count"
+      )
+      .where(
+        "NOT EXISTS (SELECT 1 FROM registration_exemptions re " \
+        "WHERE re.registration_id = registrations.id) " \
+        "OR NOT EXISTS (SELECT 1 FROM addresses a " \
+        "WHERE a.registration_id = registrations.id AND a.address_type = #{site_type})"
+      )
+  end
+
+  def row_for(registration)
+    {
+      "ID" => registration.id,
+      "Reference" => registration.reference,
+      "Status" => status_for(registration),
+      "Exemptions" => registration.exemptions_count,
+      "Sites" => registration.sites_count
+    }
+  end
+
+  def status_for(registration)
+    return "no_exemptions" if registration.registration_exemptions.empty?
+
+    registration.state
+  end
+end

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -25,8 +25,10 @@ namespace :cleanup do
     rows = IdentifyRegistrationsWithoutExemptionsOrSitesService.run
 
     unless Rails.env.test?
+      # :nocov:
       puts "Found #{rows.length} registration(s) with no exemptions or no sites \n\n"
       puts CommandLineTableFormatter.new(rows).render if rows.any?
+      # :nocov:
     end
   end
 
@@ -36,12 +38,14 @@ namespace :cleanup do
     outcome = DeleteRegistrationWithoutExemptionsService.run(reference: reference)
 
     unless Rails.env.test?
+      # :nocov:
       message = case outcome
                 when :deleted then "Deleted registration #{reference}"
                 when :has_exemptions then "Registration #{reference} has exemptions - not deleting"
                 else "No registration found with reference #{reference.inspect}"
                 end
       puts message
+      # :nocov:
     end
   end
 end

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 namespace :cleanup do
   desc "Remove old transient_registrations from the database"
   task transient_registrations: :environment do
@@ -28,4 +29,20 @@ namespace :cleanup do
       puts CommandLineTableFormatter.new(rows).render if rows.any?
     end
   end
+
+  desc "Delete a registration by reference (e.g. WEX000123), only if it has no exemptions"
+  task :delete_registration, [:reference] => :environment do |_task, args|
+    reference = args[:reference].to_s.strip
+    outcome = DeleteRegistrationWithoutExemptionsService.run(reference: reference)
+
+    unless Rails.env.test?
+      message = case outcome
+                when :deleted then "Deleted registration #{reference}"
+                when :has_exemptions then "Registration #{reference} has exemptions - not deleting"
+                else "No registration found with reference #{reference.inspect}"
+                end
+      puts message
+    end
+  end
 end
+# rubocop:enable Metrics/BlockLength

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -18,4 +18,14 @@ namespace :cleanup do
   task remove_expired_registrations: :environment do
     ExpiredRegistrationCleanupService.run
   end
+
+  desc "Identify registrations with no registration_exemptions or no site addresses"
+  task identify_registrations_without_exemptions_or_sites: :environment do
+    rows = IdentifyRegistrationsWithoutExemptionsOrSitesService.run
+
+    unless Rails.env.test?
+      puts "Found #{rows.length} registration(s) with no exemptions or no sites \n\n"
+      puts CommandLineTableFormatter.new(rows).render if rows.any?
+    end
+  end
 end

--- a/spec/lib/command_line_table_formatter_spec.rb
+++ b/spec/lib/command_line_table_formatter_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CommandLineTableFormatter do
+  subject(:rendered) { described_class.new(rows).render }
+
+  describe "#render" do
+    context "with several rows" do
+      let(:rows) do
+        [{ "ID" => 1, "Status" => "active" },
+         { "ID" => 42, "Status" => "no_exemptions" }]
+      end
+
+      it "uses the hash keys as the header row" do
+        expect(rendered.lines.first.chomp).to eq("ID  Status")
+      end
+
+      it "renders a dashed separator sized to each column" do
+        expect(rendered.lines[1].chomp).to eq("--  -------------")
+      end
+
+      it "left-aligns each column to the width of its widest value" do
+        expect(rendered.lines[2].chomp).to eq("1   active")
+        expect(rendered.lines[3].chomp).to eq("42  no_exemptions")
+      end
+
+      it "stringifies non-string values" do
+        expect(rendered).to include("42")
+      end
+
+      it "does not leave trailing whitespace on any line" do
+        expect(rendered.lines).to all(satisfy { |line| line.chomp == line.chomp.rstrip })
+      end
+    end
+
+    context "with a single hash" do
+      let(:rows) { { "ID" => 7, "Status" => "ceased" } }
+
+      it "renders it as a one-row table" do
+        expect(rendered.lines.map(&:chomp)).to eq(["ID  Status", "--  ------", "7   ceased"])
+      end
+    end
+
+    context "with no rows" do
+      let(:rows) { [] }
+
+      it "returns an empty string" do
+        expect(rendered).to eq("")
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/cleanup_spec.rb
+++ b/spec/lib/tasks/cleanup_spec.rb
@@ -78,4 +78,16 @@ RSpec.describe "Cleanup task", type: :rake do
       expect(IdentifyRegistrationsWithoutExemptionsOrSitesService).to have_received(:run)
     end
   end
+
+  describe "cleanup:delete_registration" do
+    let(:rake_task) { Rake::Task["cleanup:delete_registration"] }
+
+    after { rake_task.reenable }
+
+    it "runs the DeleteRegistrationWithoutExemptionsService with the given reference" do
+      allow(DeleteRegistrationWithoutExemptionsService).to receive(:run)
+      rake_task.invoke("WEX492684")
+      expect(DeleteRegistrationWithoutExemptionsService).to have_received(:run).with(reference: "WEX492684")
+    end
+  end
 end

--- a/spec/lib/tasks/cleanup_spec.rb
+++ b/spec/lib/tasks/cleanup_spec.rb
@@ -90,4 +90,16 @@ RSpec.describe "Cleanup task", type: :rake do
       expect(DeleteRegistrationWithoutExemptionsService).to have_received(:run).with(reference: "WEX492684")
     end
   end
+
+  describe "cleanup:remove_expired_registrations" do
+    let(:rake_task) { Rake::Task["cleanup:remove_expired_registrations"] }
+
+    after { rake_task.reenable }
+
+    it "runs the ExpiredRegistrationCleanupService" do
+      allow(ExpiredRegistrationCleanupService).to receive(:run)
+      rake_task.invoke
+      expect(ExpiredRegistrationCleanupService).to have_received(:run)
+    end
+  end
 end

--- a/spec/lib/tasks/cleanup_spec.rb
+++ b/spec/lib/tasks/cleanup_spec.rb
@@ -64,4 +64,18 @@ RSpec.describe "Cleanup task", type: :rake do
       }.from(2).to(1)
     end
   end
+
+  describe "cleanup:identify_registrations_without_exemptions_or_sites" do
+    let(:rake_task) { Rake::Task["cleanup:identify_registrations_without_exemptions_or_sites"] }
+
+    after { rake_task.reenable }
+
+    it { expect { rake_task.invoke }.not_to raise_error }
+
+    it "runs the IdentifyRegistrationsWithoutExemptionsOrSitesService" do
+      allow(IdentifyRegistrationsWithoutExemptionsOrSitesService).to receive(:run)
+      rake_task.invoke
+      expect(IdentifyRegistrationsWithoutExemptionsOrSitesService).to have_received(:run)
+    end
+  end
 end

--- a/spec/services/delete_registration_without_exemptions_service_spec.rb
+++ b/spec/services/delete_registration_without_exemptions_service_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DeleteRegistrationWithoutExemptionsService do
+  subject(:service) { described_class }
+
+  describe ".run" do
+    context "when the registration exists and has no exemptions" do
+      let!(:registration) { create(:registration, registration_exemptions: []) }
+
+      it "deletes the registration" do
+        expect { service.run(reference: registration.reference) }
+          .to change { WasteExemptionsEngine::Registration.where(id: registration.id).count }.from(1).to(0)
+      end
+
+      it "deletes the registration's addresses" do
+        expect { service.run(reference: registration.reference) }
+          .to change { WasteExemptionsEngine::Address.where(registration_id: registration.id).count }.to(0)
+      end
+
+      it "deletes the registration's account" do
+        expect { service.run(reference: registration.reference) }
+          .to change { WasteExemptionsEngine::Account.where(registration_id: registration.id).count }.to(0)
+      end
+
+      it "returns :deleted" do
+        expect(service.run(reference: registration.reference)).to eq(:deleted)
+      end
+
+      it "deletes the registration's paper trail versions", :versioning do
+        registration
+        service.run(reference: registration.reference)
+        versions = PaperTrail::Version.where(item_type: "WasteExemptionsEngine::Registration", item_id: registration.id)
+        expect(versions).to be_empty
+      end
+    end
+
+    context "when the registration has exemptions" do
+      let!(:registration) { create(:registration) }
+
+      it "does not delete it" do
+        expect { service.run(reference: registration.reference) }
+          .not_to change { WasteExemptionsEngine::Registration.where(id: registration.id).count }
+      end
+
+      it "returns :has_exemptions" do
+        expect(service.run(reference: registration.reference)).to eq(:has_exemptions)
+      end
+    end
+
+    context "when no registration matches the reference" do
+      before { create(:registration, registration_exemptions: []) }
+
+      it "returns :not_found" do
+        expect(service.run(reference: "WEX000000")).to eq(:not_found)
+      end
+
+      it "does not delete anything" do
+        expect { service.run(reference: "WEX000000") }
+          .not_to change(WasteExemptionsEngine::Registration, :count)
+      end
+    end
+  end
+end

--- a/spec/services/identify_registrations_without_exemptions_or_sites_service_spec.rb
+++ b/spec/services/identify_registrations_without_exemptions_or_sites_service_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IdentifyRegistrationsWithoutExemptionsOrSitesService do
+  subject(:service) { described_class }
+
+  let(:registration_without_exemptions) { create(:registration, registration_exemptions: []) }
+  let(:registration_without_sites) do
+    create(:registration, :with_active_exemptions,
+           addresses: [build(:address, :operator_address), build(:address, :contact_address)])
+  end
+  let(:complete_registration) { create(:registration) }
+  let(:placeholder_registration) { create(:registration, registration_exemptions: [], placeholder: true) }
+
+  describe ".run" do
+    def flagged_ids
+      service.run.pluck("ID")
+    end
+
+    it "includes a registration with no exemptions" do
+      registration_without_exemptions
+      expect(flagged_ids).to include(registration_without_exemptions.id)
+    end
+
+    it "includes a registration with no sites" do
+      registration_without_sites
+      expect(flagged_ids).to include(registration_without_sites.id)
+    end
+
+    it "excludes a registration that has both exemptions and sites" do
+      complete_registration
+      expect(flagged_ids).not_to include(complete_registration.id)
+    end
+
+    it "excludes placeholder registrations" do
+      placeholder_registration
+      expect(flagged_ids).not_to include(placeholder_registration.id)
+    end
+
+    it "reports the counts and no_exemptions status for a registration missing exemptions" do
+      registration_without_exemptions
+      row = service.run.find { |result| result["ID"] == registration_without_exemptions.id }
+      expect(row).to include("Status" => "no_exemptions")
+      expect(row["Exemptions"].to_i).to eq(0)
+      expect(row["Sites"].to_i).to eq(1)
+    end
+
+    it "reports the derived registration state for a flagged registration that has exemptions" do
+      registration_without_sites
+      row = service.run.find { |result| result["ID"] == registration_without_sites.id }
+      expect(row).to include("Status" => "active")
+      expect(row["Sites"].to_i).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-4364

Added 2 rake tasks to cleanup broken registration data:

1. cleanup:identify_registrations_without_exemptions_or_sites - Identifies registrations that are missing exemptions and/or site addresses

2. cleanup:delete_registration - Deletes a single registration (and all of its linked records) identified by its reference, but ONLY when it has no registration exemptions